### PR TITLE
fix(user-state): drop non-Option null fields that 400 the backend

### DIFF
--- a/packages/client/src/user-state/normalize.ts
+++ b/packages/client/src/user-state/normalize.ts
@@ -107,6 +107,9 @@ function buildConnection(
   liftFlat(c, flat, "auth_method", ["auth_method", "authMethod"]);
   liftFlat(c, flat, "auth_value", ["auth_value", "authValue"]);
   liftFlat(c, flat, "auth_verified_at", ["auth_verified_at", "authVerifiedAt"]);
+  // `connection.is_connected` is a non-`Option` `bool` on the backend; an
+  // explicit `null` fails serde with a 400. Drop it (defaults to false).
+  dropNullKeys(c, "is_connected");
   return Object.keys(c).length ? c : undefined;
 }
 
@@ -165,6 +168,10 @@ function buildSvm(
   const s: UnknownRecord = { ...(src ?? {}) };
   renameKey(s, "walletName", "wallet_name");
   liftFlat(s, flat, "address", ["svm_address", "svmAddress"]);
+  // `svm.capabilities` is a non-`Option` `Vec` on the backend; an explicit
+  // `null` fails serde with a 400 (the staging chat-portal regression). Drop it
+  // when null/undefined — absence defaults to an empty capability set.
+  dropNullKeys(s, "capabilities");
   return Object.keys(s).length ? s : undefined;
 }
 
@@ -202,6 +209,23 @@ function buildPending(
     snakeizeBucket(pick(src, "svm_sigs", "svmSigs", "solana_sigs", "solanaSigs")),
   );
   return Object.keys(p).length ? p : undefined;
