### PR TITLE
Fix playground embed: relative sizing, iframe detection, collapsible code panel

### DIFF
--- a/apps/landing/app/embed-playground/page.tsx
+++ b/apps/landing/app/embed-playground/page.tsx
@@ -9,6 +9,28 @@ export const metadata = {
   robots: { index: false },
 };
 
+const DARK_THEME_VARS = {
+  "--background": "oklch(0.141 0.005 285.823)",
+  "--foreground": "oklch(0.985 0 0)",
+  "--card": "oklch(0.21 0.006 285.885)",
+  "--card-foreground": "oklch(0.985 0 0)",
+  "--popover": "oklch(0.21 0.006 285.885)",
+  "--popover-foreground": "oklch(0.985 0 0)",
+  "--primary": "oklch(0.92 0.004 286.32)",
+  "--primary-foreground": "oklch(0.21 0.006 285.885)",
+  "--secondary": "oklch(0.274 0.006 286.033)",
+  "--secondary-foreground": "oklch(0.985 0 0)",
+  "--muted": "oklch(0.274 0.006 286.033)",
+  "--muted-foreground": "oklch(0.705 0.015 286.067)",
+  "--accent": "oklch(0.274 0.006 286.033)",
+  "--accent-foreground": "oklch(0.985 0 0)",
+  "--destructive": "oklch(0.704 0.191 22.216)",
+  "--border": "oklch(1 0 0 / 10%)",
+  "--input": "oklch(0.6 0 0 / 15%)",
+  "--ring": "oklch(0.552 0.016 285.938)",
+  "--radius": "0.625rem",
+} as const;
+
 export default async function EmbedPlaygroundPage(props: {
   searchParams: Promise<{ embed?: string }>;
 }) {
@@ -17,11 +39,13 @@ export default async function EmbedPlaygroundPage(props: {
 
   return (
     <div
-      style={
-        isEmbed
+      className="dark"
+      style={{
+        ...DARK_THEME_VARS,
+        ...(isEmbed
           ? { width: "100%", minHeight: "80vh", background: "#0f0f0f" }
-          : { width: "100vw", height: "100vh", overflow: "auto", background: "#0f0f0f" }
-      }
+          : { width: "100vw", height: "100vh", overflow: "auto", background: "#0f0f0f" }),
+      }}
     >
       <PlaygroundConfigurator forceEmbed={isEmbed} />
     </div>

--- a/apps/landing/app/embed-playground/page.tsx
+++ b/apps/landing/app/embed-playground/page.tsx
@@ -1,4 +1,5 @@
 // For Mintlify iframe embed — zero chrome, bare PlaygroundConfigurator
+// Supports ?embed=true param for compact iframe layout
 
 import { PlaygroundConfigurator } from "@/content/components/playground/PlaygroundConfigurator";
 
@@ -8,10 +9,21 @@ export const metadata = {
   robots: { index: false },
 };
 
-export default function EmbedPlaygroundPage() {
+export default async function EmbedPlaygroundPage(props: {
+  searchParams: Promise<{ embed?: string }>;
+}) {
+  const { embed } = await props.searchParams;
+  const isEmbed = embed === "true";
+
   return (
-    <div style={{ width: "100vw", height: "100vh", overflow: "auto", background: "#0f0f0f" }}>
-      <PlaygroundConfigurator />
+    <div
+      style={
+        isEmbed
+          ? { width: "100%", minHeight: "80vh", background: "#0f0f0f" }
+          : { width: "100vw", height: "100vh", overflow: "auto", background: "#0f0f0f" }
+      }
+    >
+      <PlaygroundConfigurator forceEmbed={isEmbed} />
     </div>
   );
 }

--- a/apps/landing/app/embed-playground/page.tsx
+++ b/apps/landing/app/embed-playground/page.tsx
@@ -1,6 +1,6 @@
 // For Mintlify iframe embed — zero chrome, bare PlaygroundConfigurator
 // Supports ?embed=true param for compact iframe layout
-// Theme follows system preference via CSS media queries
+// Theme follows system prefers-color-scheme via CSS light-dark()
 
 import { PlaygroundConfigurator } from "@/content/components/playground/PlaygroundConfigurator";
 
@@ -28,49 +28,27 @@ export default async function EmbedPlaygroundPage(props: {
       <PlaygroundConfigurator forceEmbed={isEmbed} />
       <style>{`
         .embed-playground-root {
-          background: oklch(0.985 0 0);
-          --background: oklch(1 0 0);
-          --foreground: oklch(0.141 0.005 285.823);
-          --card: oklch(1 0 0);
-          --card-foreground: oklch(0.141 0.005 285.823);
-          --popover: oklch(1 0 0);
-          --popover-foreground: oklch(0.141 0.005 285.823);
-          --primary: oklch(0.21 0.006 285.885);
-          --primary-foreground: oklch(0.985 0 0);
-          --secondary: oklch(0.967 0.001 286.375);
-          --secondary-foreground: oklch(0.21 0.006 285.885);
-          --muted: oklch(0.967 0.001 286.375);
-          --muted-foreground: oklch(0.552 0.016 285.938);
-          --accent: oklch(0.967 0.001 286.375);
-          --accent-foreground: oklch(0.21 0.006 285.885);
-          --destructive: oklch(0.577 0.245 27.325);
-          --border: oklch(0.92 0.004 286.32);
-          --input: oklch(0.92 0.004 286.32);
-          --ring: oklch(0.705 0.015 286.067);
+          color-scheme: light dark;
+          background: light-dark(oklch(0.985 0 0), #0f0f0f);
+          --background: light-dark(oklch(1 0 0), oklch(0.141 0.005 285.823));
+          --foreground: light-dark(oklch(0.141 0.005 285.823), oklch(0.985 0 0));
+          --card: light-dark(oklch(1 0 0), oklch(0.21 0.006 285.885));
+          --card-foreground: light-dark(oklch(0.141 0.005 285.823), oklch(0.985 0 0));
+          --popover: light-dark(oklch(1 0 0), oklch(0.21 0.006 285.885));
+          --popover-foreground: light-dark(oklch(0.141 0.005 285.823), oklch(0.985 0 0));
+          --primary: light-dark(oklch(0.21 0.006 285.885), oklch(0.92 0.004 286.32));
+          --primary-foreground: light-dark(oklch(0.985 0 0), oklch(0.21 0.006 285.885));
+          --secondary: light-dark(oklch(0.967 0.001 286.375), oklch(0.274 0.006 286.033));
+          --secondary-foreground: light-dark(oklch(0.21 0.006 285.885), oklch(0.985 0 0));
+          --muted: light-dark(oklch(0.967 0.001 286.375), oklch(0.274 0.006 286.033));
+          --muted-foreground: light-dark(oklch(0.552 0.016 285.938), oklch(0.705 0.015 286.067));
+          --accent: light-dark(oklch(0.967 0.001 286.375), oklch(0.274 0.006 286.033));
+          --accent-foreground: light-dark(oklch(0.21 0.006 285.885), oklch(0.985 0 0));
+          --destructive: light-dark(oklch(0.577 0.245 27.325), oklch(0.704 0.191 22.216));
+          --border: light-dark(oklch(0.92 0.004 286.32), oklch(1 0 0 / 10%));
+          --input: light-dark(oklch(0.92 0.004 286.32), oklch(0.6 0 0 / 15%));
+          --ring: light-dark(oklch(0.705 0.015 286.067), oklch(0.552 0.016 285.938));
           --radius: 0.625rem;
-        }
-        @media (prefers-color-scheme: dark) {
-          .embed-playground-root {
-            background: #0f0f0f;
-            --background: oklch(0.141 0.005 285.823);
-            --foreground: oklch(0.985 0 0);
-            --card: oklch(0.21 0.006 285.885);
-            --card-foreground: oklch(0.985 0 0);
-            --popover: oklch(0.21 0.006 285.885);
-            --popover-foreground: oklch(0.985 0 0);
-            --primary: oklch(0.92 0.004 286.32);
-            --primary-foreground: oklch(0.21 0.006 285.885);
-            --secondary: oklch(0.274 0.006 286.033);
-            --secondary-foreground: oklch(0.985 0 0);
-            --muted: oklch(0.274 0.006 286.033);
-            --muted-foreground: oklch(0.705 0.015 286.067);
-            --accent: oklch(0.274 0.006 286.033);
-            --accent-foreground: oklch(0.985 0 0);
-            --destructive: oklch(0.704 0.191 22.216);
-            --border: oklch(1 0 0 / 10%);
-            --input: oklch(0.6 0 0 / 15%);
-            --ring: oklch(0.552 0.016 285.938);
-          }
         }
       `}</style>
     </div>

--- a/apps/landing/app/embed-playground/page.tsx
+++ b/apps/landing/app/embed-playground/page.tsx
@@ -1,5 +1,6 @@
 // For Mintlify iframe embed — zero chrome, bare PlaygroundConfigurator
 // Supports ?embed=true param for compact iframe layout
+// Theme follows system preference via CSS media queries
 
 import { PlaygroundConfigurator } from "@/content/components/playground/PlaygroundConfigurator";
 
@@ -9,28 +10,6 @@ export const metadata = {
   robots: { index: false },
 };
 
-const DARK_THEME_VARS = {
-  "--background": "oklch(0.141 0.005 285.823)",
-  "--foreground": "oklch(0.985 0 0)",
-  "--card": "oklch(0.21 0.006 285.885)",
-  "--card-foreground": "oklch(0.985 0 0)",
-  "--popover": "oklch(0.21 0.006 285.885)",
-  "--popover-foreground": "oklch(0.985 0 0)",
-  "--primary": "oklch(0.92 0.004 286.32)",
-  "--primary-foreground": "oklch(0.21 0.006 285.885)",
-  "--secondary": "oklch(0.274 0.006 286.033)",
-  "--secondary-foreground": "oklch(0.985 0 0)",
-  "--muted": "oklch(0.274 0.006 286.033)",
-  "--muted-foreground": "oklch(0.705 0.015 286.067)",
-  "--accent": "oklch(0.274 0.006 286.033)",
-  "--accent-foreground": "oklch(0.985 0 0)",
-  "--destructive": "oklch(0.704 0.191 22.216)",
-  "--border": "oklch(1 0 0 / 10%)",
-  "--input": "oklch(0.6 0 0 / 15%)",
-  "--ring": "oklch(0.552 0.016 285.938)",
-  "--radius": "0.625rem",
-} as const;
-
 export default async function EmbedPlaygroundPage(props: {
   searchParams: Promise<{ embed?: string }>;
 }) {
@@ -39,15 +18,61 @@ export default async function EmbedPlaygroundPage(props: {
 
   return (
     <div
-      className="dark"
-      style={{
-        ...DARK_THEME_VARS,
-        ...(isEmbed
-          ? { width: "100%", minHeight: "80vh", background: "#0f0f0f" }
-          : { width: "100vw", height: "100vh", overflow: "auto", background: "#0f0f0f" }),
-      }}
+      className="embed-playground-root"
+      style={
+        isEmbed
+          ? { width: "100%", minHeight: "80vh" }
+          : { width: "100vw", height: "100vh", overflow: "auto" }
+      }
     >
       <PlaygroundConfigurator forceEmbed={isEmbed} />
+      <style>{`
+        .embed-playground-root {
+          background: oklch(0.985 0 0);
+          --background: oklch(1 0 0);
+          --foreground: oklch(0.141 0.005 285.823);
+          --card: oklch(1 0 0);
+          --card-foreground: oklch(0.141 0.005 285.823);
+          --popover: oklch(1 0 0);
+          --popover-foreground: oklch(0.141 0.005 285.823);
+          --primary: oklch(0.21 0.006 285.885);
+          --primary-foreground: oklch(0.985 0 0);
+          --secondary: oklch(0.967 0.001 286.375);
+          --secondary-foreground: oklch(0.21 0.006 285.885);
+          --muted: oklch(0.967 0.001 286.375);
+          --muted-foreground: oklch(0.552 0.016 285.938);
+          --accent: oklch(0.967 0.001 286.375);
+          --accent-foreground: oklch(0.21 0.006 285.885);
+          --destructive: oklch(0.577 0.245 27.325);
+          --border: oklch(0.92 0.004 286.32);
+          --input: oklch(0.92 0.004 286.32);
+          --ring: oklch(0.705 0.015 286.067);
+          --radius: 0.625rem;
+        }
+        @media (prefers-color-scheme: dark) {
+          .embed-playground-root {
+            background: #0f0f0f;
+            --background: oklch(0.141 0.005 285.823);
+            --foreground: oklch(0.985 0 0);
+            --card: oklch(0.21 0.006 285.885);
+            --card-foreground: oklch(0.985 0 0);
+            --popover: oklch(0.21 0.006 285.885);
+            --popover-foreground: oklch(0.985 0 0);
+            --primary: oklch(0.92 0.004 286.32);
+            --primary-foreground: oklch(0.21 0.006 285.885);
+            --secondary: oklch(0.274 0.006 286.033);
+            --secondary-foreground: oklch(0.985 0 0);
+            --muted: oklch(0.274 0.006 286.033);
+            --muted-foreground: oklch(0.705 0.015 286.067);
+            --accent: oklch(0.274 0.006 286.033);
+            --accent-foreground: oklch(0.985 0 0);
+            --destructive: oklch(0.704 0.191 22.216);
+            --border: oklch(1 0 0 / 10%);
+            --input: oklch(0.6 0 0 / 15%);
+            --ring: oklch(0.552 0.016 285.938);
+          }
+        }
+      `}</style>
     </div>
   );
 }

--- a/apps/landing/content/components/playground/PlaygroundConfigurator.tsx
+++ b/apps/landing/content/components/playground/PlaygroundConfigurator.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState, useMemo, useCallback, type FC } from "react";
+import { useState, useMemo, useCallback, useEffect, type FC } from "react";
 import { AomiFrame } from "@aomi-labs/widget-lib";
 import { CopyButton } from "./CopyButton";
 import {
   ThemeCustomizer,
   useThemeCustomizer,
 } from "./ThemeCustomizer";
+import { ChevronDown, ChevronUp } from "lucide-react";
 
 // =============================================================================
 // Types
@@ -272,11 +273,26 @@ const LayoutPanel: FC<{
 // Main Playground
 // =============================================================================
 
-export function PlaygroundConfigurator() {
+export function PlaygroundConfigurator({ forceEmbed }: { forceEmbed?: boolean }) {
   const [state, setState] = useState<PlaygroundState>(DEFAULT_STATE);
   const [configTab, setConfigTab] = useState<ConfigTab>("layout");
   const [codeTab, setCodeTab] = useState<CodeTab>("jsx");
+  const [isEmbedded, setIsEmbedded] = useState(forceEmbed ?? false);
+  const [codeExpanded, setCodeExpanded] = useState(!(forceEmbed ?? false));
   const backendUrl = "/";
+
+  useEffect(() => {
+    if (forceEmbed) {
+      setIsEmbedded(true);
+      setCodeExpanded(false);
+      return;
+    }
+    const detected = typeof window !== "undefined" && window.top !== window.self;
+    if (detected) {
+      setIsEmbedded(true);
+      setCodeExpanded(false);
+    }
+  }, [forceEmbed]);
 
   const update = useCallback(
     (patch: Partial<PlaygroundState>) => {
@@ -315,10 +331,12 @@ export function PlaygroundConfigurator() {
 
   const activeCode = codeTab === "jsx" ? jsxCode : theme.output.css;
 
+  const embedHeight = isEmbedded ? 400 : 560;
+
   return (
-    <div className="space-y-4">
+    <div className={isEmbedded ? "space-y-2" : "space-y-4"}>
       {/* Main split panel */}
-      <div className="flex flex-col gap-4 lg:flex-row">
+      <div className={`flex flex-col ${isEmbedded ? "gap-2" : "gap-4"} lg:flex-row`}>
         {/* Left: Live preview */}
         <div className="min-w-0 flex-1">
           <div
@@ -328,7 +346,7 @@ export function PlaygroundConfigurator() {
             style={theme.output.styleObject}
           >
             <AomiFrame.Root
-              height="560px"
+              height={`${embedHeight}px`}
               walletPosition={walletPropValue ?? null}
               showSidebar={state.sidebarShown}
               backendUrl={backendUrl}
@@ -355,7 +373,7 @@ export function PlaygroundConfigurator() {
         </div>
 
         {/* Right: Config sidebar with tabs */}
-        <div className="w-full shrink-0 lg:w-72" style={{ height: 560 }}>
+        <div className="w-full shrink-0 lg:w-72" style={{ height: embedHeight }}>
           <div className="flex h-full flex-col rounded-xl border border-fd-border bg-fd-card">
             {/* Tab header */}
             <div className="border-b border-fd-border px-4 py-3">
@@ -387,7 +405,7 @@ export function PlaygroundConfigurator() {
         </div>
       </div>
 
-      {/* Generated code panel with tabs */}
+      {/* Generated code panel with tabs (collapsible when embedded) */}
       <div className="rounded-xl border border-fd-border">
         <div className="flex items-center justify-between border-b border-fd-border px-4 py-2">
           <TabBar
@@ -398,11 +416,25 @@ export function PlaygroundConfigurator() {
             active={codeTab}
             onChange={(v) => setCodeTab(v as CodeTab)}
           />
-          <CopyButton value={activeCode} label="Copy" />
+          <div className="flex items-center gap-2">
+            <CopyButton value={activeCode} label="Copy" />
+            {isEmbedded && (
+              <button
+                type="button"
+                onClick={() => setCodeExpanded((v) => !v)}
+                className="text-fd-muted-foreground hover:text-fd-foreground transition-colors"
+                aria-label={codeExpanded ? "Collapse code" : "Expand code"}
+              >
+                {codeExpanded ? <ChevronUp className="size-4" /> : <ChevronDown className="size-4" />}
+              </button>
+            )}
+          </div>
         </div>
-        <pre className="overflow-x-auto bg-fd-secondary/30 px-4 py-3 text-xs leading-relaxed text-fd-foreground">
-          <code>{activeCode}</code>
-        </pre>
+        {codeExpanded && (
+          <pre className="overflow-x-auto bg-fd-secondary/30 px-4 py-3 text-xs leading-relaxed text-fd-foreground">
+            <code>{activeCode}</code>
+          </pre>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Makes the /embed-playground page render cleanly inside a Mintlify iframe.

Changes:
- **Root wrapper**:  →  when 
- **iframe detection**: auto-detects via  + supports  param
- **Compact layout**: reduced spacing, preview/config heights drop from 560px to 400px
- **Code panel**: collapsible by default when embedded (toggles via chevron button)
- **Mintlify iframe**: updated src to pass 

To test: visit `https://aomi.dev/embed-playground?embed=true`