### PR TITLE
Refine settings pages UI

### DIFF
--- a/apps/portal/src/components/settings/app-keys.tsx
+++ b/apps/portal/src/components/settings/app-keys.tsx
@@ -3,6 +3,22 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button, Input, useAomiAuthAdapter } from "@aomi-labs/widget-lib";
 import { settingsApiFetch } from "@portal/lib/settings-api";
+import {
+  settingsActionRowClass,
+  settingsBodyTextClass,
+  settingsCardStackClass,
+  settingsCardTitleClass,
+  settingsDescriptionClass,
+  settingsInputClass,
+  settingsLabelClass,
+  settingsPageClass,
+  settingsPillClass,
+  settingsPrimaryButtonClass,
+  settingsStatusClass,
+  settingsSubTitleClass,
+  settingsTableCardClass,
+  settingsTitleClass,
+} from "./settings-styles";
 
 type OwnedAppKey = {
   key_hash: string;
@@ -176,9 +192,7 @@ export function AppKeys() {
     async (key: OwnedAppKey) => {
       if (deletingHash) return;
 
-      const shouldDelete = window.confirm(
-        `Remove app key ${key.key_prefix}?`,
-      );
+      const shouldDelete = window.confirm(`Remove app key ${key.key_prefix}?`);
       if (!shouldDelete) return;
 
       setDeletingHash(key.key_hash);
@@ -205,41 +219,33 @@ export function AppKeys() {
   );
 
   return (
-    <div className="space-y-8">
-      <div>
-        <h3 className="text-foreground mb-4 text-lg font-semibold">App Keys</h3>
-        <p className="text-muted-foreground text-sm">
-          Programmatic access keys for Aomi. Send as <code>X-API-Key</code> to
-          call <code>/api/chat</code> from your own services. Newly generated
+    <div className={settingsPageClass}>
+      <div className="space-y-4">
+        <h1 className={settingsTitleClass}>App Keys</h1>
+        <p className={settingsDescriptionClass}>
+          Programmatic access keys for Aomi. Send as <code>AOMI-APP-KEY</code>{" "}
+          to call <code>/api/chat</code> from your own services. Newly generated
           keys are shown only once.
         </p>
-        {!identity.address && (
-          <p className="text-muted-foreground mt-2 text-sm">
-            Connect a wallet account to manage owned app keys.
-          </p>
-        )}
       </div>
 
       {status && (
         <div
-          className={`rounded-2xl p-3 text-sm ${
+          className={`${settingsStatusClass} ${
             status.type === "success"
-              ? "border border-green-500/20 bg-green-500/10 text-green-700 dark:text-green-400"
-              : "bg-destructive/10 border-destructive/20 text-destructive border"
+              ? "border-green-500/20 bg-green-500/10 text-green-700 dark:text-green-400"
+              : "border-destructive/20 bg-destructive/10 text-destructive"
           }`}
         >
           {status.text}
         </div>
       )}
 
-      <div className="border-input bg-background space-y-4 rounded-3xl border p-5">
-        <h4 className="text-foreground text-base font-semibold">Add App Key</h4>
-        <div className="grid gap-4 md:grid-cols-2">
-          <div className="space-y-2">
-            <label
-              htmlFor="app-key-label"
-              className="text-foreground block text-sm font-medium"
-            >
+      <div className={`${settingsCardStackClass} space-y-5`}>
+        <h2 className={settingsCardTitleClass}>Add App Key</h2>
+        <div className="grid gap-5 xl:grid-cols-2">
+          <div className="min-w-0 space-y-4">
+            <label htmlFor="app-key-label" className={settingsLabelClass}>
               Label (optional)
             </label>
             <Input
@@ -248,13 +254,13 @@ export function AppKeys() {
               value={labelInput}
               onChange={(event) => setLabelInput(event.target.value)}
               placeholder="Trading bot"
-              className="h-10 rounded-3xl border-2 bg-muted px-5 text-sm"
+              className={settingsInputClass}
             />
           </div>
-          <div className="space-y-3">
+          <div className="min-w-0 space-y-4">
             <label
               htmlFor="manual-app-key-input"
-              className="text-foreground block text-sm font-medium"
+              className={settingsLabelClass}
             >
               App Key Value (optional)
             </label>
@@ -264,26 +270,26 @@ export function AppKeys() {
               value={manualKeyInput}
               onChange={(event) => setManualKeyInput(event.target.value)}
               placeholder="Leave empty to auto-generate"
-              className="h-10 rounded-3xl border-2 bg-muted px-5 text-sm"
+              className={settingsInputClass}
             />
-            <p className="text-muted-foreground text-sm">
+            <p className={settingsBodyTextClass}>
               Leave blank to create a secure generated key.
             </p>
           </div>
         </div>
 
-        <div>
-          <p className="text-foreground mb-2 text-sm font-medium">Apps</p>
+        <div className="min-w-0 space-y-4">
+          <p className={settingsCardTitleClass}>Apps</p>
           {loadingApps && (
-            <p className="text-muted-foreground text-sm">Loading apps...</p>
+            <p className={settingsBodyTextClass}>Loading apps...</p>
           )}
           {!loadingApps && availableApps.length === 0 && (
-            <p className="text-muted-foreground text-sm">
+            <p className={settingsBodyTextClass}>
               No apps available for this session.
             </p>
           )}
           {!loadingApps && availableApps.length > 0 && (
-            <div className="flex flex-wrap gap-2">
+            <div className="flex min-w-0 flex-wrap gap-3">
               {availableApps.map((app) => {
                 const selected = selectedApps.includes(app);
                 return (
@@ -291,10 +297,10 @@ export function AppKeys() {
                     key={app}
                     type="button"
                     onClick={() => toggleApp(app)}
-                    className={`rounded-full border px-3 py-1.5 text-sm transition-colors ${
+                    className={`${settingsPillClass} ${
                       selected
-                        ? "bg-primary text-primary-foreground border-primary"
-                        : "bg-background text-foreground border-input hover:bg-accent"
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-input bg-background text-foreground hover:bg-accent"
                     }`}
                   >
                     {app}
@@ -305,23 +311,23 @@ export function AppKeys() {
           )}
         </div>
 
-        <div className="flex justify-end">
+        <div className={settingsActionRowClass}>
           <Button
             type="button"
             onClick={() => {
               void handleCreate();
             }}
             disabled={!canCreate}
-            className="rounded-full px-6"
+            className={settingsPrimaryButtonClass}
           >
             {creating ? "Creating..." : "Create app key"}
           </Button>
         </div>
 
         {createdAppKey && (
-          <div className="space-y-2 rounded-2xl border border-green-500/20 bg-green-500/5 p-4">
-            <p className="text-foreground text-sm font-medium">New app key</p>
-            <p className="text-foreground break-all font-mono text-sm">
+          <div className="space-y-4 rounded-3xl border border-green-500/20 bg-green-500/5 p-6">
+            <p className={settingsLabelClass}>New app key</p>
+            <p className="text-foreground break-all font-mono text-sm leading-7">
               {createdAppKey}
             </p>
             <div className="flex gap-2">
@@ -348,69 +354,80 @@ export function AppKeys() {
         )}
       </div>
 
-      <div className="border-input bg-background overflow-x-auto rounded-3xl border p-2">
-        <table className="min-w-full text-sm">
-          <thead>
-            <tr className="text-muted-foreground text-left">
-              <th className="px-3 py-2">Key</th>
-              <th className="px-3 py-2">Label</th>
-              <th className="px-3 py-2">Apps</th>
-              <th className="px-3 py-2">Status</th>
-              <th className="px-3 py-2">Last used</th>
-              <th className="px-3 py-2 text-right">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {loadingKeys && (
-              <tr>
-                <td className="text-muted-foreground px-3 py-4" colSpan={6}>
-                  Loading app keys...
-                </td>
+      <div className="space-y-4">
+        <h2 className={settingsSubTitleClass}>Owned Keys</h2>
+        <div className={settingsTableCardClass}>
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="text-muted-foreground text-center">
+                <th className="px-3 py-2">Key</th>
+                <th className="px-3 py-2">Label</th>
+                <th className="px-3 py-2">Apps</th>
+                <th className="px-3 py-2">Status</th>
+                <th className="px-3 py-2">Last used</th>
+                <th className="px-3 py-2">Actions</th>
               </tr>
-            )}
-            {!loadingKeys && appKeys.length === 0 && (
-              <tr>
-                <td className="text-muted-foreground px-3 py-4" colSpan={6}>
-                  No app keys found.
-                </td>
-              </tr>
-            )}
-            {!loadingKeys &&
-              appKeys.map((key) => (
-                <tr key={key.key_hash} className="border-border border-t">
-                  <td className="text-foreground px-3 py-2 font-mono">
-                    {key.key_prefix}
-                  </td>
-                  <td className="text-muted-foreground px-3 py-2">
-                    {key.label || "-"}
-                  </td>
-                  <td className="text-muted-foreground px-3 py-2">
-                    {key.apps.join(", ")}
-                  </td>
-                  <td className="text-muted-foreground px-3 py-2">
-                    {key.is_active ? "Active" : "Inactive"}
-                  </td>
-                  <td className="text-muted-foreground px-3 py-2">
-                    {formatTs(key.last_used_at)}
-                  </td>
-                  <td className="px-3 py-2 text-right">
-                    <Button
-                      type="button"
-                      variant="destructive"
-                      size="sm"
-                      onClick={() => {
-                        void handleRemove(key);
-                      }}
-                      disabled={deletingHash === key.key_hash}
-                      className="rounded-full"
-                    >
-                      {deletingHash === key.key_hash ? "Removing..." : "Remove"}
-                    </Button>
+            </thead>
+            <tbody>
+              {loadingKeys && (
+                <tr>
+                  <td
+                    className="text-muted-foreground px-3 py-4 text-center"
+                    colSpan={6}
+                  >
+                    Loading app keys...
                   </td>
                 </tr>
-              ))}
-          </tbody>
-        </table>
+              )}
+              {!loadingKeys && appKeys.length === 0 && (
+                <tr>
+                  <td
+                    className="text-muted-foreground px-3 py-4 text-center"
+                    colSpan={6}
+                  >
+                    No app keys found.
+                  </td>
+                </tr>
+              )}
+              {!loadingKeys &&
+                appKeys.map((key) => (
+                  <tr key={key.key_hash} className="border-border border-t">
+                    <td className="text-foreground px-3 py-2 font-mono">
+                      {key.key_prefix}
+                    </td>
+                    <td className="text-muted-foreground px-3 py-2">
+                      {key.label || "-"}
+                    </td>
+                    <td className="text-muted-foreground px-3 py-2">
+                      {key.apps.join(", ")}
+                    </td>
+                    <td className="text-muted-foreground px-3 py-2">
+                      {key.is_active ? "Active" : "Inactive"}
+                    </td>
+                    <td className="text-muted-foreground px-3 py-2">
+                      {formatTs(key.last_used_at)}
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      <Button
+                        type="button"
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => {
+                          void handleRemove(key);
+                        }}
+                        disabled={deletingHash === key.key_hash}
+                        className="rounded-full"
+                      >
+                        {deletingHash === key.key_hash
+                          ? "Removing..."
+                          : "Remove"}
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );

--- a/apps/portal/src/components/settings/apps-settings.tsx
+++ b/apps/portal/src/components/settings/apps-settings.tsx
@@ -1,9 +1,20 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { useAomiAuthAdapter } from "@aomi-labs/widget-lib";
+import { Input, useAomiAuthAdapter } from "@aomi-labs/widget-lib";
 import { settingsApiFetch } from "@portal/lib/settings-api";
 import { defaultUsageDateRange } from "@portal/lib/usage-range";
+import {
+  settingsBodyTextClass,
+  settingsCardStackClass,
+  settingsCardTitleClass,
+  settingsInputClass,
+  settingsLabelClass,
+  settingsPageClass,
+  settingsSubTitleClass,
+  settingsTableCardClass,
+  settingsTitleClass,
+} from "./settings-styles";
 
 type AppRow = {
   app: string;
@@ -87,29 +98,26 @@ export function AppsSettings() {
   }, [fetchOverview]);
 
   return (
-    <div className="space-y-8">
+    <div className={settingsPageClass}>
       <div>
-        <h3 className="text-foreground mb-4 text-lg font-semibold">Apps</h3>
-        <div className="border-input bg-background space-y-4 rounded-3xl border p-5">
+        <h1 className={`${settingsTitleClass} mb-4`}>Usage</h1>
+        <div className={settingsCardStackClass}>
           {!identity.address && (
-            <p className="text-muted-foreground text-sm">
-              Connect a wallet to view app access.
+            <p className={settingsBodyTextClass}>
+              Connect a wallet to view usage across your apps.
             </p>
           )}
-          {loading && (
-            <p className="text-muted-foreground text-sm">
-              Loading app usage...
-            </p>
-          )}
+          {loading && <p className={settingsBodyTextClass}>Loading usage...</p>}
           {error && (
             <p className="text-destructive text-sm">
               Failed to load usage: {error}
             </p>
           )}
-          <div className="grid gap-3 sm:grid-cols-2">
-            <label className="text-muted-foreground block text-sm">
+          <p className={settingsCardTitleClass}>Date Range</p>
+          <div className="mr-2 grid gap-8 sm:grid-cols-2">
+            <label className={settingsLabelClass}>
               From
-              <input
+              <Input
                 type="date"
                 value={fromDate}
                 max={toDate}
@@ -120,12 +128,12 @@ export function AppsSettings() {
                     setToDate(next);
                   }
                 }}
-                className="border-input focus:ring-ring focus:border-ring bg-background text-foreground mt-1 w-full rounded-lg border px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2"
+                className={`${settingsInputClass} mt-2`}
               />
             </label>
-            <label className="text-muted-foreground block text-sm">
+            <label className={settingsLabelClass}>
               To
-              <input
+              <Input
                 type="date"
                 value={toDate}
                 min={fromDate}
@@ -136,20 +144,20 @@ export function AppsSettings() {
                     setFromDate(next);
                   }
                 }}
-                className="border-input focus:ring-ring focus:border-ring bg-background text-foreground mt-1 w-full rounded-lg border px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2"
+                className={`${settingsInputClass} mt-1`}
               />
             </label>
           </div>
           {!loading && overview && (
             <>
-              <p className="text-muted-foreground text-sm">
+              <p className={settingsBodyTextClass}>
                 Range: {overview.period_utc_from} to {overview.period_utc_to}
               </p>
-              <p className="text-muted-foreground text-sm">
+              <p className={settingsBodyTextClass}>
                 Credits: {formatNumber(overview.overall.credit_used)} /{" "}
                 {formatNumber(overview.overall.credit_paid)}
               </p>
-              <p className="text-muted-foreground text-sm">
+              <p className={settingsBodyTextClass}>
                 Tokens: in {formatNumber(overview.overall.input_tokens)} | out{" "}
                 {formatNumber(overview.overall.output_tokens)}
               </p>
@@ -159,13 +167,11 @@ export function AppsSettings() {
       </div>
 
       <div>
-        <h3 className="text-foreground mb-4 text-lg font-semibold">
-          Available Apps
-        </h3>
-        <div className="border-input bg-background overflow-x-auto rounded-3xl border p-2">
+        <h2 className={`${settingsSubTitleClass} mb-4`}>Usage by App</h2>
+        <div className={settingsTableCardClass}>
           <table className="min-w-full text-sm">
             <thead>
-              <tr className="text-muted-foreground text-left">
+              <tr className="text-muted-foreground text-center">
                 <th className="px-3 py-2">App</th>
                 <th className="px-3 py-2">Source</th>
                 <th className="px-3 py-2">Credits</th>
@@ -194,8 +200,11 @@ export function AppsSettings() {
               ))}
               {!overview?.apps?.length && (
                 <tr>
-                  <td className="text-muted-foreground px-3 py-4" colSpan={5}>
-                    No apps found.
+                  <td
+                    className="text-muted-foreground px-3 py-4 text-center"
+                    colSpan={5}
+                  >
+                    No usage found.
                   </td>
                 </tr>
               )}

--- a/apps/portal/src/components/settings/byok.tsx
+++ b/apps/portal/src/components/settings/byok.tsx
@@ -3,6 +3,21 @@
 import { useCallback, useMemo, useState } from "react";
 import { useControl } from "@aomi-labs/react";
 import { Button, Input } from "@aomi-labs/widget-lib";
+import {
+  settingsActionRowClass,
+  settingsBodyTextClass,
+  settingsCardStackClass,
+  settingsCardTitleClass,
+  settingsDescriptionClass,
+  settingsInputClass,
+  settingsPageClass,
+  settingsPillClass,
+  settingsPrimaryButtonClass,
+  settingsStatusClass,
+  settingsSubTitleClass,
+  settingsTableCardClass,
+  settingsTitleClass,
+} from "./settings-styles";
 
 const PROVIDERS = [
   { id: "openai", label: "OpenAI" },
@@ -12,12 +27,16 @@ const PROVIDERS = [
 
 export function Byok() {
   const { state, setByok, removeByok } = useControl();
-  const [selectedProvider, setSelectedProvider] = useState<(typeof PROVIDERS)[number]["id"]>("openai");
+  const [selectedProvider, setSelectedProvider] =
+    useState<(typeof PROVIDERS)[number]["id"]>("openai");
   const [byokInput, setByokInput] = useState("");
   const [labelInput, setLabelInput] = useState("");
   const [saving, setSaving] = useState(false);
   const [deletingProvider, setDeletingProvider] = useState<string | null>(null);
-  const [status, setStatus] = useState<{ type: "success" | "error"; text: string } | null>(null);
+  const [status, setStatus] = useState<{
+    type: "success" | "error";
+    text: string;
+  } | null>(null);
   const byokKeys = useMemo(
     () =>
       Object.entries(state.byokKeys).map(([provider, entry]) => ({
@@ -50,7 +69,8 @@ export function Byok() {
     } catch (error) {
       setStatus({
         type: "error",
-        text: error instanceof Error ? error.message : "Failed to save BYOK key",
+        text:
+          error instanceof Error ? error.message : "Failed to save BYOK key",
       });
     } finally {
       setSaving(false);
@@ -67,7 +87,10 @@ export function Byok() {
       } catch (error) {
         setStatus({
           type: "error",
-          text: error instanceof Error ? error.message : "Failed to delete BYOK key",
+          text:
+            error instanceof Error
+              ? error.message
+              : "Failed to delete BYOK key",
         });
       } finally {
         setDeletingProvider(null);
@@ -77,21 +100,22 @@ export function Byok() {
   );
 
   return (
-    <div className="space-y-8">
-      <div className="space-y-2">
-        <h1 className="text-2xl font-semibold tracking-tight">LLM Keys</h1>
-        <p className="text-sm text-muted-foreground">
+    <div className={settingsPageClass}>
+      <div className="space-y-4">
+        <h1 className={settingsTitleClass}>BYOK</h1>
+        <p className={settingsDescriptionClass}>
           Bring your own LLM provider keys for OpenAI, Anthropic, or OpenRouter.
           BYOK usage is recorded, but it does not consume Aomi credits.
         </p>
       </div>
 
-      <section className="rounded-2xl border border-border bg-card p-6 space-y-4">
+      <section className={settingsCardStackClass}>
         <div className="space-y-2">
-          <h2 className="text-lg font-medium">Add or Update Key</h2>
-          <p className="text-sm text-muted-foreground">
-            One active key is stored per provider. Saving a new one replaces the previous value.
-            Keys are stored in your browser and synchronized with the backend vault.
+          <h2 className={settingsCardTitleClass}>Add or Update Key</h2>
+          <p className={settingsBodyTextClass}>
+            One active key is stored per provider. Saving a new one replaces the
+            previous value. Keys are stored in your browser and synchronized
+            with the backend vault.
           </p>
         </div>
 
@@ -103,7 +127,7 @@ export function Byok() {
                 key={provider.id}
                 type="button"
                 onClick={() => setSelectedProvider(provider.id)}
-                className={`rounded-full border px-3 py-1.5 text-sm transition-colors ${
+                className={`${settingsPillClass} ${
                   active
                     ? "border-foreground bg-foreground text-background"
                     : "border-border bg-background text-foreground hover:border-foreground/40"
@@ -120,6 +144,7 @@ export function Byok() {
             value={labelInput}
             onChange={(event) => setLabelInput(event.target.value)}
             placeholder="Label (optional)"
+            className={settingsInputClass}
           />
           <Input
             value={byokInput}
@@ -127,61 +152,89 @@ export function Byok() {
             placeholder="Paste LLM provider key"
             type="password"
             autoComplete="off"
+            className={settingsInputClass}
           />
         </div>
 
-        <Button onClick={() => void handleSave()} disabled={!canSave}>
-          {saving ? "Saving..." : "Save Key"}
-        </Button>
+        <div className={settingsActionRowClass}>
+          <Button
+            onClick={() => void handleSave()}
+            disabled={!canSave}
+            className={settingsPrimaryButtonClass}
+          >
+            {saving ? "Saving..." : "Save Key"}
+          </Button>
+        </div>
 
         {status && (
           <p
-            className={`text-sm ${status.type === "error" ? "text-destructive" : "text-emerald-600"}`}
+            className={`${settingsStatusClass} ${
+              status.type === "error"
+                ? "border-destructive/20 bg-destructive/10 text-destructive"
+                : "border-green-500/20 bg-green-500/10 text-green-700 dark:text-green-400"
+            }`}
           >
             {status.text}
           </p>
         )}
       </section>
 
-      <section className="rounded-2xl border border-border bg-card p-6 space-y-4">
+      <section className="space-y-4">
         <div className="space-y-2">
-          <h2 className="text-lg font-medium">Stored Keys</h2>
-          <p className="text-sm text-muted-foreground">
-            Keys are mirrored in local browser state and synchronized with the backend vault.
+          <h2 className={settingsSubTitleClass}>Stored Keys</h2>
+          <p className={settingsBodyTextClass}>
+            Keys are mirrored in local browser state and synchronized with the
+            backend vault.
           </p>
         </div>
 
-        {byokKeys.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No BYOK keys saved.</p>
-        ) : (
-          <div className="space-y-3">
-            {byokKeys.map((key) => (
-              <div
-                key={key.provider}
-                className="flex flex-col gap-3 rounded-xl border border-border/80 bg-background p-4 md:flex-row md:items-center md:justify-between"
-              >
-                <div className="space-y-1">
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm font-medium capitalize">{key.provider}</span>
-                    <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-                      {key.keyPrefix}
-                    </span>
-                  </div>
-                  <p className="text-sm text-muted-foreground">
-                    {key.label?.trim() ? key.label : "No label"}
-                  </p>
-                </div>
-                <Button
-                  variant="outline"
-                  disabled={deletingProvider === key.provider}
-                  onClick={() => void handleDelete(key.provider)}
-                >
-                  {deletingProvider === key.provider ? "Removing..." : "Delete"}
-                </Button>
-              </div>
-            ))}
-          </div>
-        )}
+        <div className={settingsTableCardClass}>
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="text-muted-foreground text-center">
+                <th className="px-3 py-2">Provider</th>
+                <th className="px-3 py-2">Preview</th>
+                <th className="px-3 py-2">Label</th>
+                <th className="px-3 py-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {byokKeys.length === 0 ? (
+                <tr>
+                  <td className="text-muted-foreground px-3 py-4 text-center" colSpan={4}>
+                    No BYOK keys saved.
+                  </td>
+                </tr>
+              ) : (
+                byokKeys.map((key) => (
+                  <tr key={key.provider} className="border-border border-t">
+                    <td className="text-foreground px-3 py-3 text-center font-medium capitalize">
+                      {key.provider}
+                    </td>
+                    <td className="px-3 py-3 text-center">
+                      <span className="bg-muted text-muted-foreground rounded-full px-2 py-0.5 text-xs">
+                        {key.keyPrefix}
+                      </span>
+                    </td>
+                    <td className="text-muted-foreground px-3 py-3 text-center">
+                      {key.label?.trim() ? key.label : "No label"}
+                    </td>
+                    <td className="px-3 py-3 text-center">
+                      <Button
+                        variant="outline"
+                        disabled={deletingProvider === key.provider}
+                        onClick={() => void handleDelete(key.provider)}
+                        className="rounded-full"
+                      >
+                        {deletingProvider === key.provider ? "Removing..." : "Delete"}
+                      </Button>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
       </section>
     </div>
   );

--- a/apps/portal/src/components/settings/general-settings.tsx
+++ b/apps/portal/src/components/settings/general-settings.tsx
@@ -3,10 +3,21 @@
 import { useEffect, useMemo, useState } from "react";
 import { getChainInfo } from "@aomi-labs/react";
 import {
+  Button,
   formatAuthMethod,
   useAomiAuthAdapter,
 } from "@aomi-labs/widget-lib";
 import { settingsApiFetch } from "@portal/lib/settings-api";
+import {
+  settingsBodyTextClass,
+  settingsCardClass,
+  settingsCardStackClass,
+  settingsCardTitleClass,
+  settingsPageClass,
+  settingsPrimaryButtonClass,
+  settingsSubTitleClass,
+  settingsTitleClass,
+} from "./settings-styles";
 
 type AccountProfile = {
   user_id: string;
@@ -84,34 +95,32 @@ export function GeneralSettings() {
   }, [identity.address]);
 
   return (
-    <div className="space-y-8">
+    <div className={settingsPageClass}>
       <div>
-        <h3 className="text-foreground mb-6 text-lg font-semibold">Account</h3>
-        <div className="border-input bg-background rounded-3xl border p-5">
+        <h1 className={`${settingsTitleClass} mb-4`}>Account</h1>
+        <div className={settingsCardClass}>
           <div className="flex items-start justify-between gap-4">
             <div className="space-y-1">
-              <p className="text-foreground text-sm font-medium">Identity</p>
-              <p className="text-muted-foreground text-sm">
-                Type: {identityType}
-              </p>
-              <p className="text-muted-foreground text-sm">
+              <p className={settingsCardTitleClass}>Identity</p>
+              <p className={settingsBodyTextClass}>Type: {identityType}</p>
+              <p className={settingsBodyTextClass}>
                 Primary:{" "}
                 {identity.status === "disconnected"
                   ? "Not connected"
                   : (identity.address ?? "Connected")}
               </p>
               {identity.address && (
-                <p className="text-muted-foreground text-sm">
+                <p className={settingsBodyTextClass}>
                   Wallet: {identity.address}
                 </p>
               )}
               {networkTicker && (
-                <p className="text-muted-foreground text-sm">
+                <p className={settingsBodyTextClass}>
                   Network: {networkTicker}
                 </p>
               )}
             </div>
-            <button
+            <Button
               type="button"
               onClick={() => {
                 if (identity.isConnected && adapter.openAccountUI) {
@@ -121,23 +130,21 @@ export function GeneralSettings() {
                 void adapter.connect();
               }}
               disabled={!adapter.canOpenAccountUI && !adapter.canConnect}
-              className="text-primary-foreground bg-primary hover:bg-primary/90 focus:ring-ring focus:ring-offset-background rounded-full px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2"
+              className={settingsPrimaryButtonClass}
             >
               {identity.isConnected ? "Manage account" : "Connect account"}
-            </button>
+            </Button>
           </div>
         </div>
       </div>
 
       <div>
-        <h3 className="text-foreground mb-4 text-lg font-semibold">
+        <h2 className={`${settingsSubTitleClass} mb-4`}>
           Subscription and Usage
-        </h3>
-        <div className="border-input bg-background space-y-3 rounded-3xl border p-5">
+        </h2>
+        <div className={`${settingsCardStackClass} space-y-3`}>
           {loading && (
-            <p className="text-muted-foreground text-sm">
-              Loading account overview...
-            </p>
+            <p className={settingsBodyTextClass}>Loading account overview...</p>
           )}
           {!loading && error && (
             <p className="text-destructive text-sm">
@@ -145,39 +152,39 @@ export function GeneralSettings() {
             </p>
           )}
           {!loading && !error && !account && (
-            <p className="text-muted-foreground text-sm">
+            <p className={settingsBodyTextClass}>
               Connect your wallet to load account details.
             </p>
           )}
           {!loading && !error && account && (
             <>
-              <p className="text-muted-foreground text-sm">
+              <p className={settingsBodyTextClass}>
                 User ID: {account.account.user_id}
               </p>
-              <p className="text-muted-foreground text-sm">
+              <p className={settingsBodyTextClass}>
                 Tier: {account.account.tier}
               </p>
-              <p className="text-muted-foreground text-sm">
+              <p className={settingsBodyTextClass}>
                 Verified email: {account.account.verified_email ?? "-"}
               </p>
-              <p className="text-muted-foreground text-sm">
+              <p className={settingsBodyTextClass}>
                 Status: {account.account.status}
               </p>
-              <p className="text-muted-foreground text-sm">
+              <p className={settingsBodyTextClass}>
                 Month: {account.usage.period_utc_month}
               </p>
-              <p className="text-muted-foreground text-sm">
+              <p className={settingsBodyTextClass}>
                 Credits: {formatNumber(account.usage.credit_used)} /{" "}
                 {formatNumber(account.usage.credit_paid)}
               </p>
-              <p className="text-muted-foreground text-sm">
+              <p className={settingsBodyTextClass}>
                 Tokens: in {formatNumber(account.usage.input_tokens)} | out{" "}
                 {formatNumber(account.usage.output_tokens)}
               </p>
-              <p className="text-muted-foreground text-sm">
+              <p className={settingsBodyTextClass}>
                 Created at: {formatTs(account.account.created_at)}
               </p>
-              <p className="text-muted-foreground text-sm">
+              <p className={settingsBodyTextClass}>
                 Last seen: {formatTs(account.account.last_seen_at)}
               </p>
             </>

--- a/apps/portal/src/components/settings/secrets.tsx
+++ b/apps/portal/src/components/settings/secrets.tsx
@@ -3,6 +3,21 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useControl, type AomiAppDescriptor } from "@aomi-labs/react";
 import { Button, Input } from "@aomi-labs/widget-lib";
+import {
+  settingsActionRowClass,
+  settingsBodyTextClass,
+  settingsCardStackClass,
+  settingsCardTitleClass,
+  settingsDescriptionClass,
+  settingsInputClass,
+  settingsPageClass,
+  settingsPillClass,
+  settingsPrimaryButtonClass,
+  settingsStatusClass,
+  settingsSubTitleClass,
+  settingsTableCardClass,
+  settingsTitleClass,
+} from "./settings-styles";
 
 type StoredEntry = {
   valuePrefix: string;
@@ -56,10 +71,7 @@ export function Secrets() {
     useControl();
 
   const appsWithSecrets = useMemo<AomiAppDescriptor[]>(
-    () =>
-      state.appDescriptors.filter(
-        (d) => (d.secrets ?? []).length > 0,
-      ),
+    () => state.appDescriptors.filter((d) => (d.secrets ?? []).length > 0),
     [state.appDescriptors],
   );
 
@@ -123,7 +135,10 @@ export function Secrets() {
     () => appsWithSecrets.find((d) => d.name === selectedApp),
     [appsWithSecrets, selectedApp],
   );
-  const activeSlots = activeDescriptor?.secrets ?? [];
+  const activeSlots = useMemo(
+    () => activeDescriptor?.secrets ?? [],
+    [activeDescriptor],
+  );
 
   const requiredMissing = useMemo(
     () =>
@@ -136,7 +151,10 @@ export function Secrets() {
     (s) => (slotValues[s.name] ?? "").trim().length > 0,
   );
   const canSave =
-    !saving && Boolean(state.clientId) && hasAnyValue && requiredMissing.length === 0;
+    !saving &&
+    Boolean(state.clientId) &&
+    hasAnyValue &&
+    requiredMissing.length === 0;
 
   const handleSave = useCallback(async () => {
     if (!canSave || !selectedApp) return;
@@ -156,7 +174,10 @@ export function Secrets() {
         const appPrev = prev[selectedApp] ?? {};
         const appNext = { ...appPrev };
         for (const [name, value] of Object.entries(payload)) {
-          appNext[name] = { valuePrefix: buildValuePrefix(value), addedAt: now };
+          appNext[name] = {
+            valuePrefix: buildValuePrefix(value),
+            addedAt: now,
+          };
         }
         const next = { ...prev, [selectedApp]: appNext };
         writeIndex(next);
@@ -172,8 +193,7 @@ export function Secrets() {
     } catch (error) {
       setStatus({
         type: "error",
-        text:
-          error instanceof Error ? error.message : "Failed to save secrets",
+        text: error instanceof Error ? error.message : "Failed to save secrets",
       });
     } finally {
       setSaving(false);
@@ -256,17 +276,17 @@ export function Secrets() {
   );
 
   return (
-    <div className="space-y-8">
-      <div>
-        <h3 className="text-foreground mb-4 text-lg font-semibold">Secrets</h3>
-        <p className="text-muted-foreground text-sm">
+    <div className={settingsPageClass}>
+      <div className="space-y-4">
+        <h1 className={settingsTitleClass}>Secrets</h1>
+        <p className={settingsDescriptionClass}>
           API credentials for external services Aomi tools call on your behalf
           (e.g. <code>LIMITLESS_API_KEY</code>, <code>OKX_API_KEY</code>).
-          Stored in the backend vault scoped to this browser and the chosen
-          app; tools receive them as opaque <code>$SECRET:NAME</code> handles.
+          Stored in the backend vault scoped to this browser and the chosen app;
+          tools receive them as opaque <code>$SECRET:NAME</code> handles.
         </p>
         {!state.clientId && (
-          <p className="text-muted-foreground mt-2 text-sm">
+          <p className={settingsBodyTextClass}>
             Waiting for client id to initialize…
           </p>
         )}
@@ -274,25 +294,25 @@ export function Secrets() {
 
       {status && (
         <div
-          className={`rounded-2xl p-3 text-sm ${
+          className={`${settingsStatusClass} ${
             status.type === "success"
-              ? "border border-green-500/20 bg-green-500/10 text-green-700 dark:text-green-400"
-              : "bg-destructive/10 border-destructive/20 text-destructive border"
+              ? "border-green-500/20 bg-green-500/10 text-green-700 dark:text-green-400"
+              : "border-destructive/20 bg-destructive/10 text-destructive"
           }`}
         >
           {status.text}
         </div>
       )}
 
-      <div className="border-input bg-background space-y-5 rounded-3xl border p-6">
-        <div className="space-y-3">
-          <p className="pl-2 pb-2 text-foreground text-lg font-medium">App</p>
+      <div className={`${settingsCardStackClass} space-y-6`}>
+        <div className="space-y-4">
+          <p className={settingsCardTitleClass}>App</p>
           {appsWithSecrets.length === 0 ? (
-            <p className="text-muted-foreground text-sm">
+            <p className={settingsBodyTextClass}>
               No apps declare secret slots in this session.
             </p>
           ) : (
-            <div className="flex flex-wrap gap-2">
+            <div className="flex min-w-0 flex-wrap gap-2">
               {appsWithSecrets.map((descriptor) => {
                 const active = selectedApp === descriptor.name;
                 return (
@@ -300,10 +320,10 @@ export function Secrets() {
                     key={descriptor.name}
                     type="button"
                     onClick={() => setSelectedApp(descriptor.name)}
-                    className={`rounded-full border px-3 py-1.5 text-sm transition-colors ${
+                    className={`${settingsPillClass} ${
                       active
-                        ? "bg-primary text-primary-foreground border-primary"
-                        : "bg-background text-foreground border-input hover:bg-accent"
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-input bg-background text-foreground hover:bg-accent"
                     }`}
                   >
                     {descriptor.name}
@@ -316,21 +336,23 @@ export function Secrets() {
 
         {activeDescriptor && (
           <>
-            <h4 className="pl-2 text-foreground text-base font-semibold">
+            <h2 className={settingsCardTitleClass}>
               Add Secret for {activeDescriptor.name}
-            </h4>
-            <div className="space-y-4">
+            </h2>
+            <div className="min-w-0 space-y-5">
               {activeSlots.map((slot) => (
                 <div key={slot.name} className="space-y-4">
                   <label
                     htmlFor={`slot-${activeDescriptor.name}-${slot.name}`}
-                    className="pl-2 text-foreground flex items-center gap-2 text-sm font-medium"
+                    className="text-foreground flex items-baseline gap-2 pl-2 text-sm font-medium"
                   >
-                    <span className="font-mono">{slot.name}</span>
+                    <span className="font-mono tracking-[0.02em]">
+                      {slot.name}
+                    </span>
                     {slot.required ? (
-                      <span className="text-destructive text-xs">required</span>
+                      <span className="text-destructive text-sm">required</span>
                     ) : (
-                      <span className="text-muted-foreground text-xs">
+                      <span className="text-muted-foreground text-sm">
                         optional
                       </span>
                     )}
@@ -351,21 +373,19 @@ export function Secrets() {
                         : "Paste the value from the provider's dashboard"
                     }
                     autoComplete="off"
-                    className="h-10 rounded-3xl border-2 bg-muted px-5 text-sm"
+                    className={settingsInputClass}
                   />
-                  <p className="pl-2 text-muted-foreground text-sm">
-                    {slot.description}
-                  </p>
+                  <p className={settingsBodyTextClass}>{slot.description}</p>
                 </div>
               ))}
-              <div className="flex justify-end">
+              <div className={settingsActionRowClass}>
                 <Button
                   type="button"
                   onClick={() => {
                     void handleSave();
                   }}
                   disabled={!canSave}
-                  className="rounded-full px-6 mb-2"
+                  className={`${settingsPrimaryButtonClass} mb-2`}
                 >
                   {saving ? "Saving..." : "Save secret"}
                 </Button>
@@ -376,15 +396,30 @@ export function Secrets() {
       </div>
 
       <div className="space-y-4">
-        <h2 className="text-foreground text-lg font-medium">Saved</h2>
+        <h2 className={settingsSubTitleClass}>Saved Secrets</h2>
         {savedApps.length === 0 ? (
-          <p className="text-muted-foreground text-sm">No secrets saved.</p>
+          <div className={settingsTableCardClass}>
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-muted-foreground text-center">
+                  <th className="px-3 py-2">Name</th>
+                  <th className="px-3 py-2">Preview</th>
+                  <th className="px-3 py-2">Added</th>
+                  <th className="px-3 py-2">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td className="text-muted-foreground px-3 py-4 text-center" colSpan={4}>
+                    No secrets saved.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         ) : (
           savedApps.map(([app, slots]) => (
-            <div
-              key={app}
-              className="border-input bg-background overflow-x-auto rounded-3xl border p-2"
-            >
+            <div key={app} className={settingsTableCardClass}>
               <div className="flex items-center justify-between px-3 py-2">
                 <span className="text-foreground font-medium">{app}</span>
                 <Button

--- a/apps/portal/src/components/settings/settings-layout.tsx
+++ b/apps/portal/src/components/settings/settings-layout.tsx
@@ -9,7 +9,8 @@ import { Secrets } from "./secrets";
 import { Byok } from "./byok";
 
 export function SettingsLayout() {
-  const [activeCategory, setActiveCategory] = useState<SettingsCategory>("general");
+  const [activeCategory, setActiveCategory] =
+    useState<SettingsCategory>("general");
 
   const renderContent = () => {
     switch (activeCategory) {
@@ -29,10 +30,15 @@ export function SettingsLayout() {
   };
 
   return (
-    <div className="h-screen w-full flex bg-background">
-      <SettingsSidebar activeCategory={activeCategory} onCategoryChange={setActiveCategory} />
-      <div className="flex-1 overflow-y-auto p-8">
-        <div className="max-w-3xl mx-auto">{renderContent()}</div>
+    <div className="bg-background flex h-screen w-full min-w-0">
+      <SettingsSidebar
+        activeCategory={activeCategory}
+        onCategoryChange={setActiveCategory}
+      />
+      <div className="min-w-0 flex-1 overflow-y-auto overflow-x-hidden px-8 py-10 lg:px-12">
+        <div className="mx-auto w-full min-w-0 max-w-4xl">
+          {renderContent()}
+        </div>
       </div>
     </div>
   );

--- a/apps/portal/src/components/settings/settings-sidebar.tsx
+++ b/apps/portal/src/components/settings/settings-sidebar.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { Settings, Layers, ArrowLeft, KeyRound, Lock, Unplug } from "lucide-react";
+import {
+  Settings,
+  Layers,
+  ArrowLeft,
+  KeyRound,
+  Lock,
+  Unplug,
+} from "lucide-react";
 import Link from "next/link";
 
 export type SettingsCategory =
@@ -21,10 +28,10 @@ const categories: Array<{
   icon: React.ComponentType<{ className?: string }>;
 }> = [
   { id: "general", label: "General", icon: Settings },
-  { id: "apps", label: "Apps", icon: Layers },
+  { id: "apps", label: "Usage", icon: Layers },
   { id: "app-keys", label: "App Keys", icon: KeyRound },
   { id: "secrets", label: "Secrets", icon: Lock },
-  { id: "byok", label: "LLM Keys", icon: Unplug },
+  { id: "byok", label: "BYOK", icon: Unplug },
 ];
 
 const AomiLogo = ({ className }: { className?: string }) => (
@@ -47,9 +54,12 @@ const AomiLogo = ({ className }: { className?: string }) => (
   </svg>
 );
 
-export function SettingsSidebar({ activeCategory, onCategoryChange }: SettingsSidebarProps) {
+export function SettingsSidebar({
+  activeCategory,
+  onCategoryChange,
+}: SettingsSidebarProps) {
   return (
-    <div className="w-64 bg-sidebar h-full overflow-y-auto flex flex-col">
+    <div className="bg-sidebar flex h-full w-64 flex-col overflow-y-auto">
       {/* Header with logo */}
       <div className="p-5">
         <Link
@@ -58,23 +68,23 @@ export function SettingsSidebar({ activeCategory, onCategoryChange }: SettingsSi
           rel="noopener noreferrer"
           className="flex items-center"
         >
-          <AomiLogo className="size-6 text-sidebar-foreground" />
+          <AomiLogo className="text-sidebar-foreground size-6" />
         </Link>
       </div>
 
       {/* Back to chat */}
-      <div className="px-3 mb-2">
+      <div className="mb-2 px-3">
         <Link
           href="/"
-          className="flex items-center gap-2 px-3 py-2 text-sm text-sidebar-foreground/70 hover:text-sidebar-foreground transition-colors"
+          className="text-sidebar-foreground/70 hover:text-sidebar-foreground flex items-center gap-2 px-3 py-2 text-sm transition-colors"
         >
-          <ArrowLeft className="w-4 h-4" />
+          <ArrowLeft className="h-4 w-4" />
           <span>Back to chat</span>
         </Link>
       </div>
 
       {/* Nav items */}
-      <nav className="px-3 space-y-1">
+      <nav className="space-y-1 px-3">
         {categories.map((category) => {
           const Icon = category.icon;
           const isActive = activeCategory === category.id;
@@ -82,13 +92,13 @@ export function SettingsSidebar({ activeCategory, onCategoryChange }: SettingsSi
             <button
               key={category.id}
               onClick={() => onCategoryChange(category.id)}
-              className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-colors ${
+              className={`flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors ${
                 isActive
                   ? "bg-sidebar-accent text-sidebar-accent-foreground"
                   : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
               }`}
             >
-              <Icon className="w-4 h-4" />
+              <Icon className="h-4 w-4" />
               <span>{category.label}</span>
             </button>
           );

--- a/apps/portal/src/components/settings/settings-styles.ts
+++ b/apps/portal/src/components/settings/settings-styles.ts
@@ -1,0 +1,41 @@
+export const settingsPageClass = "min-w-0 space-y-8";
+
+export const settingsHeaderClass = "space-y-4";
+
+export const settingsTitleClass =
+  "text-foreground text-2xl font-semibold tracking-tight pl-4";
+
+export const settingsDescriptionClass =
+  "text-foreground max-w-4xl break-words text-sm leading-5 pl-4";
+
+export const settingsCardClass =
+  "border-input bg-background min-w-0 rounded-3xl border p-6";
+
+export const settingsCardStackClass = `${settingsCardClass} space-y-4`;
+
+export const settingsCardTitleClass =
+  "text-foreground text-lg font-medium pl-2";
+
+export const settingsSubTitleClass = "text-foreground text-lg font-medium pl-4";
+
+export const settingsLabelClass =
+  "text-foreground block text-sm font-medium pl-2";
+
+export const settingsBodyTextClass = "text-foreground text-sm leading-5 pl-2";
+
+export const settingsInputClass =
+  "border-input bg-muted/30 placeholder:text-muted-foreground/80 h-10 rounded-2xl border-2 px-4 text-sm shadow-none";
+
+export const settingsPillClass =
+  "rounded-full border px-4 py-2 text-sm leading-none transition-colors";
+
+export const settingsActionRowClass =
+  "flex min-w-0 justify-start pt-2 md:justify-end";
+
+export const settingsPrimaryButtonClass =
+  "h-10 max-w-full whitespace-normal rounded-full px-4 text-center text-sm font-medium";
+
+export const settingsStatusClass = "rounded-3xl border p-4 text-sm";
+
+export const settingsTableCardClass =
+  "border-input bg-background min-w-0 overflow-x-auto rounded-3xl border p-3";


### PR DESCRIPTION
## Summary
- normalize typography, spacing, and card/input styles across the settings tabs
- rename the Apps page to Usage and align empty-state/table treatments across settings sections
- refine button placement and empty-table shells for Secrets, App Keys, and BYOK

## Validation
- pnpm --filter portal lint