### PR TITLE
[codex] fix Para Google sign-in identity

### DIFF
--- a/apps/registry/src/lib/aomi-auth-adapter/providers/para.test.tsx
+++ b/apps/registry/src/lib/aomi-auth-adapter/providers/para.test.tsx
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { ExtUserProvider } from "@aomi-labs/react";
+import { AomiWalletNetworkPreferencesProvider } from "../network-preferences";
+import { useAomiAuthAdapter } from "../context";
+import { AomiParaAdapterProvider } from "./para";
+
+const paraMock = vi.hoisted(() => ({
+  account: {
+    isLoading: false,
+    isConnected: false,
+    embedded: { isConnected: false },
+    external: {},
+  } as {
+    isLoading: boolean;
+    isConnected: boolean;
+    connectionType?: string;
+    embedded: Record<string, unknown>;
+    external: Record<string, unknown>;
+  },
+  issueJwtAsync: vi.fn(async () => ({ token: "jwt" })),
+  openModal: vi.fn(),
+}));
+
+vi.mock("@getpara/react-sdk", () => ({
+  Environment: { BETA: "BETA" },
+  ParaProvider: ({ children }: { children: unknown }) => children,
+  useAccount: () => paraMock.account,
+  useClient: () => ({}),
+  useIssueJwt: () => ({ issueJwtAsync: paraMock.issueJwtAsync }),
+  useModal: () => ({ openModal: paraMock.openModal }),
+}));
+
+vi.mock("@getpara/react-sdk/styles.css", () => ({}));
+
+vi.mock("./para-sol", () => ({
+  DEFAULT_SOLANA_ENDPOINT: "https://api.mainnet-beta.solana.com",
+  ParaSolanaWrapper: ({
+    children,
+  }: {
+    children: (ready: boolean) => unknown;
+  }) => children(true),
+  buildParaSolanaMethods: () => ({}),
+  connectPreferredSolanaWallet: vi.fn(async () => "unavailable"),
+  detectSolanaTransport: () => undefined,
+  getSolanaCapabilitySnapshot: () => undefined,
+  resolveParaSolanaConfig: () => ({
+    enabled: false,
+    wallets: [],
+    activeNetwork: {
+      id: "solana-mainnet",
+      label: "Mainnet",
+      cluster: "solana:mainnet",
+      rpcHttpUrl: "https://m.example",
+    },
+    cluster: "solana:mainnet",
+    rpcHttpUrl: "https://m.example",
+    rpcWsUrl: undefined,
+    preferDirectSend: true,
+    mobileChain: "mainnet-beta",
+  }),
+  useSafeSolanaWallet: () => ({
+    wallets: [],
+    publicKey: undefined,
+    walletName: undefined,
+    connecting: false,
+    connect: undefined,
+    disconnect: undefined,
+    select: undefined,
+  }),
+}));
+
+const evmChains = [
+  {
+    id: 1,
+    name: "Ethereum",
+    nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+    rpcUrls: { default: { http: ["https://eth.example"] } },
+  },
+] as const;
+
+const solanaNetworks = [
+  {
+    id: "solana-mainnet",
+    label: "Mainnet",
+    cluster: "solana:mainnet",
+    rpcHttpUrl: "https://m.example",
+    isDefault: true,
+  },
+] as const;
+
+function IdentityProbe() {
+  const adapter = useAomiAuthAdapter();
+  return (
+    <output data-testid="identity">{JSON.stringify(adapter.identity)}</output>
+  );
+}
+
+function renderProvider() {
+  return render(
+    <ExtUserProvider>
+      <AomiWalletNetworkPreferencesProvider
+        storageKey="test-para"
+        evmChains={evmChains}
+        solanaNetworks={solanaNetworks}
+      >
+        <AomiParaAdapterProvider supportedChains={evmChains}>
+          <IdentityProbe />
+        </AomiParaAdapterProvider>
+      </AomiWalletNetworkPreferencesProvider>
+    </ExtUserProvider>,
+  );
+}
+
+describe("AomiParaAdapterProvider", () => {
+  beforeEach(() => {
+    cleanup();
+    paraMock.account = {
+      isLoading: false,
+      isConnected: false,
+      embedded: { isConnected: false },
+      external: {},
+    };
+    paraMock.issueJwtAsync.mockClear();
+    paraMock.openModal.mockClear();
+  });
+
+  it("treats completed Google OAuth as connected before a wallet address is ready", () => {
+    paraMock.account = {
+      isLoading: false,
+      isConnected: true,
+      connectionType: "embedded",
+      embedded: {
+        isConnected: true,
+        email: "alice@example.com",
+        authMethods: new Set(["GOOGLE"]),
+        wallets: [],
+      },
+      external: {},
+    };
+
+    renderProvider();
+
+    const identity = JSON.parse(
+      screen.getByTestId("identity").textContent ?? "{}",
+    );
+    expect(identity.status).toBe("connected");
+    expect(identity.isConnected).toBe(true);
+    expect(identity.primaryLabel).toBe("alice@example.com");
+    expect(identity.secondaryLabel).toBe("Google");
+    expect(identity.authMethod).toBe("google");
+    expect(identity.authValue).toBe("alice@example.com");
+    expect(identity.address).toBeUndefined();
+    expect(identity.walletKind).toBeUndefined();
+  });
+});