+}
+
+/**
+ * Delete keys whose value is an explicit `null`/`undefined`.
+ *
+ * Only safe for backend fields that are NOT `Option<…>` — serde rejects an
+ * explicit `null` for those with a deserialize error → HTTP 400. Most fields
+ * here are `Option<…>` where `null` is a meaningful tombstone (e.g. AA
+ * mode-exclusive clears `evm.aa.delegation_7702: null`), so callers must list
+ * only the genuinely non-nullable wire fields.
+ */
+function dropNullKeys(obj: UnknownRecord, ...keys: string[]): void {
+  for (const key of keys) {
+    if (obj[key] === null || obj[key] === undefined) {
+      delete obj[key];
+    }
+  }
 }
 
 function deepMergePreserve(

--- a/packages/client/test/user-state-normalize.unit.test.ts
+++ b/packages/client/test/user-state-normalize.unit.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { UserState } from "../src/index";
+
+describe("normalizeUserState null pruning", () => {
+  // Regression: the staging chat portal sent `svm.capabilities: null`, which the
+  // backend's `SolCapabilitiesUserState(Vec<…>)` (a non-Option field) rejected
+  // with a serde error → HTTP 400. `null` is never meaningful vs. absent in the
+  // wallet blocks, so normalize must not emit it.
+  it("drops svm.capabilities when null (the staging 400 payload)", () => {
+    const normalized = UserState.normalize({
+      connection: {
+        is_connected: true,
+        provider: "para",
+        wallet_provider_subject: null,
+        auth_method: null,
+        auth_value: null,
+        auth_verified_at: null,
+      },
+      evm: {
+        address: "0xC764D92E312195114595cB645f31C38Fad9c14eE",
+        chain_id: 1,
+        sponsorship: {
+          sponsored: false,
+          sponsor_provider: "self",
+          sponsor_account: null,
+        },
+      },
+      svm: {
+        address: null,
+        cluster: "solana:mainnet",
+        wallet_name: null,
+        transport: null,
+        capabilities: null,
+      },
+      ext: { client_type: "web_ui" },
+    });
+
+    // The non-Option `capabilities` (the field that 400'd) must be gone.
+    expect(normalized?.svm).not.toHaveProperty("capabilities");
+    expect(normalized?.svm?.cluster).toBe("solana:mainnet");
+    // `is_connected` is preserved (it was a real boolean, not null).
+    expect(normalized?.connection?.is_connected).toBe(true);
+    // Option fields keep their nulls — the backend accepts them (verified
+    // against staging: only `svm.capabilities: null` returned 400).
+    expect(normalized?.evm?.sponsorship).toMatchObject({
+      sponsored: false,
+      sponsor_provider: "self",
+    });
+  });
+
+  it("strips connection.is_connected when explicitly null (non-Option bool)", () => {
+    const normalized = UserState.normalize({
+      connection: { is_connected: null, provider: "para" },
+    });
+    expect(normalized?.connection).not.toHaveProperty("is_connected");
+    expect(normalized?.connection?.provider).toBe("para");
+  });
+
+  it("preserves Option-field null tombstones (AA mode-exclusive clears)", () => {
+    const normalized = UserState.normalize({
+      evm: { address: "0xabc", aa: { mode: "4337", delegation_7702: null } },
+    });
+    // `delegation_7702: null` is a meaningful clear-signal; must survive.
+    expect(normalized?.evm?.aa).toHaveProperty("delegation_7702", null);
+  });
+
+  it("preserves an empty capabilities array (valid wire value)", () => {
+    const normalized = UserState.normalize({
+      svm: { address: "So11111111111111111111111111111111111111112", capabilities: [] },
+    });
+    expect(normalized?.svm?.capabilities).toEqual([]);
+  });
+
+  it("keeps falsey-but-meaningful values (is_connected:false, chain_id:0 stays valid)", () => {
+    const normalized = UserState.normalize({
+      connection: { is_connected: false },
+      evm: { address: "0xabc", sponsorship: { sponsored: false } },
+    });
+    expect(normalized?.connection).toEqual({ is_connected: false });
+    expect(normalized?.evm?.sponsorship).toEqual({ sponsored: false });
+  });
+
+  it("does not prune nulls inside free-form ext", () => {
+    const normalized = UserState.normalize({
+      connection: { is_connected: true },
+      ext: { client_type: "web_ui", custom: null },
+    });
+    expect(normalized?.ext).toEqual({ client_type: "web_ui", custom: null });
+  });
+});


### PR DESCRIPTION
## Problem

The staging chat portal failed against `staging-api.aomi.dev` (local worked). Root cause: the portal sends `svm.capabilities: null`, but the backend's Solana wallet struct declares `capabilities` as a **non-`Option`** `Vec` (`SolCapabilitiesUserState`). Serde can't deserialize `null` into a `Vec` → hard error, silently mapped to **HTTP 400** at the handler (no logs under `RUST_LOG=info`).

This was **not** the user_state schema (nested shape is fine) and **not** a missing `X-Session-Id` header — reproduced 400 *with* a valid header. Bisecting the exact portal payload against staging pinned it to the single field `svm.capabilities: null`; every other field is `Option<…>` and returns 200 with `null`.

## Fix

Strip `null`/`undefined` for the genuinely non-nullable wire fields at the normalize chokepoint (covers web provider + CLI):
- `svm.capabilities` (`Vec`)
- `connection.is_connected` (`bool`) — the other non-`Option` hazard found while checking for whack-a-mole

Pruning is deliberately **not** applied broadly: `null` is a meaningful tombstone on `Option` fields (e.g. AA mode-exclusive clears `evm.aa.delegation_7702: null`), and the backend accepts `null` there. A first, broader version of this fix broke 4 AA-tombstone e2e tests — which is exactly why the fix is scoped to the two non-nullable fields.

## Verification

- New regression test `user-state-normalize.unit.test.ts` (exact staging payload, `is_connected` guard, preserved empty-array, preserved AA tombstone, untouched `ext` nulls) — 6/6 pass.
- Full client suite: 233 passed, 27 skipped, 0 failed (incl. previously-failing AA-tombstone e2e tests).
- Lint clean.
- **End-to-end against `staging-api.aomi.dev`:** offending payload → `400`; pruned payload → `200`.

## Follow-up (optional, not in this PR)

Backend defense-in-depth: make `capabilities` tolerate `null` via `#[serde(default, deserialize_with=…)]` so a future stale client can't 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
