### PR TITLE
[codex] Copy research assets in Vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "clean:next": "rm -rf .next apps/landing/.next apps/base/.next",
     "clean:all": "rm -rf .next apps/landing/.next apps/base/.next dist .turbo node_modules/.cache .eslintcache",
     "clean": "rm -rf .next apps/landing/.next apps/base/.next dist .turbo node_modules/.cache .eslintcache",
-    "vercel-build": "pnpm run build:lib && pnpm run build:registry && mkdir -p apps/landing/public/r && cp -r apps/registry/dist/. apps/landing/public/r/ && if [ \"$VERCEL\" = \"1\" ]; then mkdir -p public/assets public/videos && cp -r apps/landing/public/assets/. public/assets/ && cp -r apps/landing/public/videos/. public/videos/; fi && pnpm --filter landing build",
+    "vercel-build": "pnpm run build:lib && pnpm run build:registry && mkdir -p apps/landing/public/r && cp -r apps/registry/dist/. apps/landing/public/r/ && if [ \"$VERCEL\" = \"1\" ]; then mkdir -p public/assets public/videos public/research && cp -r apps/landing/public/assets/. public/assets/ && cp -r apps/landing/public/videos/. public/videos/ && cp -r apps/landing/public/research/. public/research/; fi && pnpm --filter landing build",
     "start": "next start",
     "lint": "eslint .",
     "lint:landing": "pnpm --filter landing lint",


### PR DESCRIPTION
## Summary
- copy `apps/landing/public/research` into root `public/research` during Vercel builds
- ensure deployed landing-page static asset URLs under `/research/aomibench-v0.1/figures/*` are packaged alongside existing assets/videos

## Validation
- `pnpm run typecheck:landing`
- `pnpm run lint:landing`
- simulated copy locally and verified `public/research/aomibench-v0.1/figures/f01_sr1_headline.svg` exists

## Notes
The research page was merged in #176. The source files are present in `apps/landing/public`, but Vercel's root build copy step only mirrored `assets` and `videos`, which can leave `/research/...` static assets unavailable on the deployed instance.
