### PR TITLE
feat(portal): onboarding deploy picker + two GitHub-App paths

### DIFF
--- a/apps/portal/src/app/api/onboard/deploy/route.ts
+++ b/apps/portal/src/app/api/onboard/deploy/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+
+// =============================================================================
+// Onboarding deploy — BFF seam (STUB, pending the backend application_id
+// contract; backend work owned by Codex).
+//
+// The FE onboarding flow calls this once a GitHub App installation exists.
+//
+//   Request  { path: "oneshot" | "bootstrap",
+//              installationId: string,
+//              repo?: string,        // owner/name (bootstrap supplies it;
+//                                    //  oneshot creates it backend-side)
+//              actor?: string }
+//
+//   Response { repo: string,         // owner/name actually deployed
+//              releaseTag: string,
+//              applicationId?: string }  // opaque backend app identity
+//
+// Backend should: resolve the installation -> token, (oneshot) create the repo
+// from aomi-labs/playground-example via the broad App, deploy source-bound, and
+// return the release tag + application id. The runtime stays agnostic to which
+// App — addressing is by application identity, not GitHub installation. The FE
+// then polls /api/onboard/status until the release is live.
+// =============================================================================
+export async function POST(req: Request) {
+  const body = (await req.json().catch(() => ({}))) as {
+    path?: string;
+    installationId?: string;
+    repo?: string;
+    actor?: string;
+  };
+
+  if (!body.installationId) {
+    return NextResponse.json(
+      { error: "missing `installationId`" },
+      { status: 400 },
+    );
+  }
+
+  // Dev-only mock so the picker → wizard → live flow is exercisable in-browser
+  // before the real backend lands. Off by default; never set in production.
+  if (process.env.APP_ONBOARD_MOCK === "1") {
+    const repo = body.repo || "your-account/playground-example";
+    const releaseTag = `apps-playground-example-${Date.now()}`;
+    return NextResponse.json({ repo, releaseTag, applicationId: "mock-app-1" });
+  }
+
+  return NextResponse.json(
+    {
+      error:
+        "Onboarding deploy is not wired yet — pending the backend application_id contract.",
+    },
+    { status: 501 },
+  );
+}

--- a/apps/portal/src/app/api/onboard/status/route.ts
+++ b/apps/portal/src/app/api/onboard/status/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+
+// =============================================================================
+// Onboarding deploy status — BFF seam (STUB, pending backend; Codex).
+//
+//   GET /api/onboard/status?releaseTag=<tag>
+//
+//   Response { state: "building" | "activating" | "live" | "failed",
+//              releaseTag: string,
+//              message?: string }
+//
+// Backend should report release/activation progress for an in-flight onboarding
+// deploy keyed by release tag, returning "live" once the app is loaded and
+// serving. The FE polls this until live (or failed).
+// =============================================================================
+export async function GET(req: Request) {
+  const releaseTag = new URL(req.url).searchParams.get("releaseTag");
+  if (!releaseTag) {
+    return NextResponse.json(
+      { error: "missing `releaseTag`" },
+      { status: 400 },
+    );
+  }
+
+  // Dev-only mock (see deploy route). The mock release tag embeds its start
+  // time; report ~6s of "building" then "live" so the poll UI is visible.
+  if (process.env.APP_ONBOARD_MOCK === "1") {
+    const m = releaseTag.match(/-(\d{10,})$/);
+    const startMs = m ? Number(m[1]) : 0;
+    const state = Date.now() - startMs < 6000 ? "building" : "live";
+    return NextResponse.json({ state, releaseTag });
+  }
+
+  return NextResponse.json(
+    {
+      error:
+        "Onboarding status is not wired yet — pending the backend application_id contract.",
+    },
+    { status: 501 },
+  );
+}

