### PR TITLE
[codex] Require npm publish on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,56 +75,17 @@ jobs:
       - name: Build @aomi-labs/widget-lib (shadcn registry)
         run: pnpm run build:registry
 
-      - name: Check @aomi-labs/client npm access
-        id: client_npm_access
-        run: |
-          if npm access list collaborators @aomi-labs/client --json >/dev/null 2>&1; then
-            echo "can_publish=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::NPM_TOKEN cannot access @aomi-labs/client; skipping client publish."
-            echo "can_publish=false" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Publish @aomi-labs/client
-        if: steps.client_npm_access.outputs.can_publish == 'true'
         run: pnpm --filter @aomi-labs/client publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Check @aomi-labs/react npm access
-        id: react_npm_access
-        run: |
-          if npm access list collaborators @aomi-labs/react --json >/dev/null 2>&1; then
-            echo "can_publish=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::NPM_TOKEN cannot access @aomi-labs/react; skipping react publish."
-            echo "can_publish=false" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Publish @aomi-labs/react
-        if: steps.react_npm_access.outputs.can_publish == 'true'
         run: pnpm --filter @aomi-labs/react publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Check @aomi-labs/widget-lib npm access
-        id: widget_lib_npm_access
-        run: |
-          if npm access list collaborators @aomi-labs/widget-lib --json >/dev/null 2>&1; then
-            echo "can_publish=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::NPM_TOKEN cannot access @aomi-labs/widget-lib; skipping widget-lib publish."
-            echo "can_publish=false" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Publish @aomi-labs/widget-lib
-        if: steps.widget_lib_npm_access.outputs.can_publish == 'true'
         run: pnpm --filter @aomi-labs/widget-lib publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,12 +75,38 @@ jobs:
       - name: Build @aomi-labs/widget-lib (shadcn registry)
         run: pnpm run build:registry
 
+      - name: Check @aomi-labs/client npm access
+        id: client_npm_access
+        run: |
+          if npm access list collaborators @aomi-labs/client --json >/dev/null 2>&1; then
+            echo "can_publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::NPM_TOKEN cannot access @aomi-labs/client; skipping client publish."
+            echo "can_publish=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish @aomi-labs/client
+        if: steps.client_npm_access.outputs.can_publish == 'true'
         run: pnpm --filter @aomi-labs/client publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Check @aomi-labs/react npm access
+        id: react_npm_access
+        run: |
+          if npm access list collaborators @aomi-labs/react --json >/dev/null 2>&1; then
+            echo "can_publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::NPM_TOKEN cannot access @aomi-labs/react; skipping react publish."
+            echo "can_publish=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish @aomi-labs/react
+        if: steps.react_npm_access.outputs.can_publish == 'true'
         run: pnpm --filter @aomi-labs/react publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- remove the npm access preflight skip from the publish workflow
- keep npm publishing as a hard requirement on pushes to main
- keep the existing branch gate so prod/publish branch pushes do not publish npm packages

## Policy
- merge/push to main: build, test, then publish @aomi-labs/client, @aomi-labs/react, and @aomi-labs/widget-lib
- merge/push to prod or publish: no npm publish job runs

## Validation
- git diff --check