### PR TITLE
chore(publish-skills): exclude local-only tooling dirs from sync

### DIFF
--- a/scripts/publish-skills.mjs
+++ b/scripts/publish-skills.mjs
@@ -6,6 +6,16 @@ import process from "node:process";
 
 const ROOT = process.cwd();
 
+// Directory/file names that exist inside skill folders for local tooling only
+// and must never be vendored into the public skills repo.
+const LOCAL_ONLY_ENTRIES = new Set([
+  ".git",
+  ".skill-optimizer",
+  "benchmark-results",
+  "skill-optimizer",
+  "node_modules",
+]);
+
 function parseArg(flag, fallback) {
   const index = process.argv.indexOf(flag);
   if (index !== -1 && process.argv[index + 1]) {
@@ -38,11 +48,15 @@ async function clearDestination(destination) {
   }
 }
 
+function shouldSkipEntry(name) {
+  return LOCAL_ONLY_ENTRIES.has(name);
+}
+
 async function copySourceContents(source, destination) {
   const entries = await readdir(source, { withFileTypes: true });
 
   for (const entry of entries) {
-    if (entry.name === ".git") {
+    if (shouldSkipEntry(entry.name)) {
       continue;
     }
 
@@ -52,7 +66,10 @@ async function copySourceContents(source, destination) {
     await cp(sourcePath, destinationPath, {
       recursive: true,
       force: true,
-      filter: (candidate) => !candidate.split(path.sep).includes(".git"),
+      filter: (candidate) => {
+        // Exclude any local-only directory encountered anywhere in the tree.
+        return !candidate.split(path.sep).some((segment) => shouldSkipEntry(segment));
+      },
     });
   }
 }


### PR DESCRIPTION
## Summary

- \`.skill-optimizer/\` (and similar local-benchmark artifacts) was being vendored into \`aomi-labs/skills\` by \`scripts/publish-skills.mjs\` — see [skills#6](https://github.com/aomi-labs/skills/pull/6) where \`aomi-transact/.skill-optimizer/cli-commands.json\` and \`skill-optimizer.json\` showed up.
- Add a \`LOCAL_ONLY_ENTRIES\` set (\`.skill-optimizer\`, \`benchmark-results\`, \`skill-optimizer\`, \`node_modules\`, \`.git\`) that is excluded at top-level and as a recursive filter.
- Future skill syncs will only carry \`SKILL.md\` + genuine assets.

Pairs with manual cleanup of the open skills PR #6 (removing the two \`.skill-optimizer\` files from that branch).

## Test plan

- [x] Local dry-run: \`node scripts/publish-skills.mjs --source ./packages/client/skills --dest /tmp/test-dest\` — verified output contains only \`aomi-transact/SKILL.md\` + \`aomi-build/SKILL.md\`, no \`.skill-optimizer\`
- [ ] Merge, then confirm next sync PR to aomi-labs/skills is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)