### PR TITLE
chore: trigger vercel deploy for embed-playground route

### DIFF
--- a/apps/landing/app/embed-playground/page.tsx
+++ b/apps/landing/app/embed-playground/page.tsx
@@ -1,3 +1,5 @@
+// For Mintlify iframe embed — zero chrome, bare PlaygroundConfigurator
+
 import { PlaygroundConfigurator } from "@/content/components/playground/PlaygroundConfigurator";
 
 export const metadata = {


### PR DESCRIPTION
Trivial commit (added comment to embed-playground/page.tsx) to trigger Vercel auto-deploy on main.\n\nOnce merged, /embed-playground will be live on aomi.dev and the Mintlify docs iframe will work.