### PR TITLE
fix(registry): resolve lib/hooks file types for root-relative paths

### DIFF
--- a/apps/registry/scripts/build-registry.js
+++ b/apps/registry/scripts/build-registry.js
@@ -18,8 +18,10 @@ const srcDir = path.resolve(baseDir, "../src");
 
 function resolveFileType(filePath) {
   if (filePath.endsWith(".css")) return "registry:style";
-  if (filePath.includes("/hooks/")) return "registry:hook";
-  if (filePath.includes("/lib/")) return "registry:lib";
+  if (filePath.includes("/hooks/") || filePath.startsWith("hooks/"))
+    return "registry:hook";
+  if (filePath.includes("/lib/") || filePath.startsWith("lib/"))
+    return "registry:lib";
   return "registry:component";
 }
 


### PR DESCRIPTION
## Summary

- **Bug**: `resolveFileType` in `build-registry.js` checked for `/lib/` and `/hooks/` with a preceding slash, but registry entries use root-relative paths (e.g. `lib/aomi-wallet-adapter.ts`) that lack a leading slash
- **Impact**: Lib files like `aomi-wallet-adapter` and `account-identity` were typed as `registry:component` instead of `registry:lib`, causing shadcn to install them under `components/` instead of `lib/`, breaking relative imports
- **Fix**: Added `startsWith("lib/")` and `startsWith("hooks/")` checks alongside the existing `includes` checks

## Verification

```js
// Before fix:
resolveFileType("lib/aomi-wallet-adapter.ts") // => "registry:component" (WRONG)

// After fix:
resolveFileType("lib/aomi-wallet-adapter.ts") // => "registry:lib" (CORRECT)
```

Tested all path patterns:
- `lib/foo.ts` -> `registry:lib` (fixed)
- `src/lib/foo.ts` -> `registry:lib` (already worked)
- `hooks/use-foo.ts` -> `registry:hook` (fixed)
- `src/hooks/use-foo.ts` -> `registry:hook` (already worked)
- `components/foo.tsx` -> `registry:component` (unchanged)
- `libfoo/bar.ts` -> `registry:component` (no false positive)