### PR TITLE
[codex] Fix wallet tx request replay

### DIFF
--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/widget-lib",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Shadcn registry for the Aomi widget.",
   "type": "module",
   "main": "./src/index.ts",

--- a/apps/registry/src/components/runtime-tx-handler.tsx
+++ b/apps/registry/src/components/runtime-tx-handler.tsx
@@ -59,7 +59,7 @@ export function RuntimeTxHandler() {
           const payload = req.payload as WalletTxPayload;
 
           if (!adapter.sendTransaction) {
-            rejectWalletRequest(req.id, "Wallet provider is not ready");
+            await rejectWalletRequest(req.id, "Wallet provider is not ready");
             return;
           }
 
@@ -74,7 +74,7 @@ export function RuntimeTxHandler() {
 
           const result = await adapter.sendTransaction(payload);
 
-          resolveWalletRequest(req.id, {
+          await resolveWalletRequest(req.id, {
             txHash: result.txHash,
             amount: result.amount,
           });
@@ -82,7 +82,7 @@ export function RuntimeTxHandler() {
         }
 
         if (!adapter.signTypedData) {
-          rejectWalletRequest(req.id, "Wallet provider is not ready");
+          await rejectWalletRequest(req.id, "Wallet provider is not ready");
           return;
         }
 
@@ -90,7 +90,7 @@ export function RuntimeTxHandler() {
         const signArgs = toViemSignTypedDataArgs(payload);
 
         if (!signArgs) {
-          rejectWalletRequest(req.id, "Missing typed_data payload");
+          await rejectWalletRequest(req.id, "Missing typed_data payload");
           return;
         }
 
@@ -113,10 +113,10 @@ export function RuntimeTxHandler() {
           typed_data: signArgs,
         };
         const result = await adapter.signTypedData(signaturePayload);
-        resolveWalletRequest(req.id, result);
+        await resolveWalletRequest(req.id, result);
       } catch (error) {
         console.error("[RuntimeTxHandler] Request failed:", error);
-        rejectWalletRequest(
+        await rejectWalletRequest(
           req.id,
           error instanceof Error ? error.message : "Request failed",
         );

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/react",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Runtime, state, and utilities for the Aomi widget.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react/src/handlers/wallet-handler.test.tsx
+++ b/packages/react/src/handlers/wallet-handler.test.tsx
@@ -75,4 +75,62 @@ describe("useWalletHandler", () => {
 
     expect(result.current.pendingRequests).toEqual([]);
   });
+
+  it("removes a request even when backend acknowledgement fails", async () => {
+    const resolveDeferred = createDeferred<void>();
+    const session = {
+      resolve: vi.fn(() => resolveDeferred.promise),
+      reject: vi.fn(),
+    };
+
+    const request: WalletRequest = {
+      id: "tx-2",
+      kind: "transaction",
+      payload: {
+        to: "0x0000000000000000000000000000000000000000",
+        value: "100",
+        txId: 2,
+      },
+      timestamp: Date.now(),
+    };
+
+    const { result } = renderHook(() =>
+      useWalletHandler({
+        getSession: () => session as never,
+      }),
+    );
+
+    act(() => {
+      result.current.setRequests([request]);
+    });
+
+    let resolvePromise!: Promise<void>;
+    act(() => {
+      resolvePromise = result.current.resolveRequest(request.id, {
+        txHash: "0xdef",
+      });
+    });
+
+    expect(result.current.pendingRequests).toEqual([]);
+
+    await act(async () => {
+      resolveDeferred.reject(new Error("network error"));
+      await resolvePromise;
+    });
+
+    expect(result.current.pendingRequests).toEqual([]);
+
+    act(() => {
+      result.current.setRequests([request]);
+    });
+
+    expect(result.current.pendingRequests).toEqual([]);
+
+    act(() => {
+      result.current.setRequests([]);
+      result.current.setRequests([request]);
+    });
+
+    expect(result.current.pendingRequests).toEqual([request]);
+  });
 });

--- a/packages/react/src/handlers/wallet-handler.test.tsx
+++ b/packages/react/src/handlers/wallet-handler.test.tsx
@@ -1,0 +1,78 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  useWalletHandler,
+  type WalletRequest,
+} from "./wallet-handler";
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+describe("useWalletHandler", () => {
+  it("keeps an in-flight request hidden when the backend briefly re-reports it", async () => {
+    const resolveDeferred = createDeferred<void>();
+    const session = {
+      resolve: vi.fn(() => resolveDeferred.promise),
+      reject: vi.fn(),
+    };
+
+    const request: WalletRequest = {
+      id: "tx-1",
+      kind: "transaction",
+      payload: {
+        to: "0x0000000000000000000000000000000000000000",
+        value: "100",
+        txId: 1,
+      },
+      timestamp: Date.now(),
+    };
+
+    const { result } = renderHook(() =>
+      useWalletHandler({
+        getSession: () => session as never,
+      }),
+    );
+
+    act(() => {
+      result.current.setRequests([request]);
+    });
+
+    expect(result.current.pendingRequests).toEqual([request]);
+
+    let resolvePromise!: Promise<void>;
+    act(() => {
+      result.current.startRequest(request.id);
+      resolvePromise = result.current.resolveRequest(request.id, {
+        txHash: "0xabc",
+      });
+    });
+
+    expect(result.current.pendingRequests).toEqual([]);
+    expect(session.resolve).toHaveBeenCalledWith(request.id, {
+      txHash: "0xabc",
+    });
+
+    act(() => {
+      result.current.setRequests([request]);
+    });
+
+    expect(result.current.pendingRequests).toEqual([]);
+
+    await act(async () => {
+      resolveDeferred.resolve();
+      await resolvePromise;
+    });
+
+    expect(result.current.pendingRequests).toEqual([]);
+  });
+});

--- a/packages/react/src/handlers/wallet-handler.ts
+++ b/packages/react/src/handlers/wallet-handler.ts
@@ -30,10 +30,12 @@ export type WalletHandlerApi = {
   pendingRequests: WalletRequest[];
   /** Replace pending requests with the session's authoritative snapshot. */
   setRequests: (requests: WalletRequest[]) => void;
+  /** Mark a request as in-flight so it is not replayed while awaiting backend ack. */
+  startRequest: (id: string) => void;
   /** Complete a request successfully — sends response to backend via ClientSession */
-  resolveRequest: (id: string, result: WalletRequestResult) => void;
+  resolveRequest: (id: string, result: WalletRequestResult) => Promise<void>;
   /** Fail a request — sends error to backend via ClientSession */
-  rejectRequest: (id: string, error?: string) => void;
+  rejectRequest: (id: string, error?: string) => Promise<void>;
 };
 
 export function useWalletHandler({
@@ -41,49 +43,91 @@ export function useWalletHandler({
 }: WalletHandlerConfig): WalletHandlerApi {
   const [pendingRequests, setPendingRequests] = useState<WalletRequest[]>([]);
   const requestsRef = useRef<WalletRequest[]>(pendingRequests);
+  const inFlightRequestIdsRef = useRef<Set<string>>(new Set());
 
-  const setRequests = useCallback((requests: WalletRequest[]) => {
-    requestsRef.current = [...requests];
-    setPendingRequests(requestsRef.current);
+  const syncVisibleRequests = useCallback(() => {
+    setPendingRequests(
+      requestsRef.current.filter(
+        (request) => !inFlightRequestIdsRef.current.has(request.id),
+      ),
+    );
   }, []);
 
+  const setRequests = useCallback((requests: WalletRequest[]) => {
+    const incomingIds = new Set(requests.map((request) => request.id));
+    const preservedInFlight = requestsRef.current.filter(
+      (request) =>
+        inFlightRequestIdsRef.current.has(request.id) &&
+        !incomingIds.has(request.id),
+    );
+
+    requestsRef.current = [...requests, ...preservedInFlight];
+    syncVisibleRequests();
+  }, [syncVisibleRequests]);
+
+  const startRequest = useCallback((id: string) => {
+    if (!requestsRef.current.some((request) => request.id === id)) {
+      return;
+    }
+
+    inFlightRequestIdsRef.current.add(id);
+    syncVisibleRequests();
+  }, [syncVisibleRequests]);
+
   const resolveRequest = useCallback(
-    (id: string, result: WalletRequestResult) => {
+    async (id: string, result: WalletRequestResult) => {
       const session = getSession();
       if (!session) {
         console.error("[wallet-handler] No session available to resolve request");
         return;
       }
 
-      setRequests(requestsRef.current.filter((request) => request.id !== id));
+      startRequest(id);
 
-      void session.resolve(id, result).catch((err) => {
+      try {
+        await session.resolve(id, result);
+        requestsRef.current = requestsRef.current.filter(
+          (request) => request.id !== id,
+        );
+      } catch (err) {
         console.error("[wallet-handler] Failed to resolve request:", err);
-      });
+      } finally {
+        inFlightRequestIdsRef.current.delete(id);
+        syncVisibleRequests();
+      }
     },
-    [getSession, setRequests],
+    [getSession, startRequest, syncVisibleRequests],
   );
 
   const rejectRequest = useCallback(
-    (id: string, error?: string) => {
+    async (id: string, error?: string) => {
       const session = getSession();
       if (!session) {
         console.error("[wallet-handler] No session available to reject request");
         return;
       }
 
-      setRequests(requestsRef.current.filter((request) => request.id !== id));
+      startRequest(id);
 
-      void session.reject(id, error).catch((err) => {
+      try {
+        await session.reject(id, error);
+        requestsRef.current = requestsRef.current.filter(
+          (request) => request.id !== id,
+        );
+      } catch (err) {
         console.error("[wallet-handler] Failed to reject request:", err);
-      });
+      } finally {
+        inFlightRequestIdsRef.current.delete(id);
+        syncVisibleRequests();
+      }
     },
-    [getSession, setRequests],
+    [getSession, startRequest, syncVisibleRequests],
   );
 
   return {
     pendingRequests,
     setRequests,
+    startRequest,
     resolveRequest,
     rejectRequest,
   };

--- a/packages/react/src/handlers/wallet-handler.ts
+++ b/packages/react/src/handlers/wallet-handler.ts
@@ -43,31 +43,31 @@ export function useWalletHandler({
 }: WalletHandlerConfig): WalletHandlerApi {
   const [pendingRequests, setPendingRequests] = useState<WalletRequest[]>([]);
   const requestsRef = useRef<WalletRequest[]>(pendingRequests);
-  const inFlightRequestIdsRef = useRef<Set<string>>(new Set());
-  const suppressedRequestIdsRef = useRef<Set<string>>(new Set());
+  const inFlightRequestSetRef = useRef<Set<string>>(new Set());
+  const suppressedRequestSetRef = useRef<Set<string>>(new Set());
 
   const syncVisibleRequests = useCallback(() => {
     setPendingRequests(
       requestsRef.current.filter(
-        (request) => !suppressedRequestIdsRef.current.has(request.id),
+        (request) => !suppressedRequestSetRef.current.has(request.id),
       ),
     );
   }, []);
 
   const setRequests = useCallback((requests: WalletRequest[]) => {
     const incomingIds = new Set(requests.map((request) => request.id));
-    for (const id of suppressedRequestIdsRef.current) {
+    for (const id of suppressedRequestSetRef.current) {
       if (
         !incomingIds.has(id) &&
-        !inFlightRequestIdsRef.current.has(id)
+        !inFlightRequestSetRef.current.has(id)
       ) {
-        suppressedRequestIdsRef.current.delete(id);
+        suppressedRequestSetRef.current.delete(id);
       }
     }
 
     const preservedInFlight = requestsRef.current.filter(
       (request) =>
-        inFlightRequestIdsRef.current.has(request.id) &&
+        inFlightRequestSetRef.current.has(request.id) &&
         !incomingIds.has(request.id),
     );
 
@@ -80,8 +80,8 @@ export function useWalletHandler({
       return;
     }
 
-    inFlightRequestIdsRef.current.add(id);
-    suppressedRequestIdsRef.current.add(id);
+    inFlightRequestSetRef.current.add(id);
+    suppressedRequestSetRef.current.add(id);
     syncVisibleRequests();
   }, [syncVisibleRequests]);
 
@@ -103,7 +103,7 @@ export function useWalletHandler({
         requestsRef.current = requestsRef.current.filter(
           (request) => request.id !== id,
         );
-        inFlightRequestIdsRef.current.delete(id);
+        inFlightRequestSetRef.current.delete(id);
         syncVisibleRequests();
       }
     },
@@ -128,7 +128,7 @@ export function useWalletHandler({
         requestsRef.current = requestsRef.current.filter(
           (request) => request.id !== id,
         );
-        inFlightRequestIdsRef.current.delete(id);
+        inFlightRequestSetRef.current.delete(id);
         syncVisibleRequests();
       }
     },

--- a/packages/react/src/handlers/wallet-handler.ts
+++ b/packages/react/src/handlers/wallet-handler.ts
@@ -44,17 +44,27 @@ export function useWalletHandler({
   const [pendingRequests, setPendingRequests] = useState<WalletRequest[]>([]);
   const requestsRef = useRef<WalletRequest[]>(pendingRequests);
   const inFlightRequestIdsRef = useRef<Set<string>>(new Set());
+  const suppressedRequestIdsRef = useRef<Set<string>>(new Set());
 
   const syncVisibleRequests = useCallback(() => {
     setPendingRequests(
       requestsRef.current.filter(
-        (request) => !inFlightRequestIdsRef.current.has(request.id),
+        (request) => !suppressedRequestIdsRef.current.has(request.id),
       ),
     );
   }, []);
 
   const setRequests = useCallback((requests: WalletRequest[]) => {
     const incomingIds = new Set(requests.map((request) => request.id));
+    for (const id of suppressedRequestIdsRef.current) {
+      if (
+        !incomingIds.has(id) &&
+        !inFlightRequestIdsRef.current.has(id)
+      ) {
+        suppressedRequestIdsRef.current.delete(id);
+      }
+    }
+
     const preservedInFlight = requestsRef.current.filter(
       (request) =>
         inFlightRequestIdsRef.current.has(request.id) &&
@@ -71,6 +81,7 @@ export function useWalletHandler({
     }
 
     inFlightRequestIdsRef.current.add(id);
+    suppressedRequestIdsRef.current.add(id);
     syncVisibleRequests();
   }, [syncVisibleRequests]);
 
@@ -86,12 +97,12 @@ export function useWalletHandler({
 
       try {
         await session.resolve(id, result);
-        requestsRef.current = requestsRef.current.filter(
-          (request) => request.id !== id,
-        );
       } catch (err) {
         console.error("[wallet-handler] Failed to resolve request:", err);
       } finally {
+        requestsRef.current = requestsRef.current.filter(
+          (request) => request.id !== id,
+        );
         inFlightRequestIdsRef.current.delete(id);
         syncVisibleRequests();
       }
@@ -111,12 +122,12 @@ export function useWalletHandler({
 
       try {
         await session.reject(id, error);
-        requestsRef.current = requestsRef.current.filter(
-          (request) => request.id !== id,
-        );
       } catch (err) {
         console.error("[wallet-handler] Failed to reject request:", err);
       } finally {
+        requestsRef.current = requestsRef.current.filter(
+          (request) => request.id !== id,
+        );
         inFlightRequestIdsRef.current.delete(id);
         syncVisibleRequests();
       }

--- a/packages/react/src/interface.tsx
+++ b/packages/react/src/interface.tsx
@@ -92,10 +92,13 @@ export type AomiRuntimeApi = {
   pendingWalletRequests: WalletRequest[];
   /** Mark a wallet request as being processed */
   startWalletRequest: (id: string) => void;
-  /** Complete a wallet request — dequeues + sends response to backend */
-  resolveWalletRequest: (id: string, result: WalletRequestResult) => void;
-  /** Fail a wallet request — dequeues + sends error to backend */
-  rejectWalletRequest: (id: string, error?: string) => void;
+  /** Complete a wallet request after the backend acknowledges the response */
+  resolveWalletRequest: (
+    id: string,
+    result: WalletRequestResult,
+  ) => Promise<void>;
+  /** Fail a wallet request after the backend acknowledges the error */
+  rejectWalletRequest: (id: string, error?: string) => Promise<void>;
 
   // -------------------------------------------------------------------------
   // EVENT API

--- a/packages/react/src/runtime/core.tsx
+++ b/packages/react/src/runtime/core.tsx
@@ -493,7 +493,7 @@ export function AomiRuntimeCore({
 
       // Wallet API
       pendingWalletRequests: walletHandler.pendingRequests,
-      startWalletRequest: () => {}, // No-op: ClientSession manages processing state
+      startWalletRequest: walletHandler.startRequest,
       resolveWalletRequest: walletHandler.resolveRequest,
       rejectWalletRequest: walletHandler.rejectRequest,
 


### PR DESCRIPTION
## Summary

This PR fixes a frontend/runtime bug that could cause the same wallet transaction request to be surfaced to the user twice, resulting in duplicate wallet approval prompts for a single action.

## Issue

When a user asked the assistant to perform a simple on-chain action such as sending ETH, the wallet could sometimes prompt for the same transaction twice. This was reproducible in the landing app and in other apps consuming the shared `@aomi-labs/react` runtime, which indicated that the problem lived in the shared frontend flow rather than in app-specific widget code.

## Root Cause

The shared wallet request pipeline did not maintain durable in-flight state for a request once processing began:

- `RuntimeTxHandler` started processing a wallet request from a `useEffect`, but `startWalletRequest` in the runtime API was effectively a no-op.
- The request could be removed locally before the backend had fully acknowledged the resolution.
- During that gap, the next backend poll could briefly re-report the same `pending_txs` entry.
- Because the request appeared pending again, the runtime could treat it as a fresh request and replay the wallet send flow, causing a second wallet prompt.

## Fix

This PR makes wallet request processing explicit and durable in the shared React runtime:

- add real in-flight tracking to `useWalletHandler`
- wire `startWalletRequest` to that shared in-flight state instead of leaving it as a no-op
- keep requests hidden from `pendingWalletRequests` while they are being resolved or rejected
- await backend acknowledgement before dropping the request guard in `RuntimeTxHandler`
- add a regression test that covers the stale re-queue case where the backend briefly re-reports the same pending transaction

## Impact

This prevents replay of the same wallet request while the backend is catching up, so a single user intent should result in a single wallet approval flow.

Because the fix is in the shared runtime layer, it applies both to the landing app and to other applications that consume `@aomi-labs/react`.

## Validation

- `bunx vitest run packages/react/src/handlers/wallet-handler.test.tsx packages/react/src/runtime/__tests__/chat.test.tsx`

## Notes

A broader `bunx tsc -p packages/react/tsconfig.json --noEmit` run still reports pre-existing test-harness typing issues unrelated to this change.
