### PR TITLE
Fix Telegram mini app wallet connect flow

### DIFF
--- a/apps/telegram/src/components/connect-wallet.tsx
+++ b/apps/telegram/src/components/connect-wallet.tsx
@@ -100,6 +100,7 @@ function ConnectContent({
   const chainId = useChainId();
   const { data: ensName } = useEnsName({ address: address as `0x${string}` | undefined });
   const prevConnected = useRef(false);
+  const closeTimer = useRef<number | null>(null);
   const [shouldOpen, setShouldOpen] = useState(false);
 
   useEffect(() => {
@@ -166,9 +167,13 @@ function ConnectContent({
     // Persist + sendData on every fresh connect (rising edge)
     if (!isConnected || !address) {
       prevConnected.current = false;
+      if (closeTimer.current) {
+        window.clearTimeout(closeTimer.current);
+        closeTimer.current = null;
+      }
       return;
     }
-    if (prevConnected.current) return;
+    if (prevConnected.current || closeTimer.current) return;
     prevConnected.current = true;
 
     const source = connector?.name?.toLowerCase().replace(/\s+/g, '') || 'nonTG';
@@ -184,22 +189,21 @@ function ConnectContent({
       body: JSON.stringify({ user_id: userId, address, chainId, source: 'mini_app' }),
     }).then(r => console.log('[connect] POST response: %s', r.status)).catch(e => console.warn('[connect] POST failed:', e));
 
-    // Delay so wallet state finishes writing all IDB entries before we snapshot
-    const timer = setTimeout(() => {
-      const save = tgUserId ? persist(tgUserId) : Promise.resolve();
-      save.finally(() => {
-        if (window.Telegram?.WebApp?.sendData) {
-          console.log('[connect] calling sendData');
-          window.Telegram.WebApp.sendData(
-            JSON.stringify({ address, chainId, ensName: ensName ?? null }),
-          );
-          window.Telegram.WebApp.close();
-        } else {
-          console.log('[dev] connected:', address, chainId, ensName);
-        }
-      });
+    // Delay so wallet state finishes writing all IDB entries before we snapshot.
+    // Do not block Telegram close on this best-effort persistence step.
+    closeTimer.current = window.setTimeout(() => {
+      closeTimer.current = null;
+      if (tgUserId) void persist(tgUserId);
+      if (window.Telegram?.WebApp?.sendData) {
+        console.log('[connect] calling sendData');
+        window.Telegram.WebApp.sendData(
+          JSON.stringify({ address, chainId, ensName: ensName ?? null }),
+        );
+        window.Telegram.WebApp.close();
+      } else {
+        console.log('[dev] connected:', address, chainId, ensName);
+      }
     }, WALLET_PERSIST_DELAY_MS);
-    return () => clearTimeout(timer);
   }, [isConnected, address, chainId, connector?.name, ensName, tgUserId]);
 
   // The wallet modal covers the screen — just show a dark background

--- a/apps/telegram/src/components/connect-wallet.tsx
+++ b/apps/telegram/src/components/connect-wallet.tsx
@@ -4,7 +4,14 @@ import { useEffect, useRef, useState } from 'react';
 import { useModal } from '@getpara/react-sdk';
 import { useAccount, useChainId, useDisconnect, useEnsName } from 'wagmi';
 import { Providers, initAppKit } from './providers';
-import { restore, persist, clear, clearLsWhitelisted, clearIdb } from '@/lib/session-bridge';
+import {
+  restore,
+  persist,
+  clear,
+  clearLsWhitelisted,
+  clearSessionWhitelisted,
+  clearIdb,
+} from '@/lib/session-bridge';
 import { getTelegramUserId, readyTelegramWebApp } from '@/lib/telegram-webapp';
 import {
   CONNECT_CONTEXT_KEY,
@@ -136,7 +143,7 @@ function ConnectContent({
       // Open the WalletConnect modal immediately — it IS the UI
       setShouldOpen(true);
     }
-  }, [openModal, tgUserId, restoredSession, hasResultUri, isConnected]);
+  }, [openModal, tgUserId, restoredSession, hasResultUri, isConnected, disconnectAsync]);
 
   useEffect(() => {
     if (shouldOpen && !isConnected) {
@@ -186,13 +193,14 @@ function ConnectContent({
           window.Telegram.WebApp.sendData(
             JSON.stringify({ address, chainId, ensName: ensName ?? null }),
           );
+          window.Telegram.WebApp.close();
         } else {
           console.log('[dev] connected:', address, chainId, ensName);
         }
       });
     }, WALLET_PERSIST_DELAY_MS);
     return () => clearTimeout(timer);
-  }, [isConnected, address]);
+  }, [isConnected, address, chainId, connector?.name, ensName, tgUserId]);
 
   // The wallet modal covers the screen — just show a dark background
   return <main className="min-h-screen bg-black" />;
