### PR TITLE
Bump client version to 0.1.21

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/client",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Platform-agnostic TypeScript client for the Aomi backend API",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- Bump `@aomi-labs/client` version to 0.1.21 (already published to npm)

## Test plan
- [x] Version bump only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)