### PR TITLE
[codex] Refine mobile widget layout

### DIFF
--- a/apps/registry/src/components/aomi-frame.tsx
+++ b/apps/registry/src/components/aomi-frame.tsx
@@ -115,7 +115,7 @@ const Root: FC<RootProps> = ({
           {showSidebar && (
             <ThreadListSidebar walletPosition={walletPosition} />
           )}
-          <SidebarInset className="relative flex flex-col">
+          <SidebarInset className="relative flex min-h-0 flex-col">
             {children}
           </SidebarInset>
           <NotificationToaster />

--- a/apps/registry/src/components/assistant-ui/thread.tsx
+++ b/apps/registry/src/components/assistant-ui/thread.tsx
@@ -64,7 +64,7 @@ export const Thread: FC = () => {
             ["--thread-max-width" as string]: "44rem",
           }}
         >
-          <ThreadPrimitive.Viewport className="aui-thread-viewport relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll px-2">
+          <ThreadPrimitive.Viewport className="aui-thread-viewport relative flex min-h-0 flex-1 flex-col overflow-x-auto overflow-y-scroll px-2">
             <ThreadPrimitive.If empty>
               <ThreadWelcome />
             </ThreadPrimitive.If>
@@ -81,9 +81,9 @@ export const Thread: FC = () => {
             <ThreadPrimitive.If empty={false}>
               <div className="aui-thread-viewport-spacer min-h-8 grow" />
             </ThreadPrimitive.If>
-
-            <Composer />
           </ThreadPrimitive.Viewport>
+
+          <Composer />
         </ThreadPrimitive.Root>
       </MotionConfig>
     </LazyMotion>
@@ -192,7 +192,7 @@ const ThreadSuggestions: FC = () => {
 
 const Composer: FC = () => {
   return (
-    <div className="aui-composer-wrapper bg-background sticky bottom-0 mx-auto flex w-full max-w-[var(--thread-max-width)] flex-col gap-4 overflow-visible rounded-t-3xl pb-4 md:pb-6">
+    <div className="aui-composer-wrapper bg-background mx-auto flex w-full max-w-[var(--thread-max-width)] shrink-0 flex-col gap-4 overflow-visible px-2 pb-[max(0.75rem,env(safe-area-inset-bottom))] md:pb-6">
       <ThreadScrollToBottom />
       <ComposerPrimitive.Root className="aui-composer-root rounded-4xl bg-sidebar text-card-foreground relative flex w-full flex-col px-1 pt-2">
         <ComposerPrimitive.Input
@@ -218,10 +218,10 @@ const ComposerAction: FC = () => {
   const hideNetwork = controlBarProps.hideNetwork ?? false;
 
   return (
-    <div className="aui-composer-action-wrapper relative mx-1 mb-2 mt-2 flex items-center">
-      {/* Inline controls: [Model ▾] [App ▾] [🔑] */}
+    <div className="aui-composer-action-wrapper relative mx-1 mb-2 mt-2 flex items-center gap-1">
+      {/* Inline controls — horizontally scrollable on mobile */}
       {composerControl.enabled && (
-        <div className="ml-2 flex items-center gap-2">
+        <div className="aui-composer-action-scroll ml-1 flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto md:ml-2 md:gap-2">
           {!hideNetwork && <NetworkSelect />}
           {!hideModel && <ModelSelect />}
           {!hideApp && <AppSelect />}
@@ -230,38 +230,40 @@ const ComposerAction: FC = () => {
         </div>
       )}
 
-      {/* Spacer */}
-      <div className="flex-1" />
+      {/* Spacer — only when no inline controls */}
+      {!composerControl.enabled && <div className="flex-1" />}
 
-      <ThreadPrimitive.If running={false}>
-        <ComposerPrimitive.Send asChild>
-          <TooltipIconButton
-            tooltip="Send message"
-            side="bottom"
-            type="submit"
-            variant="default"
-            size="icon"
-            className="aui-composer-send mb-3 mr-3 size-[34px] rounded-full p-1"
-            aria-label="Send message"
-          >
-            <ArrowUpIcon className="aui-composer-send-icon size-5" />
-          </TooltipIconButton>
-        </ComposerPrimitive.Send>
-      </ThreadPrimitive.If>
+      <div className="shrink-0">
+        <ThreadPrimitive.If running={false}>
+          <ComposerPrimitive.Send asChild>
+            <TooltipIconButton
+              tooltip="Send message"
+              side="bottom"
+              type="submit"
+              variant="default"
+              size="icon"
+              className="aui-composer-send mb-3 mr-2 size-[38px] rounded-full p-1 md:mr-3 md:size-[34px]"
+              aria-label="Send message"
+            >
+              <ArrowUpIcon className="aui-composer-send-icon size-5" />
+            </TooltipIconButton>
+          </ComposerPrimitive.Send>
+        </ThreadPrimitive.If>
 
-      <ThreadPrimitive.If running>
-        <ComposerPrimitive.Cancel asChild>
-          <Button
-            type="button"
-            variant="default"
-            size="icon"
-            className="aui-composer-cancel border-muted-foreground/60 hover:bg-primary/75 dark:border-muted-foreground/90 size-[34px] rounded-full border"
-            aria-label="Stop generating"
-          >
-            <Square className="aui-composer-cancel-icon size-3.5 fill-white dark:fill-black" />
-          </Button>
-        </ComposerPrimitive.Cancel>
-      </ThreadPrimitive.If>
+        <ThreadPrimitive.If running>
+          <ComposerPrimitive.Cancel asChild>
+            <Button
+              type="button"
+              variant="default"
+              size="icon"
+              className="aui-composer-cancel border-muted-foreground/60 hover:bg-primary/75 dark:border-muted-foreground/90 mb-3 mr-2 size-[38px] rounded-full border md:mr-3 md:size-[34px]"
+              aria-label="Stop generating"
+            >
+              <Square className="aui-composer-cancel-icon size-3.5 fill-white dark:fill-black" />
+            </Button>
+          </ComposerPrimitive.Cancel>
+        </ThreadPrimitive.If>
+      </div>
     </div>
   );
 };
@@ -280,7 +282,7 @@ const AssistantMessage: FC = () => {
   return (
     <MessagePrimitive.Root asChild>
       <div
-        className="aui-assistant-message-root animate-in fade-in slide-in-from-bottom-1 relative mx-auto w-full max-w-[var(--thread-max-width)] py-4 duration-150 ease-out last:mb-24"
+        className="aui-assistant-message-root animate-in fade-in slide-in-from-bottom-1 relative mx-auto w-full max-w-[var(--thread-max-width)] py-4 duration-150 ease-out"
         data-role="assistant"
       >
         <div className="aui-assistant-message-content text-foreground mx-2 break-words text-sm leading-5">

--- a/apps/registry/src/themes/default.css
+++ b/apps/registry/src/themes/default.css
@@ -166,3 +166,23 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* ============================================
+   Mobile / iOS Safari fixes
+   ============================================ */
+
+/* Hide scrollbar on inline control bar (mobile swipe) */
+.aui-composer-action-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.aui-composer-action-scroll {
+  scrollbar-width: none;
+}
+
+/* Prevent iOS from zooming on input focus (font-size >= 16px) */
+@media screen and (max-width: 767px) {
+  .aui-composer-input {
+    font-size: 16px;
+  }
+}


### PR DESCRIPTION
## Summary
This PR tightens the widget's mobile behavior without changing the underlying runtime/package surface.

## What changed
- moved the composer outside the scrolling message viewport so the input stays anchored more reliably on mobile
- preserved the `min-h-0` flex fixes needed for the thread layout to size correctly
- kept the inline composer controls swipeable on smaller screens and hid their scrollbar for a cleaner mobile presentation
- increased the mobile composer font size to 16px to avoid iOS Safari zoom-on-focus
- restored horizontal access for wide assistant output by keeping `overflow-x-auto` on the thread viewport
- removed the unused visual viewport hook so we do not ship dead keyboard-avoidance code
- dropped the unrelated `packages/react/dist/*` churn from this change so the patch stays focused on widget UI behavior

## Why
The original goal was mobile usability, but the uncommitted diff had started to mix in unrelated packaged runtime output and an unused viewport hook. This version keeps the improvements that help the mobile widget today while avoiding unnecessary surface area and regressions for wide assistant content.

## Impact
- safer mobile composer behavior
- cleaner, easier-to-review widget-only diff
- no packaged runtime changes bundled into a UI patch

## Validation
- `git diff --check`
- `./node_modules/.bin/eslint apps/registry/src/components/aomi-frame.tsx apps/registry/src/components/assistant-ui/thread.tsx`
- manual verification via the fullscreen renderer in `../aomi-miniapp`
