### PR TITLE
[codex] Simplify Privy auth portal callback

### DIFF
--- a/apps/portal/src/app/auth/privy/page.tsx
+++ b/apps/portal/src/app/auth/privy/page.tsx
@@ -16,6 +16,7 @@ type SearchParams = Promise<{
   state?: string;
   app_id?: string;
   callback_url?: string;
+  signer_id?: string;
 }>;
 
 export const dynamic = "force-dynamic";
@@ -29,6 +30,7 @@ export default async function PrivyAuthPage({
     state,
     app_id: appId,
     callback_url: rawCallbackUrl,
+    signer_id: signerId,
   } = await searchParams;
   const callbackUrl = normalizeCallbackUrl(rawCallbackUrl);
 
@@ -47,8 +49,18 @@ export default async function PrivyAuthPage({
   }
 
   return (
-    <PrivyAuthClient state={state} appId={appId} callbackUrl={callbackUrl} />
+    <PrivyAuthClient
+      state={state}
+      appId={appId}
+      callbackUrl={callbackUrl}
+      signerId={normalizeSignerId(signerId)}
+    />
   );
+}
+
+function normalizeSignerId(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
 }
 
 function normalizeCallbackUrl(value?: string): string | undefined {

--- a/apps/portal/src/app/auth/privy/page.tsx
+++ b/apps/portal/src/app/auth/privy/page.tsx
@@ -2,10 +2,9 @@
 // /auth/privy — the Privy login landing page.
 // =============================================================================
 //
-// Where /api/auth/privy/start redirects to after Aomi BE (or MCP) calls
-// /api/auth/begin with provider=privy. URL shape:
+// Backend-owned auth URLs land here after Aomi mints signed state. URL shape:
 //
-//   chat.aomi.dev/auth/privy?state=<token>&app_id=<aomi-privy-app-id>
+//   chat.aomi.dev/auth/privy?state=<token>&app_id=<aomi-privy-app-id>&callback_url=<backend-callback>
 //
 // We don't render any of Privy's login UI from this server file — that's the
 // client component below. This page just guards on the required query params
@@ -16,7 +15,7 @@ import { PrivyAuthClient } from "./privy-login-client";
 type SearchParams = Promise<{
   state?: string;
   app_id?: string;
-  signer_id?: string;
+  callback_url?: string;
 }>;
 
 export const dynamic = "force-dynamic";
@@ -26,9 +25,14 @@ export default async function PrivyAuthPage({
 }: {
   searchParams: SearchParams;
 }) {
-  const { state, app_id: appId, signer_id: signerId } = await searchParams;
+  const {
+    state,
+    app_id: appId,
+    callback_url: rawCallbackUrl,
+  } = await searchParams;
+  const callbackUrl = normalizeCallbackUrl(rawCallbackUrl);
 
-  if (!state || !appId) {
+  if (!state || !appId || (rawCallbackUrl && !callbackUrl)) {
     return (
       <main className="bg-background text-foreground flex min-h-screen items-center justify-center px-6">
         <div className="border-input bg-background w-full max-w-md rounded-3xl border p-8">
@@ -42,5 +46,39 @@ export default async function PrivyAuthPage({
     );
   }
 
-  return <PrivyAuthClient state={state} appId={appId} signerId={signerId} />;
+  return (
+    <PrivyAuthClient state={state} appId={appId} callbackUrl={callbackUrl} />
+  );
+}
+
+function normalizeCallbackUrl(value?: string): string | undefined {
+  if (!value) return undefined;
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return undefined;
+  }
+  if (!isAllowedCallbackHost(url.hostname)) return undefined;
+  if (url.protocol === "https:") return url.toString();
+  if (url.protocol === "http:" && isLocalhost(url.hostname))
+    return url.toString();
+  return undefined;
+}
+
+function isAllowedCallbackHost(hostname: string): boolean {
+  return (
+    isLocalhost(hostname) ||
+    hostname === "aomi.dev" ||
+    hostname.endsWith(".aomi.dev")
+  );
+}
+
+function isLocalhost(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname === "[::1]"
+  );
 }

--- a/apps/portal/src/app/auth/privy/privy-login-client.tsx
+++ b/apps/portal/src/app/auth/privy/privy-login-client.tsx
@@ -13,8 +13,7 @@
 //      this page's JS.
 //   3. Once authenticated, collect the EVM embedded wallet info + access
 //      token and POST to /api/auth/privy/callback with the state token.
-//      That endpoint stashes the credentials into the BE secret vault and
-//      completes the pending_auths row.
+//      That endpoint registers Aomi's signer and persists the approval.
 //   4. Show success (or error) — Alice closes the tab.
 //
 // We do NOT support unlinking, account switching, or wallet management here;
@@ -27,7 +26,6 @@ import {
   type User,
   useCreateWallet,
   usePrivy,
-  useSigners,
   useWallets,
 } from "@privy-io/react-auth";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -35,10 +33,10 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 interface Props {
   state: string;
   appId: string;
-  signerId?: string;
+  callbackUrl?: string;
 }
 
-export function PrivyAuthClient({ state, appId, signerId }: Props) {
+export function PrivyAuthClient({ state, appId, callbackUrl }: Props) {
   return (
     <PrivyProvider
       appId={appId}
@@ -55,7 +53,7 @@ export function PrivyAuthClient({ state, appId, signerId }: Props) {
         },
       }}
     >
-      <PrivyConnectFlow state={state} signerId={signerId} />
+      <PrivyConnectFlow state={state} callbackUrl={callbackUrl} />
     </PrivyProvider>
   );
 }
@@ -69,15 +67,14 @@ type Status =
 
 function PrivyConnectFlow({
   state,
-  signerId,
+  callbackUrl,
 }: {
   state: string;
-  signerId?: string;
+  callbackUrl?: string;
 }) {
   const { ready, authenticated, user, login, getAccessToken, logout } =
     usePrivy();
   const { createWallet } = useCreateWallet();
-  const { addSigners } = useSigners();
   const { ready: walletsReady, wallets } = useWallets();
 
   const [status, setStatus] = useState<Status>({ kind: "loading" });
@@ -135,28 +132,11 @@ function PrivyConnectFlow({
       }
     }
 
-    if (signerId) {
-      try {
-        const result = await addSigners({
-          address: walletAddress,
-          signers: [{ signerId, policyIds: [] }],
-        });
-        walletId =
-          walletId ?? embeddedWalletIdForUser(result.user, walletAddress);
-      } catch (err) {
-        setStatus({
-          kind: "error",
-          message: `Could not authorize Aomi signer: ${errMsg(err)}`,
-        });
-        setHasSubmitted(false);
-        return;
-      }
-    }
-
     if (!walletId) {
       setStatus({
         kind: "error",
-        message: "Privy did not return a stable wallet id for the embedded wallet.",
+        message:
+          "Privy did not return a stable wallet id for the embedded wallet.",
       });
       setHasSubmitted(false);
       return;
@@ -178,7 +158,7 @@ function PrivyConnectFlow({
     }
 
     try {
-      const res = await fetch("/api/auth/privy/callback", {
+      const res = await fetch(callbackUrl ?? "/api/auth/privy/callback", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -205,12 +185,11 @@ function PrivyConnectFlow({
       });
     }
   }, [
-    addSigners,
+    callbackUrl,
     createWallet,
     embeddedWallet,
     getAccessToken,
     hasSubmitted,
-    signerId,
     state,
     user,
   ]);
@@ -259,9 +238,9 @@ function Header() {
       </div>
       <h1 className="text-lg font-semibold">Connect a self-custody wallet</h1>
       <p className="text-muted-foreground text-sm">
-        Aomi is setting up a new wallet that you fully control. Privy holds
-        the key on your behalf — Aomi never sees it. The login UI below is
-        served by Privy directly.
+        Aomi is setting up a new wallet that you fully control. Privy holds the
+        key on your behalf — Aomi never sees it. The login UI below is served by
+        Privy directly.
       </p>
     </div>
   );

--- a/apps/portal/src/app/auth/privy/privy-login-client.tsx
+++ b/apps/portal/src/app/auth/privy/privy-login-client.tsx
@@ -26,6 +26,7 @@ import {
   type User,
   useCreateWallet,
   usePrivy,
+  useSigners,
   useWallets,
 } from "@privy-io/react-auth";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -34,9 +35,10 @@ interface Props {
   state: string;
   appId: string;
   callbackUrl?: string;
+  signerId?: string;
 }
 
-export function PrivyAuthClient({ state, appId, callbackUrl }: Props) {
+export function PrivyAuthClient({ state, appId, callbackUrl, signerId }: Props) {
   return (
     <PrivyProvider
       appId={appId}
@@ -53,7 +55,11 @@ export function PrivyAuthClient({ state, appId, callbackUrl }: Props) {
         },
       }}
     >
-      <PrivyConnectFlow state={state} callbackUrl={callbackUrl} />
+      <PrivyConnectFlow
+        state={state}
+        callbackUrl={callbackUrl}
+        signerId={signerId}
+      />
     </PrivyProvider>
   );
 }
@@ -68,13 +74,16 @@ type Status =
 function PrivyConnectFlow({
   state,
   callbackUrl,
+  signerId,
 }: {
   state: string;
   callbackUrl?: string;
+  signerId?: string;
 }) {
   const { ready, authenticated, user, login, getAccessToken, logout } =
     usePrivy();
   const { createWallet } = useCreateWallet();
+  const { addSigners } = useSigners();
   const { ready: walletsReady, wallets } = useWallets();
 
   const [status, setStatus] = useState<Status>({ kind: "loading" });
@@ -126,6 +135,24 @@ function PrivyConnectFlow({
         setStatus({
           kind: "error",
           message: `Could not create embedded Privy wallet: ${errMsg(err)}`,
+        });
+        setHasSubmitted(false);
+        return;
+      }
+    }
+
+    if (signerId) {
+      try {
+        const result = await addSigners({
+          address: walletAddress,
+          signers: [{ signerId, policyIds: [] }],
+        });
+        walletId =
+          walletId ?? embeddedWalletIdForUser(result.user, walletAddress);
+      } catch (err) {
+        setStatus({
+          kind: "error",
+          message: `Could not authorize Aomi signer: ${errMsg(err)}`,
         });
         setHasSubmitted(false);
         return;
@@ -186,10 +213,12 @@ function PrivyConnectFlow({
     }
   }, [
     callbackUrl,
+    addSigners,
     createWallet,
     embeddedWallet,
     getAccessToken,
     hasSubmitted,
+    signerId,
     state,
     user,
   ]);

--- a/apps/portal/src/components/wallet-providers.tsx
+++ b/apps/portal/src/components/wallet-providers.tsx
@@ -5,6 +5,7 @@ import {
   type TOAuthMethod,
   type TExternalWallet,
 } from "@getpara/react-sdk";
+import { usePathname } from "next/navigation";
 import { type ReactNode, useEffect } from "react";
 import { useAccount, useSwitchChain } from "wagmi";
 import {
@@ -97,7 +98,8 @@ const solanaNetworks = [
       process.env.NEXT_PUBLIC_SOLANA_DEVNET_RPC_URL ??
       process.env.NEXT_PUBLIC_SOLANA_RPC_URL ??
       "https://api.devnet.solana.com",
-    rpcWsUrl: process.env.NEXT_PUBLIC_SOLANA_DEVNET_RPC_WS_URL ??
+    rpcWsUrl:
+      process.env.NEXT_PUBLIC_SOLANA_DEVNET_RPC_WS_URL ??
       process.env.NEXT_PUBLIC_SOLANA_RPC_WS_URL,
   },
   {
@@ -193,6 +195,11 @@ type Props = {
 };
 
 export function WalletProviders({ children }: Props) {
+  const pathname = usePathname();
+  if (pathname?.startsWith("/auth/privy")) {
+    return <>{children}</>;
+  }
+
   const content = paraApiKey ? (
     <LocalhostNetworkEnforcer>{children}</LocalhostNetworkEnforcer>
   ) : (


### PR DESCRIPTION
## Summary
- Keep the Privy portal page as a browser-only login and embedded wallet setup page.
- Remove browser-side signer registration via useSigners/addSigners.
- Allow backend-generated auth URLs to post directly to the backend callback URL after Privy login.
- Bypass the site wallet shell on /auth/privy so the standalone Privy login route does not require a Para/wagmi provider.

## Why
The backend now owns Privy quorum signer registration and approval ingestion, so the portal should only collect the Privy login payload and hand it to the callback.

## Validation
- pnpm run typecheck:portal
- Local manual load of /auth/privy returned 200 and posted to the backend callback

## Companion
- Backend PR: https://github.com/aomi-labs/product-mono/pull/618