--- a/apps/portal/src/components/settings/onboarding/bootstrap-wizard.tsx
+++ b/apps/portal/src/components/settings/onboarding/bootstrap-wizard.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useState } from "react";
+import { ExternalLink, Check } from "lucide-react";
+import { Button, Input } from "@aomi-labs/widget-lib";
+import {
+  bootstrapStep,
+  normalizeRepo,
+  TEMPLATE_GENERATE_URL,
+  type PathProgress,
+} from "@portal/lib/onboarding";
+import { Stepper } from "./stepper";
+import { DeployStep } from "./deploy-step";
+import { LivePanel } from "./live-panel";
+import { WizardHeader } from "./oneshot-wizard";
+
+const STEPS = [
+  { key: "template", label: "Template" },
+  { key: "install", label: "Install" },
+  { key: "deploy", label: "Deploy" },
+  { key: "live", label: "Live" },
+];
+
+export function BootstrapWizard({
+  progress,
+  actor,
+  onBack,
+  beginInstall,
+  patch,
+}: {
+  progress: PathProgress;
+  actor?: string;
+  onBack: () => void;
+  beginInstall: () => void;
+  patch: (patch: Partial<PathProgress>) => void;
+}) {
+  const step = bootstrapStep(progress);
+  const [repoInput, setRepoInput] = useState("");
+  const [repoError, setRepoError] = useState<string | null>(null);
+
+  const confirmRepo = () => {
+    const repo = normalizeRepo(repoInput);
+    if (!repo) {
+      setRepoError("Enter your repo as owner/name.");
+      return;
+    }
+    setRepoError(null);
+    patch({ repo });
+  };
+
+  return (
+    <div className="space-y-6">
+      <WizardHeader
+        title="Fork & customize"
+        subtitle="Make your own repo from our template, then we deploy it."
+        onBack={onBack}
+      />
+
+      <Stepper steps={STEPS} current={step} />
+
+      {(progress.repo || progress.installationId) && (
+        <div className="text-muted-foreground flex flex-wrap gap-x-6 gap-y-1 text-xs">
+          {progress.repo && (
+            <span>
+              repo <code className="text-foreground">{progress.repo}</code>
+            </span>
+          )}
+          {progress.installationId && (
+            <span>
+              installation{" "}
+              <code className="text-foreground">{progress.installationId}</code>
+            </span>
+          )}
+        </div>
+      )}
+
+      {step === "template" && (
+        <div className="border-input space-y-3 rounded-2xl border p-4">
+          <div className="text-foreground text-sm font-medium">
+            Step 1 — Create your repo from the template
+          </div>
+          <p className="text-muted-foreground text-sm leading-5">
+            Opens GitHub&apos;s “Use this template”. Name it whatever you like,
+            then paste it back here.
+          </p>
+          <a
+            href={TEMPLATE_GENERATE_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="bg-foreground text-background inline-flex h-10 items-center rounded-full px-4 text-sm font-medium"
+          >
+            Use this template <ExternalLink className="ml-1 h-4 w-4" />
+          </a>
+          <div className="flex items-start gap-2 pt-1">
+            <div className="flex-1">
+              <Input
+                value={repoInput}
+                onChange={(e) => setRepoInput(e.target.value)}
+                placeholder="your-account/my-agent"
+                onKeyDown={(e) => e.key === "Enter" && confirmRepo()}
+              />
+              {repoError && (
+                <p className="mt-1 pl-1 text-xs text-red-500">{repoError}</p>
+              )}
+            </div>
+            <Button
+              onClick={confirmRepo}
+              disabled={!repoInput.trim()}
+              className="h-10 rounded-full px-4 text-sm font-medium"
+            >
+              <Check className="mr-1 h-4 w-4" /> Confirm
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {step === "install" && progress.repo && (
+        <div className="border-input space-y-3 rounded-2xl border p-4">
+          <div className="text-foreground text-sm font-medium">
+            Step 2 — Install the Aomi GitHub App on your repo
+          </div>
+          <p className="text-muted-foreground text-sm leading-5">
+            Installs the narrow <code>aomi-build</code> App (one repo: contents,
+            pull requests & checks) on <code>{progress.repo}</code>.
+            You&apos;ll return here automatically after consent.
+          </p>
+          <Button
+            onClick={beginInstall}
+            className="h-10 rounded-full px-4 text-sm font-medium"
+          >
+            Install on GitHub <ExternalLink className="ml-1 h-4 w-4" />
+          </Button>
+        </div>
+      )}
+
+      {step === "deploy" && progress.installationId && (
+        <div className="border-input space-y-3 rounded-2xl border p-4">
+          <div className="text-foreground text-sm font-medium">
+            Step 3 — Deploy your app
+          </div>
+          <DeployStep
+            path="bootstrap"
+            installationId={progress.installationId}
+            repo={progress.repo}
+            actor={actor}
+            active
+            releaseTag={progress.releaseTag}
+            onDeployStarted={(r) =>
+              patch({
+                repo: r.repo,
+                releaseTag: r.releaseTag,
+                applicationId: r.applicationId,
+              })
+            }
+            onLive={(r) =>
+              patch({
+                repo: r.repo,
+                releaseTag: r.releaseTag,
+                applicationId: r.applicationId,
+                live: true,
+              })
+            }
+          />
+        </div>
+      )}
+
+      {step === "live" && <LivePanel repo={progress.repo} />}
+    </div>
+  );
+}

--- a/apps/portal/src/components/settings/onboarding/deploy-step.tsx
+++ b/apps/portal/src/components/settings/onboarding/deploy-step.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Loader2, AlertTriangle, RotateCcw } from "lucide-react";
+import { Button } from "@aomi-labs/widget-lib";
+import {
+  onboardDeploy,
+  onboardStatus,
+  type OnboardingPath,
+} from "@portal/lib/onboarding";
+
+type Phase = "deploying" | "building" | "live" | "error";
+
+/**
+ * The one backend-coupled step, shared by both wizards. Auto-starts once it
+ * becomes the active step: kicks off the deploy, then polls until the release
+ * is live. Reports results up so the parent can persist them.
+ *
+ * The deploy/status calls hit /api/onboard/* — currently 501 stubs pending the
+ * backend's application_id contract. Until those land, this renders a clear
+ * "backend wiring pending" notice with a retry, and the GitHub-side steps above
+ * stay fully functional.
+ */
+export function DeployStep({
+  path,
+  installationId,
+  repo,
+  actor,
+  active,
+  releaseTag,
+  onDeployStarted,
+  onLive,
+}: {
+  path: OnboardingPath;
+  installationId: string;
+  repo?: string;
+  actor?: string;
+  active: boolean;
+  /** Set if a deploy was already kicked off (resume after reload). */
+  releaseTag?: string;
+  /** Fires when the deploy is accepted (repo + releaseTag known) — persist this
+   *  so a reload resumes polling rather than re-running create. */
+  onDeployStarted: (result: {
+    repo: string;
+    releaseTag: string;
+    applicationId?: string;
+  }) => void;
+  onLive: (result: {
+    repo: string;
+    releaseTag: string;
+    applicationId?: string;
+  }) => void;
+}) {
+  const [phase, setPhase] = useState<Phase>(releaseTag ? "building" : "deploying");
+  const [tag, setTag] = useState<string | undefined>(releaseTag);
+  const [resolvedRepo, setResolvedRepo] = useState<string | undefined>(repo);
+  const [appId, setAppId] = useState<string | undefined>(undefined);
+  const [error, setError] = useState<string | null>(null);
+  const [attempt, setAttempt] = useState(0);
+  const startedRef = useRef(false);
+  const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // 1. Kick off the deploy once, when this becomes the active step.
+  useEffect(() => {
+    if (!active || startedRef.current || tag) return;
+    startedRef.current = true;
+    setPhase("deploying");
+    setError(null);
+    (async () => {
+      try {
+        const result = await onboardDeploy({ path, installationId, repo, actor });
+        setTag(result.releaseTag);
+        setResolvedRepo(result.repo);
+        setAppId(result.applicationId);
+        onDeployStarted(result);
+        setPhase("building");
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+        setPhase("error");
+      }
+    })();
+  }, [active, tag, path, installationId, repo, actor, attempt, onDeployStarted]);
+
+  // 2. Poll until the release is live.
+  useEffect(() => {
+    if (phase !== "building" || !tag) return;
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const s = await onboardStatus(tag);
+        if (cancelled) return;
+        if (s.state === "live") {
+          setPhase("live");
+          onLive({
+            repo: resolvedRepo ?? repo ?? "",
+            releaseTag: tag,
+            applicationId: appId,
+          });
+          return;
+        }
+        if (s.state === "failed") {
+          setError(s.message ?? "Build failed.");
+          setPhase("error");
+          return;
+        }
+        pollRef.current = setTimeout(tick, 4000);
+      } catch (e) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : String(e));
+        setPhase("error");
+      }
+    };
+    pollRef.current = setTimeout(tick, 2000);
+    return () => {
+      cancelled = true;
+      if (pollRef.current) clearTimeout(pollRef.current);
+    };
+  }, [phase, tag, resolvedRepo, repo, appId, onLive]);
+
+  const retry = useCallback(() => {
+    startedRef.current = false;
+    setTag(undefined);
+    setError(null);
+    setPhase("deploying");
+    setAttempt((n) => n + 1);
+  }, []);
+
+  if (phase === "error") {
+    return (
+      <div className="space-y-3 rounded-xl border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+        <div className="text-foreground flex items-start gap-2">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+          <div>
+            <div className="font-medium">Backend wiring pending</div>
+            <div className="text-muted-foreground mt-0.5 text-xs break-words">
+              {error}
+            </div>
+          </div>
+        </div>
+        <Button
+          onClick={retry}
+          className="h-8 rounded-full px-3 text-xs font-medium"
+        >
+          <RotateCcw className="mr-1 h-3.5 w-3.5" /> Retry
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-muted-foreground flex items-center gap-2 text-sm">
+      <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
+      {phase === "deploying"
+        ? path === "oneshot"
+          ? "Creating your repo and starting the deploy…"
+          : "Starting the deploy…"
+        : "Building release → activating…"}
+      {tag && <code className="text-foreground text-xs">{tag}</code>}
+    </div>
+  );
+}

