### PR TITLE
Release @aomi-labs/client 0.1.41 (Privy login)

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/client",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "description": "Platform-agnostic TypeScript client for the Aomi backend API",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- Bumps `@aomi-labs/client` from `0.1.40` → `0.1.41`
- Releases the CLI with Privy login support that landed in #200

## Test plan

- [ ] `npm publish` / `pnpm publish` from `packages/client` after merge
- [ ] Confirm `aomi` CLI binary picks up Privy login flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)