### PR TITLE
Bump published @aomi-labs package versions

### DIFF
--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/widget-lib",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "description": "Shadcn registry for the Aomi widget.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/client",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "Platform-agnostic TypeScript client for the Aomi backend API",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/react",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Runtime, state, and utilities for the Aomi widget.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- bump `@aomi-labs/client` from `0.1.35` to `0.1.36`
- bump `@aomi-labs/react` from `0.3.18` to `0.3.19`
- bump `@aomi-labs/widget-lib` from `1.2.14` to `1.2.15`

## Verification
- manifest-only version bump; verified the three publishable `package.json` files were updated on top of current `main`