### PR TITLE
[codex] Tune research and agents pages

### DIFF
--- a/apps/landing/app/agents/page.tsx
+++ b/apps/landing/app/agents/page.tsx
@@ -25,19 +25,34 @@ export const metadata: Metadata = {
 export default function AgentsPage() {
   return (
     <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col gap-8 px-6 py-16">
-      <div className="space-y-4">
-        <h1 className="font-serif text-4xl tracking-tight text-foreground md:text-5xl">
-          Aomi for Agents
-        </h1>
-        <p className="font-geist text-xl font-medium tracking-tight text-foreground md:text-2xl">
-          The blockchain harness for agentic AI.
-        </p>
-        <p className="font-geist max-w-3xl text-base leading-7 text-muted-foreground">
-          Use Aomi to transact on wallets, embed a chat surface, or expose your
-          product as callable AI tools — non-custodial by design, with
-          simulation and local signing built in.
-        </p>
-      </div>
+      <header>
+        <Link
+          href="/"
+          aria-label="Aomi home"
+          className="flex items-center justify-end gap-2 pr-5 font-serif text-xl font-bold tracking-tight text-foreground"
+        >
+          <img
+            src="/assets/images/bubble.svg"
+            alt=""
+            className="h-5 w-5 dark:invert"
+          />
+          <span>aomi</span>
+        </Link>
+        <div className="mt-8 space-y-4">
+          <h1 className="font-serif text-4xl tracking-tight text-foreground md:text-5xl">
+            Aomi for Agents
+          </h1>
+          <p className="font-geist text-xl font-medium tracking-tight text-foreground md:text-2xl">
+            The blockchain harness for agentic AI.
+          </p>
+          <p className="font-geist max-w-3xl text-base leading-7 text-muted-foreground">
+            Use Aomi to transact on wallets, embed a chat surface, or expose
+            your product as callable AI tools — non-custodial by design, with
+            simulation and local signing built in.
+          </p>
+        </div>
+        <div className="mt-8 h-px w-full bg-stone-200" />
+      </header>
 
       <section className="space-y-3">
         <h2 className="font-geist text-xl font-semibold">

--- a/apps/landing/app/research/[slug]/page.tsx
+++ b/apps/landing/app/research/[slug]/page.tsx
@@ -61,7 +61,7 @@ const markdownComponents: Components = {
     </h2>
   ),
   h3: ({ children }) => (
-    <h3 className="font-geist mt-9 text-xl font-normal tracking-tight text-foreground">
+    <h3 className="mt-9 font-serif text-2xl font-normal tracking-tight text-foreground">
       {children}
     </h3>
   ),
@@ -81,7 +81,7 @@ const markdownComponents: Components = {
     }
 
     return (
-      <p className="font-geist text-[17px] leading-8 text-stone-700 dark:text-white">
+      <p className="font-geist text-[15px] leading-[1.9] text-stone-700 dark:text-white">
         {children}
       </p>
     );
@@ -99,12 +99,12 @@ const markdownComponents: Components = {
     />
   ),
   ul: ({ children }) => (
-    <ul className="font-geist my-5 list-disc space-y-2 pl-6 text-[17px] leading-8 text-stone-700 dark:text-white">
+    <ul className="font-geist my-5 list-disc space-y-2 pl-6 text-[15px] leading-[1.9] text-stone-700 dark:text-white">
       {children}
     </ul>
   ),
   ol: ({ children }) => (
-    <ol className="font-geist my-5 list-decimal space-y-2 pl-6 text-[17px] leading-8 text-stone-700 dark:text-white">
+    <ol className="font-geist my-5 list-decimal space-y-2 pl-6 text-[15px] leading-[1.9] text-stone-700 dark:text-white">
       {children}
     </ol>
   ),

--- a/apps/landing/app/research/page.tsx
+++ b/apps/landing/app/research/page.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
 
 export default function ResearchPage() {
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-16 px-8 py-12 sm:px-12 lg:px-16">
+    <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col gap-12 px-6 py-16">
       <header>
         <div className="flex items-center justify-end gap-2 pr-5 font-serif text-lg font-normal tracking-tight text-foreground">
           <img
@@ -41,12 +41,12 @@ export default function ResearchPage() {
           <Link
             key={post.slug}
             href={`/research/${post.slug}`}
-            className="group grid min-h-[240px] overflow-hidden rounded-[28px] border border-stone-200 bg-white text-stone-950 shadow-sm transition duration-200 hover:-translate-y-0.5 hover:border-stone-300 hover:shadow-md md:grid-cols-[minmax(260px,34%)_1fr]"
+            className="group grid min-h-[150px] overflow-hidden rounded-[24px] border border-stone-200 bg-white text-stone-950 shadow-sm transition duration-200 hover:-translate-y-0.5 hover:border-stone-300 hover:shadow-md md:grid-cols-[minmax(180px,34%)_1fr]"
           >
             <div
               aria-hidden="true"
               className={[
-                "min-h-[150px] border-b border-stone-200 md:min-h-full md:border-r md:border-b-0",
+                "min-h-[120px] border-b border-stone-200 md:min-h-full md:border-r md:border-b-0",
                 index % 2 === 0
                   ? "bg-[radial-gradient(circle_at_82%_62%,rgba(255,214,122,0.82)_0%,rgba(255,126,143,0.84)_18%,transparent_34%),linear-gradient(180deg,#75aeca_0%,#b9b8ae_42%,#ff7f8f_72%,#a887a2_100%)]"
                   : "bg-[radial-gradient(circle_at_18%_68%,rgba(255,214,122,0.82)_0%,rgba(255,126,143,0.84)_18%,transparent_34%),linear-gradient(180deg,#75aeca_0%,#b9b8ae_42%,#ff7f8f_72%,#a887a2_100%)]",
@@ -55,20 +55,20 @@ export default function ResearchPage() {
               <div className="h-full w-full bg-[linear-gradient(90deg,rgba(255,255,255,0.18)_1px,transparent_1px),linear-gradient(0deg,rgba(255,255,255,0.12)_1px,transparent_1px)] bg-[size:34px_34px] opacity-35" />
             </div>
 
-            <div className="flex flex-col justify-center gap-8 px-6 py-8 sm:px-10 lg:px-12">
-              <div className="space-y-5">
-                <span className="font-geist-mono inline-flex w-fit rounded-full bg-stone-100 px-3 py-1 text-xs font-medium tracking-[0.12em] text-stone-600">
+            <div className="flex flex-col justify-center gap-4 px-5 py-5 sm:px-7 lg:px-8">
+              <div className="space-y-3">
+                <span className="font-geist-mono inline-flex w-fit rounded-full bg-stone-100 px-2.5 py-0.5 text-[11px] font-medium tracking-[0.1em] text-stone-600">
                   {post.tag}
                 </span>
-                <h2 className="max-w-4xl font-serif text-2xl leading-tight font-normal tracking-tight text-stone-950 md:text-4xl">
+                <h2 className="max-w-3xl font-serif text-xl leading-tight font-normal tracking-tight text-stone-950 md:text-2xl">
                   {post.title}
                 </h2>
-                <p className="font-geist max-w-3xl text-base leading-7 text-stone-500">
+                <p className="font-geist max-w-2xl text-sm leading-6 text-stone-500">
                   {post.subtitle}
                 </p>
               </div>
               <time
-                className="font-geist-mono text-sm text-stone-500"
+                className="font-geist-mono text-xs text-stone-500"
                 dateTime={post.isoDate}
               >
                 {post.date}

--- a/apps/landing/app/research/page.tsx
+++ b/apps/landing/app/research/page.tsx
@@ -22,14 +22,18 @@ export default function ResearchPage() {
   return (
     <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col gap-12 px-6 py-16">
       <header>
-        <div className="flex items-center justify-end gap-2 pr-5 font-serif text-lg font-normal tracking-tight text-foreground">
+        <Link
+          href="/"
+          aria-label="Aomi home"
+          className="flex items-center justify-end gap-2 pr-5 font-serif text-xl font-bold tracking-tight text-foreground"
+        >
           <img
             src="/assets/images/bubble.svg"
             alt=""
             className="h-5 w-5 dark:invert"
           />
-          <span>aomi labs</span>
-        </div>
+          <span>aomi</span>
+        </Link>
         <h1 className="mt-8 font-serif text-4xl tracking-tight text-foreground md:text-5xl">
           Research
         </h1>

--- a/apps/landing/content/research/aomibench-v0.1.md
+++ b/apps/landing/content/research/aomibench-v0.1.md
@@ -376,12 +376,13 @@ Read the task-success-rate numbers as product-and-harness signal — task comple
 
 ## 9. What's next
 
-- harder, multi-step, multi-protocol task splits that separate frontier models;
-- per-category scoring cards (swaps, staking, bridging, lending, signatures, read-only, safety);
-- more passes per spec for variance and confidence intervals;
-- a structured failure taxonomy with representative passing and failing traces;
-- public methodology cards: model IDs, harness version, prompt hashes, tool surface, budgets, fork context, retry policy;
-- and, in time, a public-dev task set with private/rolling holdouts for contamination resistance.
+The roadmap runs along two lines: harder tasks with deeper evaluation, and opening the harness up so anyone can use it.
+
+- Harder task splits: cross-chain and cross-protocol execution, and long-horizon intent that spans many dependent steps, built to separate frontier models where v0.1 saturates.
+- Wider model coverage at both ends of the range. A core goal of Aomi is a harness usable enough that even small, low-cost models can transact reliably through it, so we benchmark the low end as deliberately as the high end.
+- Deeper evaluation: more passes per spec for variance and confidence intervals, plus behavioral telemetry such as tool-call patterns, tool-call frequency, and tool calls per task.
+- Aomi as a remote runtime over MCP: the same tools, skills, and guards shown here, exposed as an MCP server, so any agent can read chain state, stage, simulate, and request signatures through the same interface we benchmark.
+- Self-serve benchmarking: with the harness reachable from your local Claude as a CLI and MCP server, anyone can run their own model or agent against the suite and score it on the same verifier.
 
 The standard we hold ourselves to is the one credible execution benchmarks converge on: publish the task, the verifier, the harness, the artifacts, and the failure cases.
 


### PR DESCRIPTION
## Summary
- match the research index width/card scale to the agents page
- add the shared top-right Aomi home link/header treatment to research and agents
- tune AomiBench article typography and update the "What's next" section

## Checks
- pnpm run typecheck:landing
- pnpm run lint:landing
- git diff --check