### PR TITLE
fix: move vercel.json to apps/landing to prevent override of other projects

### DIFF
--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,7 +1,7 @@
 {
-  "installCommand": "pnpm install --frozen-lockfile",
-  "buildCommand": "pnpm -w run vercel-build",
-  "outputDirectory": "apps/landing/.next",
+  "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
+  "buildCommand": "cd ../.. && pnpm -w run vercel-build",
+  "outputDirectory": ".next",
   "rewrites": [
     {
       "source": "/_mintlify/:path*",


### PR DESCRIPTION
## Problem
Root `vercel.json` was forcing **all** Vercel projects (landing, portal, base) to build the landing app, causing `chat-staging.aomi.dev` (portal project) to incorrectly render the landing page instead of the portal app.

## Solution
Move `vercel.json` to `apps/landing/` so it only applies to the landing project. Portal and base projects now use their Vercel dashboard settings correctly.

## Changes
- `vercel.json` → `apps/landing/vercel.json`
- Updated `installCommand`: `cd ../.. && pnpm install --frozen-lockfile`
- Updated `buildCommand`: `cd ../.. && pnpm -w run vercel-build`
- Updated `outputDirectory`: `.next` (relative to `apps/landing/`)
- Mintlify rewrites preserved for landing/aomi.dev

## Testing
After merge, verify:
1. `aomi.dev` still loads landing page with `/docs` rewrites working
2. `chat-staging.aomi.dev` loads portal app correctly (not landing)
3. Base deployments unaffected

Fixes: chat-staging.aomi.dev rendering wrong app
Related: #183