### PR TITLE
[codex] Bump client package for republish

### DIFF
--- a/packages/client/dist/cli.js
+++ b/packages/client/dist/cli.js
@@ -8542,7 +8542,7 @@ init_shared();
 // package.json
 var package_default = {
   name: "@aomi-labs/client",
-  version: "0.1.39",
+  version: "0.1.40",
   description: "Platform-agnostic TypeScript client for the Aomi backend API",
   type: "module",
   main: "./dist/index.cjs",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/client",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "description": "Platform-agnostic TypeScript client for the Aomi backend API",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- Bump `@aomi-labs/client` from `0.1.39` to `0.1.40`.
- Regenerate the built CLI dist version string to match the package version.

## Why
The published `0.1.39` client is behind the current source user_state model, while newer source code still had the same package version. Publishing a new version avoids a version-string collision and gives the CLI a clean package version for the nested user_state changes already on main.

## Validation
- `pnpm --filter @aomi-labs/client build`