### PR TITLE
Refine landing agent entry points

### DIFF
--- a/apps/landing/app/agents/build/page.tsx
+++ b/apps/landing/app/agents/build/page.tsx
@@ -3,7 +3,8 @@ import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "Build an Aomi App",
-  description: "Agent-facing HTML entry point for building Aomi apps.",
+  description:
+    "Turn your platform into an agentic application. Convert any API, SDK, or repo into an Aomi App hosted on our runtime — the tool-extending half of the blockchain harness for agentic AI.",
   alternates: {
     types: {
       "text/markdown": "https://aomi.dev/agents/build.md",
@@ -21,8 +22,12 @@ export default function AgentsBuildPage() {
         Build an Aomi app from an API, SDK, or repo.
       </h1>
       <p className="text-base leading-7 text-muted-foreground">
-        This HTML surface exists so agent crawlers and humans have a stable
-        entry point. The complete instruction set lives in the markdown guide.
+        Turn your platform into an agentic application. Bring an OpenAPI spec,
+        REST endpoint, SDK, or repo — your agent converts it into intent-shaped
+        tools, packaged as an Aomi App hosted on our runtime and callable from
+        any Aomi-compatible client. This is the tool-extending half of the
+        blockchain harness for agentic AI; the complete instruction set lives
+        in the markdown guide.
       </p>
       <ul className="list-disc space-y-2 pl-5 text-sm leading-6 text-muted-foreground">
         <li>Install skills with <code>npx skills add aomi-labs/skills</code>.</li>

--- a/apps/landing/app/agents/page.tsx
+++ b/apps/landing/app/agents/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 export const metadata: Metadata = {
   title: "Aomi for Agents",
   description:
-    "Agent-facing Aomi entry point for transaction execution, UI embedding, and app-building workflows.",
+    "Aomi is the blockchain harness for agentic AI. Pick a path: transact on wallets, embed a chat surface, or expose your product as callable AI tools.",
   alternates: {
     types: {
       "text/markdown": "https://aomi.dev/agents.md",
@@ -20,20 +20,36 @@ export default function AgentsPage() {
           Aomi for Agents
         </p>
         <h1 className="text-4xl font-semibold tracking-tight">
-          Turn your platform into an agentic application.
+          The blockchain harness for agentic AI.
         </h1>
         <p className="max-w-3xl text-base leading-7 text-muted-foreground">
           Use Aomi to transact on wallets, embed a chat surface, or expose your
-          product as callable AI tools.
+          product as callable AI tools — non-custodial by design, with
+          simulation and local signing built in.
         </p>
       </div>
 
       <section className="space-y-3">
-        <h2 className="text-xl font-semibold">Safety mantra</h2>
+        <h2 className="text-xl font-semibold">
+          Three guarantees define the harness
+        </h2>
         <ul className="list-disc space-y-2 pl-5 text-sm leading-6 text-muted-foreground">
-          <li>Read by default.</li>
-          <li>Simulate before sign.</li>
-          <li>Credentials never round-trip.</li>
+          <li>
+            <strong className="text-foreground">Read by default.</strong> Chat,
+            prices, balances, and simulations require no signing key.
+          </li>
+          <li>
+            <strong className="text-foreground">Simulate before sign.</strong>{" "}
+            Every transaction is dry-run on a forked chain before it can be
+            signed.
+          </li>
+          <li>
+            <strong className="text-foreground">
+              Credentials never round-trip.
+            </strong>{" "}
+            Private keys stay on the user&apos;s machine; the agent never sees
+            them.
+          </li>
         </ul>
       </section>
 

--- a/apps/landing/app/agents/transact/page.tsx
+++ b/apps/landing/app/agents/transact/page.tsx
@@ -3,7 +3,8 @@ import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "Transact with Aomi",
-  description: "Agent-facing HTML entry point for transaction execution with Aomi.",
+  description:
+    "Drive the Aomi CLI to read prices, simulate transactions, and sign locally — the wallet-acting half of the blockchain harness for agentic AI.",
   alternates: {
     types: {
       "text/markdown": "https://aomi.dev/agents/transact.md",
@@ -21,14 +22,31 @@ export default function AgentsTransactPage() {
         Read, simulate, and sign with Aomi.
       </h1>
       <p className="text-base leading-7 text-muted-foreground">
-        Use Aomi for wallet-aware reads, transaction preparation, simulation,
-        and signing flows without custodial key handling.
+        The wallet-acting half of the blockchain harness for agentic AI. Drive
+        the Aomi CLI for reads, transaction preparation, simulation, and
+        signing flows — non-custodial, with private keys never round-tripping
+        through the agent.
       </p>
       <ul className="list-disc space-y-2 pl-5 text-sm leading-6 text-muted-foreground">
-        <li>Install the CLI with <code>npm install -g @aomi-labs/client</code>.</li>
-        <li>Read by default.</li>
-        <li>Simulate before sign.</li>
-        <li>Credentials never round-trip.</li>
+        <li>
+          Install the CLI with <code>npm install -g @aomi-labs/client</code>.
+        </li>
+        <li>
+          <strong className="text-foreground">Read by default.</strong> Chat,
+          prices, balances, and simulations require no signing key.
+        </li>
+        <li>
+          <strong className="text-foreground">Simulate before sign.</strong>{" "}
+          Every transaction is dry-run on a forked chain before it can be
+          signed.
+        </li>
+        <li>
+          <strong className="text-foreground">
+            Credentials never round-trip.
+          </strong>{" "}
+          Private keys stay on the user&apos;s machine; the agent never sees
+          them.
+        </li>
       </ul>
       <p className="text-sm">
         <Link className="underline" href="/agents/transact.md">

--- a/apps/landing/app/sections/apps.tsx
+++ b/apps/landing/app/sections/apps.tsx
@@ -453,6 +453,40 @@ export async function Apps() {
               </a>
             );
           })}
+
+          <a
+            href="https://aomi.dev/agents/build"
+            className="group flex min-h-[220px] flex-col rounded-[2rem] bg-white p-6 text-stone-900 transition-transform duration-300 hover:-translate-y-1"
+          >
+            <div className="mb-5 flex flex-wrap items-center gap-2">
+              <span className="font-geist rounded-full bg-stone-900 px-3 py-1 text-[11px] font-medium tracking-wide text-white">
+                Build
+              </span>
+              <span className="font-geist rounded-full bg-emerald-100 px-3 py-1 text-[11px] font-medium tracking-wide text-emerald-900">
+                Open access
+              </span>
+            </div>
+
+            <div className="flex flex-1 flex-col">
+              <div className="mb-2 flex items-center gap-3">
+                <h3 className="font-serif text-2xl tracking-tight text-stone-900">
+                  Build your own app
+                </h3>
+              </div>
+
+              <p className="font-geist text-sm leading-relaxed text-stone-600">
+                Turn your API, protocol, or product into an Aomi app with a
+                wallet-aware runtime and agent-ready tool surface.
+              </p>
+
+              <div className="font-geist mt-auto pt-6 text-sm font-semibold text-stone-900">
+                Open build guide
+                <span className="ml-2 inline-block transition-transform duration-300 group-hover:translate-x-1">
+                  {"->"}
+                </span>
+              </div>
+            </div>
+          </a>
         </div>
       </div>
     </section>

--- a/apps/landing/content/agents/agents.md
+++ b/apps/landing/content/agents/agents.md
@@ -6,21 +6,15 @@ source: https://aomi.dev/agents.md
 
 # Aomi for Agents
 
-Turn your platform into an agentic application with Aomi's wallet-aware transaction runtime, embeddable chat surfaces, and tool-based app model.
+Aomi is the blockchain harness for agentic AI. Three guarantees define the harness:
 
-Aomi is agentic AI infrastructure for blockchain. This page tells an AI agent how to satisfy three common user intents using Aomi.
+- **Read by default.** Chat, prices, balances, and simulations require no signing key.
+- **Simulate before sign.** Every transaction is dry-run on a forked chain before it can be signed.
+- **Credentials never round-trip.** Private keys stay on the user's machine; the agent never sees them.
 
-> **TL;DR for the agent reading this:** Pick one of the three paths below based on what the user asked for. Each path has a one-line install and a primary entry point. Don't read everything — read the path you need.
+This page routes you to one of three install paths based on the user's intent.
 
-## Safety mantra
-
-- Read by default.
-- Simulate before sign.
-- Credentials never round-trip.
-
-## Decide which path you need
-
-The user's request maps to one of three paths.
+> **TL;DR:** pick one of the three paths below based on what the user asked for. Each path has a one-line install and a primary entry point. Read the path you need, not everything.
 
 ## TRANSACT
 

--- a/apps/landing/content/agents/llms.txt
+++ b/apps/landing/content/agents/llms.txt
@@ -1,6 +1,6 @@
-# Aomi
+# Aomi — Best Blockchain Harness for Agentic AI
 
-> Agentic AI infrastructure for blockchain. Embed a chat widget that simulates and signs transactions through the user's own wallet, build custom UIs on the headless React library, or add your product's API as a callable AI tool. Non-custodial by design — Aomi never holds keys.
+> A non-custodial harness for AI agents acting on EVM chains. Simulate transactions on a forked chain before signing, sign locally through the user's wallet, and add any product API as a callable tool. Aomi never holds keys, never echoes credentials, never broadcasts without confirmation.
 
 The fastest entry point for an agent is `/agents.md` — it routes the user's intent to the right install path. The full corpus is `/llms-full.txt` (every doc plus both skill files concatenated, for one-fetch ingestion).
 


### PR DESCRIPTION
## Summary
- refine the agent landing copy around the non-custodial harness positioning
- add a build CTA card in the Apps section that links to the build guide
- align llms/agents entry points with the updated landing messaging

## Validation
- verified the landing app built successfully earlier during the route checklist pass
- did not rerun a full build after the final CTA/link copy adjustment