--- a/apps/registry/src/lib/aomi-auth-adapter/providers/para.tsx
+++ b/apps/registry/src/lib/aomi-auth-adapter/providers/para.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
   Environment,
   ParaProvider,
@@ -118,12 +112,27 @@ type AdapterSolanaRuntimeConfig = Pick<
 type ParaAccountShape = {
   isLoading: boolean;
   isConnected: boolean;
+  connectionType?: "embedded" | "external" | "both" | "none";
   embedded: {
+    isConnected?: boolean;
+    isGuestMode?: boolean;
+    userId?: string;
+    auth?: {
+      email?: string;
+      phone?: string;
+      farcasterUsername?: string;
+      telegramUserId?: string;
+      externalWalletAddress?: string;
+    };
+    authType?: string;
+    identifier?: string;
     email?: string;
+    phone?: string;
     farcasterUsername?: string;
     telegramUserId?: string;
+    externalWalletAddress?: string;
     authMethods?: Set<unknown>;
-    wallets?: Array<{ address?: string }>;
+    wallets?: Array<{ address?: string; type?: string; isExternal?: boolean }>;
   };
   external: {
     evm?: {
@@ -208,7 +217,9 @@ function useSafeParaClient(): ParaWeb | null {
   }
 }
 
-function useSafeIssueJwt(): (() => Promise<AomiAccountCredential | null>) | null {
+function useSafeIssueJwt():
+  | (() => Promise<AomiAccountCredential | null>)
+  | null {
   try {
     const { issueJwtAsync } = useIssueJwt();
     return async () => {
@@ -552,26 +563,29 @@ export function AomiParaAdapterProvider({
   const userDelegation7702 = UserState.Delegation7702(user);
 
   const adapter = useMemo<AomiAuthAdapter>(() => {
-    const isConnected = Boolean(paraAccount.isConnected || wagmiConnected);
+    const isParaConnected = Boolean(
+      paraAccount.isConnected || paraAccount.embedded.isConnected,
+    );
+    const isConnected = Boolean(isParaConnected || wagmiConnected);
     const isBooting = paraAccount.isLoading && !isConnected;
 
+    const authMethod = inferParaAuthMethod(paraAccount.embedded);
+    const authValue = resolveParaAuthValue(paraAccount.embedded, authMethod);
     const embeddedPrimary =
-      paraAccount.embedded.email ??
-      paraAccount.embedded.farcasterUsername ??
-      paraAccount.embedded.telegramUserId ??
+      authValue ??
+      paraAccount.embedded.identifier ??
+      paraAccount.embedded.userId ??
       undefined;
-    const embeddedWallet = paraAccount.embedded.wallets?.[0] as
-      | { address?: string }
-      | undefined;
+    const embeddedWallet =
+      paraAccount.embedded.wallets?.find(
+        (wallet) => wallet.address && wallet.type?.toUpperCase() === "EVM",
+      ) ?? paraAccount.embedded.wallets?.find((wallet) => wallet.address);
     const embeddedAddress = embeddedWallet?.address;
     const externalAddress = paraAccount.external.evm?.address;
     const address =
       wagmiAddress ?? externalAddress ?? embeddedAddress ?? undefined;
     const walletProvider = "para" as const;
-    const authMethod = inferAuthMethod(paraAccount.embedded.authMethods);
-    const authValue = resolveParaAuthValue(paraAccount.embedded, authMethod);
-    const secondaryLabel =
-      formatAuthMethod(authMethod) ?? "Para";
+    const secondaryLabel = formatAuthMethod(authMethod) ?? "Para";
     const { sponsored, sponsorProvider, sponsorAccount } =
       resolveParaSponsorship();
 
@@ -593,6 +607,10 @@ export function AomiParaAdapterProvider({
       activeSolanaAddress: svmAddress,
     });
 
+    const connectedPrimaryLabel =
+      embeddedPrimary ?? formatAddress(address) ?? "Para account";
+    const hasEvmAddress = Boolean(address);
+
     const identity: AomiAuthIdentity = isBooting
       ? {
           ...AOMI_AUTH_BOOTING_IDENTITY,
@@ -603,15 +621,19 @@ export function AomiParaAdapterProvider({
           solanaTransport: svmAddress ? solanaTransport : undefined,
           solanaCapabilities,
         }
-      : isConnected && embeddedPrimary
+      : isConnected
         ? {
             status: "connected",
             isConnected: true,
             address,
-            walletKind: "eoa",
-            aaMode: userAAMode ?? "none",
-            SmartAccount4337: userSmartAccount4337 ?? undefined,
-            Delegation7702: userDelegation7702 ?? undefined,
+            walletKind: hasEvmAddress ? "eoa" : undefined,
+            aaMode: hasEvmAddress ? (userAAMode ?? "none") : undefined,
+            SmartAccount4337: hasEvmAddress
+              ? (userSmartAccount4337 ?? undefined)
+              : undefined,
+            Delegation7702: hasEvmAddress
+              ? (userDelegation7702 ?? undefined)
+              : undefined,
             sponsored,
             sponsorProvider,
             sponsorAccount,
@@ -621,67 +643,43 @@ export function AomiParaAdapterProvider({
             authMethod,
             authProvider: authMethod,
             authValue,
-            primaryLabel: embeddedPrimary,
+            walletProviderSubject: paraAccount.embedded.userId,
+            primaryLabel: connectedPrimaryLabel,
             secondaryLabel,
             solanaCluster: resolvedAdapterSolanaConfig.cluster,
             solanaWalletName: solanaWallet.walletName,
             solanaTransport: svmAddress ? solanaTransport : undefined,
             solanaCapabilities,
           }
-        : isConnected && address
+        : svmAddress
           ? {
               status: "connected",
               isConnected: true,
-              address,
-              walletKind: "eoa",
-              aaMode: userAAMode ?? "none",
-              SmartAccount4337: userSmartAccount4337 ?? undefined,
-              Delegation7702: userDelegation7702 ?? undefined,
-              sponsored,
-              sponsorProvider,
-              sponsorAccount,
+              walletKind: undefined,
+              aaMode: undefined,
               chainId: chainId ?? undefined,
               svmAddress,
               walletProvider,
               authMethod,
               authProvider: authMethod,
               authValue,
-              primaryLabel: formatAddress(address) ?? "Connected wallet",
-              secondaryLabel,
+              primaryLabel:
+                formatAddress(svmAddress) ?? "Connected Solana wallet",
+              secondaryLabel: "Solana",
               solanaCluster: resolvedAdapterSolanaConfig.cluster,
               solanaWalletName: solanaWallet.walletName,
-              solanaTransport: svmAddress ? solanaTransport : undefined,
+              solanaTransport,
               solanaCapabilities,
             }
-          : svmAddress
-            ? {
-                status: "connected",
-                isConnected: true,
-                walletKind: undefined,
-                aaMode: undefined,
-                chainId: chainId ?? undefined,
-                svmAddress,
-                walletProvider,
-                authMethod,
-                authProvider: authMethod,
-                authValue,
-                primaryLabel:
-                  formatAddress(svmAddress) ?? "Connected Solana wallet",
-                secondaryLabel: "Solana",
-                solanaCluster: resolvedAdapterSolanaConfig.cluster,
-                solanaWalletName: solanaWallet.walletName,
-                solanaTransport,
-                solanaCapabilities,
-              }
-            : {
-                ...AOMI_AUTH_DISCONNECTED_IDENTITY,
-                chainId: chainId ?? undefined,
-                walletProvider,
-                authMethod,
-                authProvider: authMethod,
-                authValue,
-                solanaCluster: resolvedAdapterSolanaConfig.cluster,
-              };
+          : {
+              ...AOMI_AUTH_DISCONNECTED_IDENTITY,
+              chainId: chainId ?? undefined,
+              walletProvider,
+              authMethod,
+              authProvider: authMethod,
+              authValue,
+              solanaCluster: resolvedAdapterSolanaConfig.cluster,
+            };
 
     const connectorName = connector?.name?.toLowerCase() ?? "";
     const isParaWallet = connectorName.includes("para");
@@ -689,12 +687,12 @@ export function AomiParaAdapterProvider({
 
     const hasAnyDisconnectablePath = Boolean(
       wagmiDisconnectAsync ||
-        solanaWallet.disconnect ||
-        // Para's own session — `useParaClient().logout()` would also count
-        // here, but Para's logout has cross-tab implications so we
-        // currently leave it to `openAccountUI` (the Para account modal
-        // has a Disconnect button) and only handle wagmi + Solana below.
-        false,
+      solanaWallet.disconnect ||
+      // Para's own session — `useParaClient().logout()` would also count
+      // here, but Para's logout has cross-tab implications so we
+      // currently leave it to `openAccountUI` (the Para account modal
+      // has a Disconnect button) and only handle wagmi + Solana below.
+      false,
     );
 
     // Map the wallet-adapter's `wallets` array to our descriptor shape so
@@ -829,7 +827,10 @@ export function AomiParaAdapterProvider({
             try {
               await wagmiDisconnectAsync(connector ? { connector } : undefined);
             } catch (error) {
-              console.warn("[aomi-auth-adapter] EVM account disconnect failed", error);
+              console.warn(
+                "[aomi-auth-adapter] EVM account disconnect failed",
+                error,
+              );
             }
             return;
           }
@@ -868,10 +869,7 @@ export function AomiParaAdapterProvider({
           try {
             await wagmiDisconnectAsync();
           } catch (error) {
-            console.warn(
-              "[aomi-auth-adapter] Wagmi disconnect failed",
-              error,
-            );
+            console.warn("[aomi-auth-adapter] Wagmi disconnect failed", error);
           }
         }
 
@@ -1194,15 +1192,39 @@ function resolveParaAuthValue(
   authMethod: AomiAuthMethod | undefined,
 ): string | undefined {
   if (authMethod === "telegram") {
-    return embedded.telegramUserId;
+    return embedded.telegramUserId ?? embedded.auth?.telegramUserId;
   }
   if (authMethod === "farcaster") {
-    return embedded.farcasterUsername;
+    return embedded.farcasterUsername ?? embedded.auth?.farcasterUsername;
   }
-  if (!authMethod || authMethod === "wagmi") {
+  if (authMethod === "phone") {
+    return embedded.phone ?? embedded.auth?.phone;
+  }
+  if (authMethod === "wagmi") {
+    return (
+      embedded.externalWalletAddress ?? embedded.auth?.externalWalletAddress
+    );
+  }
+  if (!authMethod) {
     return undefined;
   }
-  return embedded.email;
+  return embedded.email ?? embedded.auth?.email ?? embedded.identifier;
+}
+
+function inferParaAuthMethod(
+  embedded: ParaAccountShape["embedded"],
+): AomiAuthMethod | undefined {
+  const authMethod = inferAuthMethod(embedded.authMethods);
+  if (authMethod) return authMethod;
+
+  const normalizedAuthType = embedded.authType?.toLowerCase();
+  if (!normalizedAuthType) return undefined;
+  if (normalizedAuthType === "externalwallet") return "wagmi";
+  if (normalizedAuthType === "email") return "email";
+  if (normalizedAuthType === "phone") return "phone";
+  if (normalizedAuthType === "farcaster") return "farcaster";
+  if (normalizedAuthType === "telegram") return "telegram";
+  return undefined;
 }
 
 export function AomiParaProvider(props: AomiParaProviderProps) {

--- a/memory/2026-06-09.md
+++ b/memory/2026-06-09.md
@@ -1,0 +1,4 @@
+# 2026-06-09
+
+- Fixed the Para frontend adapter so completed Google OAuth sessions count as connected even before Para exposes an EVM/Solana wallet address. The adapter now reads Para's embedded account fields (`auth`, `authType`, `identifier`, `userId`, and typed wallet entries), labels Google sessions from the auth value, and only marks EVM wallet fields/AA mode when an EVM address exists.
+- Added a registry regression test covering the Google custodial/embedded Para session shape with no wallet address yet, preventing the UI from staying in the login/spinner state after OAuth completes.


### PR DESCRIPTION
## Summary

Fixes the Para Google custodial sign-in hang by treating completed embedded Para sessions as connected even before Para exposes an EVM wallet address.

Changes:
- widen the Para account shape to cover newer embedded account fields (`embedded.isConnected`, `auth`, `authType`, `identifier`, `userId`, typed wallet entries)
- derive the Aomi identity from completed embedded auth, while only setting EVM wallet fields/AA mode once an EVM address exists
- add a regression test for a Google OAuth Para account with no wallet address yet
- record the completed work in `memory/2026-06-09.md`

## Root Cause

The adapter previously required either an older embedded primary field or an address-oriented account shape before producing a connected Aomi identity. Para Google custodial/embedded login can complete OAuth while wallet addresses are not ready or not surfaced in that older shape yet, leaving the UI in a login/spinner state.

## Validation

- `pnpm --dir apps/registry exec vitest run src/lib/aomi-auth-adapter/providers/para.test.tsx`
- `pnpm run build:registry`
- Manually ran the landing app locally against `127.0.0.1:8080` and verified the Para modal path opens
- Manually ran the chat portal locally against `127.0.0.1:8080` and verified the chat frame plus model/app controls load

## Staging / Prod Notes

For first-party web deployments, no backend change or npm publish should be required as long as staging/prod rebuild from this commit:

- `apps/portal/next.config.ts` aliases `@aomi-labs/widget-lib` directly to `apps/registry/src/index.ts`, so the portal picks up this source change during its Next build.
- `apps/landing/vercel.json` runs `pnpm -w run vercel-build`; the root `vercel-build` runs `build:registry` and copies `apps/registry/dist` into `apps/landing/public/r`, so the hosted registry JSON is regenerated during deploy.

Make sure staging/prod envs still have the expected Para/WalletConnect/backend values (`NEXT_PUBLIC_PARA_API_KEY`, `NEXT_PUBLIC_PARA_ENVIRONMENT`, `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` or `NEXT_PUBLIC_PROJECT_ID`, and the correct backend URL/proxy target). External consumers using a published npm package or static registry artifact would need that artifact rebuilt/published from this commit.