### PR TITLE
Add bare embed-playground route for clean iframe embed

### DIFF
--- a/apps/landing/app/embed-playground/page.tsx
+++ b/apps/landing/app/embed-playground/page.tsx
@@ -1,0 +1,15 @@
+import { PlaygroundConfigurator } from "@/content/components/playground/PlaygroundConfigurator";
+
+export const metadata = {
+  title: "Playground — Aomi",
+  description: "Interactively configure the AomiFrame widget and copy the generated code.",
+  robots: { index: false },
+};
+
+export default function EmbedPlaygroundPage() {
+  return (
+    <div style={{ width: "100vw", height: "100vh", overflow: "auto", background: "#0f0f0f" }}>
+      <PlaygroundConfigurator />
+    </div>
+  );
+}


### PR DESCRIPTION
New route at `/embed-playground` that renders the PlaygroundConfigurator widget with zero chrome (no Fumadocs layout, no nav bar). Used by the Mintlify docs site for a clean iframe embed.