@@ -241,8 +249,13 @@ export default function ConnectWallet() {
 
         if (!alreadyApplied) {
           console.log('[connect] clearing session (force_new first apply)');
-          if (userId) await clear(userId);
-          else { clearLsWhitelisted(); await clearIdb(); }
+          if (userId) {
+            await clear(userId);
+          } else {
+            clearLsWhitelisted();
+            clearSessionWhitelisted();
+            await clearIdb();
+          }
           markForceNewApplied(markerKey);
           return false;
         }

--- a/apps/telegram/src/components/providers.tsx
+++ b/apps/telegram/src/components/providers.tsx
@@ -70,7 +70,7 @@ export function Providers({ children }: { children: ReactNode }) {
           appName: 'Aomi',
         }}
         paraModalConfig={{
-          oAuthMethods: [],
+          oAuthMethods: ['GOOGLE'],
           disableEmailLogin: false,
           disablePhoneLogin: false,
           theme: {

--- a/apps/telegram/src/lib/constants.ts
+++ b/apps/telegram/src/lib/constants.ts
@@ -4,8 +4,14 @@
 
 // ── WalletConnect Storage ──
 
-/** LocalStorage key prefixes for wallet session data (includes legacy AppKit keys). */
-export const LS_KEY_PREFIXES = ['@appkit/', 'wagmi.', 'WALLETCONNECT_DEEPLINK'] as const;
+/** Browser storage key prefixes for wallet session data. */
+export const WALLET_STORAGE_KEY_PREFIXES = [
+  '@appkit/',
+  '@CAPSULE/',
+  '@PARA/',
+  'wagmi.',
+  'WALLETCONNECT_DEEPLINK',
+] as const;
 
 /** IndexedDB database name for WalletConnect v2. */
 export const WC_IDB_NAME = 'WALLET_CONNECT_V2_INDEXED_DB';

--- a/apps/telegram/src/lib/para-client.ts
+++ b/apps/telegram/src/lib/para-client.ts
@@ -1,6 +1,57 @@
 import Para from '@getpara/web-sdk';
 
 let paraClient: Para | null | undefined;
+let telegramOAuthPopupInstalled = false;
+
+type ParaWithPopup = Para & {
+  platformUtils?: {
+    openPopup?: (url: string, options?: { type?: { toString: () => string } }) => Promise<Window>;
+  };
+};
+
+function installTelegramOAuthPopup(para: Para) {
+  if (telegramOAuthPopupInstalled || typeof window === 'undefined') return;
+
+  const openLink = window.Telegram?.WebApp?.openLink;
+  const platformUtils = (para as ParaWithPopup).platformUtils;
+  const originalOpenPopup = platformUtils?.openPopup?.bind(platformUtils);
+  if (!openLink || !platformUtils || !originalOpenPopup) return;
+
+  platformUtils.openPopup = async (url, options) => {
+    const isOAuthPopup = options?.type?.toString() === 'OAUTH' && url === 'about:blank';
+    if (!isOAuthPopup) {
+      return originalOpenPopup(url, options);
+    }
+
+    let href = url;
+    let closed = false;
+    const popup = {
+      get closed() {
+        return closed;
+      },
+      close() {
+        closed = true;
+      },
+      focus() {},
+      location: {
+        get href() {
+          return href;
+        },
+        set href(nextUrl: string) {
+          href = nextUrl;
+          openLink(nextUrl);
+        },
+      },
+    };
+
+    // Para polls OAuth completion while holding the popup reference. Telegram
+    // opens OAuth URLs through its own API, so this lightweight window shape
+    // keeps Para from canceling the flow as soon as the external browser opens.
+    return popup as Window;
+  };
+
+  telegramOAuthPopupInstalled = true;
+}
 
 export function isParaEnabled(): boolean {
   return Boolean(process.env.NEXT_PUBLIC_PARA_API_KEY?.trim());
@@ -13,6 +64,8 @@ export function getParaClient(): Para | null {
   if (paraClient === undefined) {
     paraClient = new Para(apiKey);
   }
+
+  if (paraClient) installTelegramOAuthPopup(paraClient);
 
   return paraClient;
 }

--- a/apps/telegram/src/lib/session-bridge.ts
+++ b/apps/telegram/src/lib/session-bridge.ts
@@ -1,4 +1,4 @@
-import { LS_KEY_PREFIXES, WC_IDB_NAME, WC_IDB_STORE } from './constants';
+import { WALLET_STORAGE_KEY_PREFIXES, WC_IDB_NAME, WC_IDB_STORE } from './constants';
 
 // ---------------------------------------------------------------------------
 // IDB helpers
@@ -102,7 +102,7 @@ function readLsWhitelisted(): Record<string, string> {
   for (let i = 0; i < localStorage.length; i++) {
     const key = localStorage.key(i);
     if (!key) continue;
-    if (LS_KEY_PREFIXES.some((p) => key.startsWith(p))) {
+    if (WALLET_STORAGE_KEY_PREFIXES.some((p) => key.startsWith(p))) {
       result[key] = localStorage.getItem(key)!;
     }
   }
@@ -119,12 +119,25 @@ export function clearLsWhitelisted() {
   const toRemove: string[] = [];
   for (let i = 0; i < localStorage.length; i++) {
     const key = localStorage.key(i);
-    if (key && LS_KEY_PREFIXES.some((p) => key.startsWith(p))) {
+    if (key && WALLET_STORAGE_KEY_PREFIXES.some((p) => key.startsWith(p))) {
       toRemove.push(key);
     }
   }
   for (const key of toRemove) {
     localStorage.removeItem(key);
+  }
+}
+
+export function clearSessionWhitelisted() {
+  const toRemove: string[] = [];
+  for (let i = 0; i < sessionStorage.length; i++) {
+    const key = sessionStorage.key(i);
+    if (key && WALLET_STORAGE_KEY_PREFIXES.some((p) => key.startsWith(p))) {
+      toRemove.push(key);
+    }
+  }
+  for (const key of toRemove) {
+    sessionStorage.removeItem(key);
   }
 }
 
@@ -188,5 +201,6 @@ export async function clear(userId: string): Promise<void> {
   }
   // Also wipe browser state on explicit disconnect
   clearLsWhitelisted();
+  clearSessionWhitelisted();
   await clearIdb();
 }

--- a/apps/telegram/src/types/telegram.d.ts
+++ b/apps/telegram/src/types/telegram.d.ts
@@ -15,6 +15,7 @@ declare global {
         ready: () => void;
         close: () => void;
         expand: () => void;
+        openLink?: (url: string, options?: { try_instant_view?: boolean }) => void;
         sendData: (data: string) => void;
         MainButton: {
           text: string;


### PR DESCRIPTION
## Summary
- Fixes the Telegram mini app wallet OAuth/connect flow.
- Closes the Telegram mini app after wallet connect so control returns cleanly to the bot flow.

## Validation
- Local Telegram mini app wallet connect testing with external wallet and Google/Para flow.
- Confirmed disconnect and connect callbacks returned to the bot flow during manual testing.