--- a/apps/portal/src/components/settings/onboarding/live-panel.tsx
+++ b/apps/portal/src/components/settings/onboarding/live-panel.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { CheckCircle2, ExternalLink } from "lucide-react";
+import { TEMPLATE_REPO_URL } from "@portal/lib/onboarding";
+
+/** Shared success state. `repo` is owner/name when known; falls back to the
+ *  template so the clone story still renders during early wiring. */
+export function LivePanel({
+  repo,
+  chatUrl,
+}: {
+  repo?: string;
+  chatUrl?: string;
+}) {
+  const repoUrl = repo ? `https://github.com/${repo}` : TEMPLATE_REPO_URL;
+  const dir = repo ? repo.split("/")[1] : "playground-example";
+
+  return (
+    <div className="space-y-4 rounded-3xl border border-green-500/40 bg-green-500/10 p-6">
+      <div className="text-foreground flex items-center gap-2 font-medium">
+        <CheckCircle2 className="h-5 w-5 text-green-500" />
+        {repo ? (
+          <span>
+            <code>{repo}</code> is live in your chat session.
+          </span>
+        ) : (
+          <span>Your agent is live in your chat session.</span>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-muted-foreground text-sm">
+          Make it yours — clone, edit a tool, and redeploy:
+        </p>
+        <pre className="bg-background/60 overflow-x-auto rounded-xl p-3 text-xs leading-relaxed">
+          {`git clone ${repoUrl}.git
+cd ${dir}
+$EDITOR src/lib.rs     # copy the GreetTool pattern
+aomi-build deploy      # redeploy your changes`}
+        </pre>
+      </div>
+
+      <div className="flex flex-wrap gap-3 text-sm">
+        <a
+          href={repoUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="text-foreground inline-flex items-center gap-1 underline"
+        >
+          Open repo <ExternalLink className="h-3.5 w-3.5" />
+        </a>
+        {chatUrl && (
+          <a
+            href={chatUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-foreground inline-flex items-center gap-1 underline"
+          >
+            Open in chat <ExternalLink className="h-3.5 w-3.5" />
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/portal/src/components/settings/onboarding/onboarding.tsx
+++ b/apps/portal/src/components/settings/onboarding/onboarding.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useAomiAuthAdapter } from "@aomi-labs/widget-lib";
+import {
+  loadOnboarding,
+  saveOnboarding,
+  readGithubRedirect,
+  newStateToken,
+  appInstallUrl,
+  withPath,
+  withProgress,
+  withPendingInstall,
+  GITHUB_REDIRECT_KEYS,
+  type OnboardingState,
+  type OnboardingPath,
+  type PathProgress,
+} from "@portal/lib/onboarding";
+import { Picker } from "./picker";
+import { OneshotWizard } from "./oneshot-wizard";
+import { BootstrapWizard } from "./bootstrap-wizard";
+
+export function Onboarding() {
+  const adapter = useAomiAuthAdapter();
+  const actor = adapter.identity.address ?? undefined;
+
+  const [state, setState] = useState<OnboardingState>(() => loadOnboarding());
+
+  const update = useCallback((next: OnboardingState) => {
+    setState(next);
+    saveOnboarding(next);
+  }, []);
+
+  // --- hydrate the GitHub install redirect (runs once) ----------------------
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const redirect = readGithubRedirect(window.location.search);
+    if (!redirect) return;
+
+    const cur = loadOnboarding();
+    // Match the redirect to the path that started it via the state token; fall
+    // back to whatever path is currently selected.
+    const matched =
+      cur.pendingInstall && cur.pendingInstall.token === redirect.state
+        ? cur.pendingInstall.path
+        : cur.path;
+    if (matched) {
+      const next = withPendingInstall(
+        withProgress(withPath(cur, matched), matched, {
+          installationId: redirect.installationId,
+        }),
+        null,
+      );
+      update(next);
+    }
+
+    // Strip GitHub's params so a refresh doesn't re-trigger hydration.
+    const url = new URL(window.location.href);
+    let changed = false;
+    for (const key of GITHUB_REDIRECT_KEYS) {
+      if (url.searchParams.has(key)) {
+        url.searchParams.delete(key);
+        changed = true;
+      }
+    }
+    if (changed) window.history.replaceState({}, "", url.toString());
+    // `update` is a stable useCallback ([] deps), so this still runs once.
+  }, [update]);
+
+  // --- actions handed to the picker / wizards -------------------------------
+  const choose = useCallback(
+    (path: OnboardingPath) => update(withPath(state, path)),
+    [state, update],
+  );
+
+  const back = useCallback(
+    () => update(withPath(state, null)),
+    [state, update],
+  );
+
+  const makePatch = useCallback(
+    (path: OnboardingPath) => (patch: Partial<PathProgress>) =>
+      update(withProgress(state, path, patch)),
+    [state, update],
+  );
+
+  // Persist the pending-install token BEFORE leaving for github.com, so we can
+  // match the redirect when we come back.
+  const makeBeginInstall = useCallback(
+    (path: OnboardingPath) => () => {
+      const token = newStateToken();
+      const next = withPendingInstall(withPath(state, path), { token, path });
+      saveOnboarding(next);
+      setState(next);
+      window.location.assign(appInstallUrl(path, token));
+    },
+    [state],
+  );
+
+  if (!state.path) {
+    return <Picker onChoose={choose} />;
+  }
+
+  if (state.path === "oneshot") {
+    return (
+      <OneshotWizard
+        progress={state.oneshot}
+        actor={actor}
+        onBack={back}
+        beginInstall={makeBeginInstall("oneshot")}
+        patch={makePatch("oneshot")}
+      />
+    );
+  }
+
+  return (
+    <BootstrapWizard
+      progress={state.bootstrap}
+      actor={actor}
+      onBack={back}
+      beginInstall={makeBeginInstall("bootstrap")}
+      patch={makePatch("bootstrap")}
+    />
+  );
+}

--- a/apps/portal/src/components/settings/onboarding/oneshot-wizard.tsx
+++ b/apps/portal/src/components/settings/onboarding/oneshot-wizard.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { ExternalLink, ArrowLeft } from "lucide-react";
+import { Button } from "@aomi-labs/widget-lib";
+import {
+  oneshotStep,
+  type PathProgress,
+} from "@portal/lib/onboarding";
+import { Stepper } from "./stepper";
+import { DeployStep } from "./deploy-step";
+import { LivePanel } from "./live-panel";
+
+const STEPS = [
+  { key: "install", label: "Install" },
+  { key: "create", label: "Create" },
+  { key: "build", label: "Build" },
+  { key: "live", label: "Live" },
+];
+
+export function OneshotWizard({
+  progress,
+  actor,
+  onBack,
+  beginInstall,
+  patch,
+}: {
+  progress: PathProgress;
+  actor?: string;
+  onBack: () => void;
+  beginInstall: () => void;
+  patch: (patch: Partial<PathProgress>) => void;
+}) {
+  const step = oneshotStep(progress);
+
+  return (
+    <div className="space-y-6">
+      <WizardHeader
+        title="One-click"
+        subtitle="We create the repo and deploy it for you."
+        onBack={onBack}
+      />
+
+      <Stepper steps={STEPS} current={step} />
+
+      {/* completed-fact summary */}
+      {(progress.installationId || progress.repo) && (
+        <div className="text-muted-foreground flex flex-wrap gap-x-6 gap-y-1 text-xs">
+          {progress.installationId && (
+            <span>
+              installation{" "}
+              <code className="text-foreground">{progress.installationId}</code>
+            </span>
+          )}
+          {progress.repo && (
+            <span>
+              repo <code className="text-foreground">{progress.repo}</code>
+            </span>
+          )}
+        </div>
+      )}
+
+      {step === "install" && (
+        <div className="border-input space-y-3 rounded-2xl border p-4">
+          <div className="text-foreground text-sm font-medium">
+            Step 1 — Install the Aomi GitHub App
+          </div>
+          <p className="text-muted-foreground text-sm leading-5">
+            Installs <code>aomi-build-oneshot</code>. It can create a repo in
+            your account from our template and open deploy pull requests.
+            You&apos;ll return here automatically after consent.
+          </p>
+          <Button
+            onClick={beginInstall}
+            className="h-10 rounded-full px-4 text-sm font-medium"
+          >
+            Install on GitHub <ExternalLink className="ml-1 h-4 w-4" />
+          </Button>
+        </div>
+      )}
+
+      {(step === "create" || step === "build") && progress.installationId && (
+        <div className="border-input space-y-3 rounded-2xl border p-4">
+          <div className="text-foreground text-sm font-medium">
+            Step 2–3 — Create from template & build
+          </div>
+          <DeployStep
+            path="oneshot"
+            installationId={progress.installationId}
+            repo={progress.repo}
+            actor={actor}
+            active
+            releaseTag={progress.releaseTag}
+            onDeployStarted={(r) =>
+              patch({
+                repo: r.repo,
+                releaseTag: r.releaseTag,
+                applicationId: r.applicationId,
+              })
+            }
+            onLive={(r) =>
+              patch({
+                repo: r.repo,
+                releaseTag: r.releaseTag,
+                applicationId: r.applicationId,
+                live: true,
+              })
+            }
+          />
+        </div>
+      )}
+
+      {step === "live" && <LivePanel repo={progress.repo} />}
+    </div>
+  );
+}
+
+function WizardHeader({
+  title,
+  subtitle,
+  onBack,
+}: {
+  title: string;
+  subtitle: string;
+  onBack: () => void;
+}) {
+  return (
+    <header className="space-y-2">
+      <button
+        type="button"
+        onClick={onBack}
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-sm"
+      >
+        <ArrowLeft className="h-4 w-4" /> Back
+      </button>
+      <h1 className="text-foreground text-2xl font-semibold tracking-tight">
+        {title}
+      </h1>
+      <p className="text-muted-foreground text-sm">{subtitle}</p>
+    </header>
+  );
+}
+
+export { WizardHeader };

--- a/apps/portal/src/components/settings/onboarding/picker.tsx
+++ b/apps/portal/src/components/settings/onboarding/picker.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Zap, Wrench, ArrowRight } from "lucide-react";
+import type { OnboardingPath } from "@portal/lib/onboarding";
+
+type CardSpec = {
+  path: OnboardingPath;
+  icon: typeof Zap;
+  title: string;
+  blurb: string;
+  grants: string;
+};
+
+const CARDS: CardSpec[] = [
+  {
+    path: "oneshot",
+    icon: Zap,
+    title: "One-click",
+    blurb:
+      "We create the repo in your account and deploy it for you. Fastest path to a live agent.",
+    grants: "broad — can create repositories",
+  },
+  {
+    path: "bootstrap",
+    icon: Wrench,
+    title: "Fork & customize",
+    blurb:
+      "You make your own repo from our template, then we deploy it. A few more steps, narrower access.",
+    grants: "narrow — one repo, pull requests & checks",
+  },
+];
+
+export function Picker({
+  onChoose,
+}: {
+  onChoose: (path: OnboardingPath) => void;
+}) {
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-foreground text-2xl font-semibold tracking-tight">
+          Deploy an example agent
+        </h1>
+        <p className="text-muted-foreground max-w-2xl text-sm leading-5">
+          Get a working Aomi agent running in your account, then clone it and
+          make it yours. Pick how much access you want to grant.
+        </p>
+      </header>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {CARDS.map((card) => (
+          <button
+            key={card.path}
+            type="button"
+            onClick={() => onChoose(card.path)}
+            className="border-input bg-background hover:border-foreground/30 hover:bg-muted/30 group flex flex-col gap-3 rounded-3xl border p-6 text-left transition-colors"
+          >
+            <div className="flex items-center gap-2">
+              <card.icon className="text-foreground h-5 w-5" />
+              <span className="text-foreground text-lg font-medium">
+                {card.title}
+              </span>
+            </div>
+            <p className="text-muted-foreground min-h-[3.5rem] text-sm leading-5">
+              {card.blurb}
+            </p>
+            <div className="text-muted-foreground text-xs">
+              Grants:{" "}
+              <span className="text-foreground font-medium">{card.grants}</span>
+            </div>
+            <span className="text-foreground mt-1 inline-flex items-center gap-1 text-sm font-medium">
+              Choose
+              <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/portal/src/components/settings/onboarding/stepper.tsx
+++ b/apps/portal/src/components/settings/onboarding/stepper.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { CheckCircle2, Loader2, Circle, XCircle } from "lucide-react";
+
+export type StepStatus = "done" | "active" | "pending" | "failed";
+
+/** Horizontal dots: ●━━○━━○ with labels underneath. */
+export function Stepper({
+  steps,
+  current,
+  failed,
+}: {
+  steps: { key: string; label: string }[];
+  current: string;
+  failed?: boolean;
+}) {
+  const currentIndex = steps.findIndex((s) => s.key === current);
+  return (
+    <ol className="flex items-center">
+      {steps.map((step, i) => {
+        const status: StepStatus =
+          i < currentIndex
+            ? "done"
+            : i === currentIndex
+              ? failed
+                ? "failed"
+                : "active"
+              : "pending";
+        return (
+          <li key={step.key} className="flex flex-1 items-center last:flex-none">
+            <div className="flex flex-col items-center gap-1">
+              <Dot status={status} />
+              <span
+                className={
+                  status === "pending"
+                    ? "text-muted-foreground/60 text-xs"
+                    : "text-foreground text-xs font-medium"
+                }
+              >
+                {step.label}
+              </span>
+            </div>
+            {i < steps.length - 1 && (
+              <div
+                className={`mx-2 mb-5 h-px flex-1 ${
+                  i < currentIndex ? "bg-foreground/40" : "bg-border"
+                }`}
+              />
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function Dot({ status }: { status: StepStatus }) {
+  if (status === "done")
+    return <CheckCircle2 className="h-5 w-5 text-green-500" />;
+  if (status === "failed") return <XCircle className="h-5 w-5 text-red-500" />;
+  if (status === "active")
+    return <Loader2 className="h-5 w-5 animate-spin text-blue-500" />;
+  return <Circle className="text-muted-foreground/40 h-5 w-5" />;
+}
+
+/** A bordered step block, dimmed until it's the active step (or done). */
+export function StepCard({
+  index,
+  title,
+  state,
+  children,
+}: {
+  index: number;
+  title: string;
+  state: StepStatus;
+  children?: ReactNode;
+}) {
+  const dim = state === "pending";
+  return (
+    <div
+      className={`border-input rounded-2xl border p-4 ${
+        dim ? "opacity-50" : ""
+      }`}
+    >
+      <div className="flex items-center gap-2">
+        <StepBadge index={index} state={state} />
+        <span className="text-foreground text-sm font-medium">{title}</span>
+      </div>
+      {children && <div className="mt-3">{children}</div>}
+    </div>
+  );
+}
+
+function StepBadge({ index, state }: { index: number; state: StepStatus }) {
+  if (state === "done")
+    return <CheckCircle2 className="h-4 w-4 shrink-0 text-green-500" />;
+  if (state === "failed")
+    return <XCircle className="h-4 w-4 shrink-0 text-red-500" />;
+  if (state === "active")
+    return <Loader2 className="h-4 w-4 shrink-0 animate-spin text-blue-500" />;
+  return (
+    <span className="border-border text-muted-foreground flex h-4 w-4 shrink-0 items-center justify-center rounded-full border text-[10px]">
+      {index}
+    </span>
+  );
+}

--- a/apps/portal/src/components/settings/settings-layout.tsx
+++ b/apps/portal/src/components/settings/settings-layout.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { SettingsSidebar, SettingsCategory } from "./settings-sidebar";
 import { GeneralSettings } from "./general-settings";
 import { AppsSettings } from "./apps-settings";
 import { DeploySettings } from "./deploy-settings";
+import { Onboarding } from "./onboarding/onboarding";
 import { AppKeys } from "./app-keys";
 import { Bots } from "./bots";
 import { Secrets } from "./secrets";
@@ -14,6 +15,17 @@ export function SettingsLayout() {
   const [activeCategory, setActiveCategory] =
     useState<SettingsCategory>("general");
 
+  // Returning from a GitHub App install lands on /settings?installation_id=…
+  // (category is React state, not the URL), so open the Deploy tab where the
+  // onboarding flow can pick the redirect up.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.has("installation_id")) {
+      setActiveCategory("deploy");
+    }
+  }, []);
+
   const renderContent = () => {
     switch (activeCategory) {
       case "general":
@@ -21,7 +33,18 @@ export function SettingsLayout() {
       case "apps":
         return <AppsSettings />;
       case "deploy":
-        return <DeploySettings />;
+        // Onboarding picker + two-path wizards on top; the manual / advanced
+        // deploy flow is preserved below, unchanged.
+        return (
+          <div className="min-w-0 space-y-8">
+            <Onboarding />
+            <hr className="border-input" />
+            <p className="text-muted-foreground pl-4 text-xs uppercase tracking-wide">
+              Manual / advanced deploy
+            </p>
+            <DeploySettings />
+          </div>
+        );
       case "app-keys":
         return <AppKeys />;
       case "bots":

--- a/apps/portal/src/lib/onboarding.test.ts
+++ b/apps/portal/src/lib/onboarding.test.ts
@@ -1,0 +1,126 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// NOTE: vitest config excludes apps/**, so this is not run by CI. It documents
+// the onboarding state machine and is runnable locally with a TS-aware runner,
+// e.g. `npx tsx --test src/lib/onboarding.test.ts` from apps/portal.
+
+const moduleUrl = new URL("./onboarding.ts", import.meta.url).href;
+
+test("oneshotStep advances install → create → build → live", async () => {
+  const { oneshotStep } = await import(moduleUrl);
+  assert.equal(oneshotStep({}), "install");
+  assert.equal(oneshotStep({ installationId: "1" }), "create");
+  assert.equal(oneshotStep({ installationId: "1", repo: "a/b" }), "build");
+  assert.equal(
+    oneshotStep({ installationId: "1", repo: "a/b", releaseTag: "t" }),
+    "build",
+  );
+  assert.equal(
+    oneshotStep({ installationId: "1", repo: "a/b", live: true }),
+    "live",
+  );
+});
+
+test("bootstrapStep advances template → install → deploy → live", async () => {
+  const { bootstrapStep } = await import(moduleUrl);
+  assert.equal(bootstrapStep({}), "template");
+  assert.equal(bootstrapStep({ repo: "a/b" }), "install");
+  assert.equal(bootstrapStep({ repo: "a/b", installationId: "1" }), "deploy");
+  assert.equal(
+    bootstrapStep({ repo: "a/b", installationId: "1", live: true }),
+    "live",
+  );
+});
+
+test("normalizeRepo accepts owner/name, URLs, .git, trailing slash", async () => {
+  const { normalizeRepo } = await import(moduleUrl);
+  assert.equal(normalizeRepo("you/my-agent"), "you/my-agent");
+  assert.equal(normalizeRepo("  you/my-agent  "), "you/my-agent");
+  assert.equal(
+    normalizeRepo("https://github.com/you/my-agent"),
+    "you/my-agent",
+  );
+  assert.equal(normalizeRepo("https://github.com/you/my-agent.git"), "you/my-agent");
+  assert.equal(normalizeRepo("you/my-agent/"), "you/my-agent");
+  assert.equal(normalizeRepo("not-a-repo"), null);
+  assert.equal(normalizeRepo(""), null);
+});
+
+test("readGithubRedirect parses installation_id + state + setup_action", async () => {
+  const { readGithubRedirect } = await import(moduleUrl);
+  assert.equal(readGithubRedirect("?foo=bar"), null);
+  assert.deepEqual(
+    readGithubRedirect("?installation_id=42&setup_action=install&state=tok"),
+    { installationId: "42", setupAction: "install", state: "tok" },
+  );
+  assert.deepEqual(readGithubRedirect("?installation_id=42"), {
+    installationId: "42",
+    setupAction: null,
+    state: null,
+  });
+});
+
+test("appInstallUrl points at the right App slug and carries state", async () => {
+  const { appInstallUrl } = await import(moduleUrl);
+  const one = appInstallUrl("oneshot", "abc");
+  const boot = appInstallUrl("bootstrap", "xyz");
+  assert.match(one, /github\.com\/apps\/aomi-build-oneshot\/installations\/new/);
+  assert.match(one, /state=abc/);
+  assert.match(boot, /github\.com\/apps\/aomi-build\/installations\/new/);
+  assert.match(boot, /state=xyz/);
+});
+
+test("state transitions are immutable and correct", async () => {
+  const { withPath, withProgress, withPendingInstall } = await import(
+    moduleUrl
+  );
+  const base = { path: null, oneshot: {}, bootstrap: {}, pendingInstall: null };
+
+  const a = withPath(base, "oneshot");
+  assert.equal(a.path, "oneshot");
+  assert.equal(base.path, null); // original untouched
+
+  const b = withProgress(a, "oneshot", { installationId: "9" });
+  assert.deepEqual(b.oneshot, { installationId: "9" });
+  assert.deepEqual(a.oneshot, {}); // original untouched
+
+  const c = withPendingInstall(b, { token: "t", path: "oneshot" });
+  assert.deepEqual(c.pendingInstall, { token: "t", path: "oneshot" });
+  assert.equal(withPendingInstall(c, null).pendingInstall, null);
+});
+
+test("load/save round-trips through a window.localStorage stub", async () => {
+  const store = new Map<string, string>();
+  const win = {
+    localStorage: {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+    },
+  } as unknown as Window & typeof globalThis;
+  globalThis.window = win;
+
+  const { loadOnboarding, saveOnboarding, withProgress } = await import(
+    moduleUrl
+  );
+  assert.deepEqual(loadOnboarding(), {
+    path: null,
+    oneshot: {},
+    bootstrap: {},
+    pendingInstall: null,
+  });
+
+  const next = withProgress(loadOnboarding(), "bootstrap", { repo: "me/app" });
+  saveOnboarding(next);
+  assert.equal(loadOnboarding().bootstrap.repo, "me/app");
+
+  (globalThis as { window?: unknown }).window = undefined;
+});
+
+test("GITHUB_REDIRECT_KEYS covers the params GitHub appends", async () => {
+  const { GITHUB_REDIRECT_KEYS } = await import(moduleUrl);
+  for (const k of ["installation_id", "setup_action", "state", "code"]) {
+    assert.ok(GITHUB_REDIRECT_KEYS.includes(k), `missing ${k}`);
+  }
+});

--- a/apps/portal/src/lib/onboarding.ts
+++ b/apps/portal/src/lib/onboarding.ts
@@ -1,0 +1,269 @@
+"use client";
+
+// =============================================================================
+// Onboarding state machine for the two "deploy an example" paths.
+//
+// Pure client module — it owns only the GitHub-side flow and its persistence:
+//   • localStorage so progress survives the full-page redirect to github.com
+//     and back (installing a GitHub App leaves the SPA entirely),
+//   • a CSRF/return token so we can match the redirect to the path that started
+//     it and resume on the right step,
+//   • deep-link builders for the App-install and "use this template" pages,
+//   • a per-path step resolver derived from accumulated progress.
+//
+// The deploy/create calls that need the backend (create-repo-from-template,
+// deploy-by-application-id) are NOT here — the wizards call /api/onboard/*,
+// which is the single seam pending the backend's opaque app-identity contract.
+// =============================================================================
+
+export type OnboardingPath = "oneshot" | "bootstrap";
+
+// --- config -----------------------------------------------------------------
+// App slugs are deployment-time config (they differ per environment, and the
+// one-shot App may not be registered yet), so they're overridable via env.
+const ONESHOT_SLUG =
+  process.env.NEXT_PUBLIC_AOMI_BUILD_ONESHOT_SLUG || "aomi-build-oneshot";
+const BOOTSTRAP_SLUG = process.env.NEXT_PUBLIC_AOMI_BUILD_SLUG || "aomi-build";
+
+export const TEMPLATE_REPO = "aomi-labs/playground-example";
+export const TEMPLATE_REPO_URL = `https://github.com/${TEMPLATE_REPO}`;
+export const TEMPLATE_GENERATE_URL = `${TEMPLATE_REPO_URL}/generate`;
+
+/** GitHub App install page. After consent, GitHub redirects back to the App's
+ *  configured Setup URL with `?installation_id=…&setup_action=…&state=<token>`. */
+export function appInstallUrl(path: OnboardingPath, state: string): string {
+  const slug = path === "oneshot" ? ONESHOT_SLUG : BOOTSTRAP_SLUG;
+  const params = new URLSearchParams({ state });
+  return `https://github.com/apps/${slug}/installations/new?${params.toString()}`;
+}
+
+/** Accept "owner/name" or a full github.com URL; return "owner/name" or null. */
+export function normalizeRepo(input: string): string | null {
+  const trimmed = input.trim().replace(/^https?:\/\/github\.com\//i, "");
+  const m = trimmed.match(/^([\w.-]+)\/([\w.-]+?)(?:\.git)?\/?$/);
+  return m ? `${m[1]}/${m[2]}` : null;
+}
+
+// --- per-path progress ------------------------------------------------------
+export type PathProgress = {
+  /** GitHub installation id, from the install-callback redirect. */
+  installationId?: string;
+  /** `owner/name` — created from the template (oneshot) or supplied by the
+   *  user (bootstrap). */
+  repo?: string;
+  /** Release tag emitted once a deploy has been kicked off. */
+  releaseTag?: string;
+  /** Opaque backend app identity (the application_id contract). */
+  applicationId?: string;
+  /** True once activation has succeeded and the app is serving. */
+  live?: boolean;
+};
+
+export type PendingInstall = {
+  token: string;
+  path: OnboardingPath;
+};
+
+export type OnboardingState = {
+  /** null → render the picker. */
+  path: OnboardingPath | null;
+  oneshot: PathProgress;
+  bootstrap: PathProgress;
+  /** The in-flight GitHub redirect we expect to come back, if any. */
+  pendingInstall: PendingInstall | null;
+};
+
+const STORAGE_KEY = "aomi_onboard";
+
+function empty(): OnboardingState {
+  return { path: null, oneshot: {}, bootstrap: {}, pendingInstall: null };
+}
+
+export function loadOnboarding(): OnboardingState {
+  if (typeof window === "undefined") return empty();
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return empty();
+    const parsed = JSON.parse(raw) as Partial<OnboardingState>;
+    return {
+      path: parsed.path ?? null,
+      oneshot: parsed.oneshot ?? {},
+      bootstrap: parsed.bootstrap ?? {},
+      pendingInstall: parsed.pendingInstall ?? null,
+    };
+  } catch {
+    return empty();
+  }
+}
+
+export function saveOnboarding(state: OnboardingState): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+export function resetOnboarding(): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(STORAGE_KEY);
+}
+
+// --- pure state transitions -------------------------------------------------
+export function progressOf(
+  state: OnboardingState,
+  path: OnboardingPath,
+): PathProgress {
+  return state[path];
+}
+
+export function withPath(
+  state: OnboardingState,
+  path: OnboardingPath | null,
+): OnboardingState {
+  return { ...state, path };
+}
+
+export function withProgress(
+  state: OnboardingState,
+  path: OnboardingPath,
+  patch: Partial<PathProgress>,
+): OnboardingState {
+  return { ...state, [path]: { ...state[path], ...patch } };
+}
+
+export function withPendingInstall(
+  state: OnboardingState,
+  pending: PendingInstall | null,
+): OnboardingState {
+  return { ...state, pendingInstall: pending };
+}
+
+// --- CSRF / return token ----------------------------------------------------
+export function newStateToken(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `s-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+// --- GitHub redirect parsing ------------------------------------------------
+export type GithubRedirect = {
+  installationId: string;
+  setupAction: string | null;
+  state: string | null;
+};
+
+/** Parse the `?installation_id=…&setup_action=…&state=…` GitHub appends to the
+ *  App's Setup URL after an install. Returns null if this isn't such a redirect. */
+export function readGithubRedirect(search: string): GithubRedirect | null {
+  const params = new URLSearchParams(search);
+  const installationId = params.get("installation_id");
+  if (!installationId) return null;
+  return {
+    installationId,
+    setupAction: params.get("setup_action"),
+    state: params.get("state"),
+  };
+}
+
+/** The query keys GitHub adds on redirect — stripped from the URL after we fold
+ *  them into state, so a refresh doesn't re-trigger hydration. */
+export const GITHUB_REDIRECT_KEYS = [
+  "installation_id",
+  "setup_action",
+  "state",
+  "code",
+] as const;
+
+// --- step resolvers ---------------------------------------------------------
+export type OneshotStep = "install" | "create" | "build" | "live";
+export type BootstrapStep = "template" | "install" | "deploy" | "live";
+
+export const ONESHOT_STEPS: OneshotStep[] = [
+  "install",
+  "create",
+  "build",
+  "live",
+];
+export const BOOTSTRAP_STEPS: BootstrapStep[] = [
+  "template",
+  "install",
+  "deploy",
+  "live",
+];
+
+export function oneshotStep(p: PathProgress): OneshotStep {
+  if (!p.installationId) return "install";
+  if (!p.repo) return "create";
+  if (!p.live) return "build";
+  return "live";
+}
+
+export function bootstrapStep(p: PathProgress): BootstrapStep {
+  if (!p.repo) return "template";
+  if (!p.installationId) return "install";
+  if (!p.live) return "deploy";
+  return "live";
+}
+
+// --- backend seam (pending the application_id contract) ---------------------
+// These hit /api/onboard/*, which is currently a 501 stub. The wizards surface
+// a clear "pending backend" state when it errors, so the GitHub-side flow stays
+// fully exercisable in the meantime.
+export type OnboardDeployInput = {
+  path: OnboardingPath;
+  installationId: string;
+  /** owner/name of the source repo (created or user-supplied). */
+  repo?: string;
+  actor?: string;
+};
+
+export type OnboardDeployResult = {
+  /** owner/name actually deployed (oneshot creates it backend-side). */
+  repo: string;
+  releaseTag: string;
+  applicationId?: string;
+};
+
+export async function onboardDeploy(
+  input: OnboardDeployInput,
+): Promise<OnboardDeployResult> {
+  const res = await fetch("/api/onboard/deploy", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  const json = (await res.json().catch(() => ({}))) as
+    | OnboardDeployResult
+    | { error?: string };
+  if (!res.ok) {
+    const msg =
+      "error" in json && json.error
+        ? json.error
+        : `onboarding deploy failed (${res.status})`;
+    throw new Error(msg);
+  }
+  return json as OnboardDeployResult;
+}
+
+export type OnboardStatus = {
+  state: "building" | "activating" | "live" | "failed";
+  releaseTag: string;
+  message?: string;
+};
+
+/** Poll release/activation progress for an in-flight onboarding deploy. */
+export async function onboardStatus(releaseTag: string): Promise<OnboardStatus> {
+  const res = await fetch(
+    `/api/onboard/status?releaseTag=${encodeURIComponent(releaseTag)}`,
+  );
+  const json = (await res.json().catch(() => ({}))) as
+    | OnboardStatus
+    | { error?: string };
+  if (!res.ok) {
+    const msg =
+      "error" in json && json.error
+        ? json.error
+        : `onboarding status failed (${res.status})`;
+    throw new Error(msg);
+  }
+  return json as OnboardStatus;
+}


### PR DESCRIPTION
## What

Adds the **"deploy an example agent"** onboarding flow to the portal's **Deploy** settings tab: a picker offering two consent experiences (each backed by its own GitHub App), then a resumable wizard per path.

| Path | App | Flow |
|---|---|---|
| **One-click** | broad `aomi-build-oneshot` | install → backend creates the repo from `aomi-labs/playground-example` & deploys |
| **Fork & customize** | narrow `aomi-build` | "Use this template" → install on your repo → deploy |

## How it works

- **State machine** (`src/lib/onboarding.ts`) persists to `localStorage` so progress survives the full-page redirect to github.com and back. A CSRF/return token matches the redirect to the path that started it and resumes on the right step.
- `settings-layout` opens the Deploy tab when GitHub returns with `?installation_id=` (category is React state, not the URL).
- Components: `picker` → `oneshot-wizard` / `bootstrap-wizard` → shared `stepper`, `deploy-step` (resumable build/poll), `live-panel`.

## Backend seam (for the BE work, owned by Codex)

The one backend-coupled step hits **`/api/onboard/{deploy,status}`** — currently **501 stubs** documenting the request/response contract (keyed on an opaque `application_id`, runtime agnostic to which App). A **dev-only mock** (`APP_ONBOARD_MOCK=1`, off by default) lets the full picker → wizard → live flow run in-browser before the backend lands.

## Scope / safety

- **Additive & decoupled**: mounts *above* the existing manual deploy flow (preserved unchanged); imports nothing from `@aomi-labs/deploy`, so it's independent of the in-flight deploy-package refactor.
- The companion template repo is live: https://github.com/aomi-labs/playground-example (public, `isTemplate`).

## Verification

- `tsc --noEmit` ✓ · `eslint .` ✓ (verified against this branch's base)
- `src/lib/onboarding.test.ts` — 8/8 pass (step resolvers, redirect parse, repo normalize, state transitions, deep-links, persistence). Runs locally; **vitest config excludes `apps/**`, so it does not run in CI**.

## Not in scope (follow-ups)

- BE: implement `/api/onboard/{deploy,status}` against the `application_id` contract.
- Register the `aomi-build-oneshot` GitHub App + set its slug via `NEXT_PUBLIC_AOMI_BUILD_ONESHOT_SLUG`.
- Real-BE E2E (blocked tonight: no local `.env.dev`/secrets to boot `scripts/dev.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)