### PR TITLE
Fix portal onboarding BFF runtime

### DIFF
--- a/apps/portal/src/app/api/onboard/activate/route.ts
+++ b/apps/portal/src/app/api/onboard/activate/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+
 import {
   activationEnv,
   type BackendActivationResult,

--- a/apps/portal/src/app/api/onboard/app/route.ts
+++ b/apps/portal/src/app/api/onboard/app/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+
 import {
   type BackendAppStatusResult,
   backendRequest,

--- a/apps/portal/src/app/api/onboard/create/route.ts
+++ b/apps/portal/src/app/api/onboard/create/route.ts
@@ -1,6 +1,8 @@
 import { randomBytes } from "crypto";
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+
 import {
   type BackendAppSourceResult,
   backendRequest,

--- a/apps/portal/src/app/api/onboard/deploy/route.ts
+++ b/apps/portal/src/app/api/onboard/deploy/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+
 import {
   appNamesFromDeployment,
   type BackendDeployResult,

--- a/apps/portal/src/app/api/onboard/dry-run/route.ts
+++ b/apps/portal/src/app/api/onboard/dry-run/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+
 import {
   appNamesFromDeployment,
   type BackendDeployResult,

--- a/apps/portal/src/app/api/onboard/status/route.ts
+++ b/apps/portal/src/app/api/onboard/status/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+
 import {
   type BackendDeploymentStatusResult,
   backendRequest,

--- a/apps/portal/src/app/api/onboard/sync-installed/route.ts
+++ b/apps/portal/src/app/api/onboard/sync-installed/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+
 import {
   type BackendAppSourceResult,
   backendRequest,

--- a/apps/portal/src/lib/onboard-deploy.ts
+++ b/apps/portal/src/lib/onboard-deploy.ts
@@ -95,7 +95,7 @@ export function readOnboardDeployEnv(): OnboardDeployEnv {
     .split(",")
     .map((path) => path.trim())
     .filter(Boolean);
-  const targetTags = (process.env.APP_DEPLOY_TARGET_TAGS || "staging")
+  const targetTags = (process.env.APP_DEPLOY_TARGET_TAGS || "")
     .split(",")
     .map((tag) => tag.trim())
     .filter(Boolean);

--- a/apps/registry/src/lib/aomi-auth-adapter/providers/base-account.tsx
+++ b/apps/registry/src/lib/aomi-auth-adapter/providers/base-account.tsx
@@ -216,7 +216,11 @@ function BaseAccountAdapterInner({
             sponsored: sponsorshipEnabled,
             sponsorProvider: sponsorshipEnabled ? "coinbase" : "self",
             sponsorAccount: undefined,
-            chainId: chainId ?? undefined,
+            // Fall back to the selected EVM network while wagmi hasn't resolved
+            // the connected chain, so the chain reported to the backend (via
+            // setUser) matches the network selector instead of defaulting to
+            // Ethereum mainnet server-side.
+            chainId: chainId ?? selectedEvmChainId,
             walletProvider: "baseAccount",
             authMethod: undefined,
           }

--- a/apps/registry/src/lib/aomi-auth-adapter/providers/para.tsx
+++ b/apps/registry/src/lib/aomi-auth-adapter/providers/para.tsx
@@ -637,7 +637,13 @@ export function AomiParaAdapterProvider({
             sponsored,
             sponsorProvider,
             sponsorAccount,
-            chainId: chainId ?? undefined,
+            // Fall back to the user's selected EVM network while wagmi hasn't
+            // resolved the connected chain yet. The network selector already
+            // shows `identity.chainId ?? selectedEvmChainId`; mirroring that
+            // here keeps the chain reported to the backend (via setUser) in
+            // sync with the UI, instead of leaving it undefined (which the
+            // backend silently treats as Ethereum mainnet).
+            chainId: chainId ?? (hasEvmAddress ? selectedEvmChainId : undefined),
             svmAddress,
             walletProvider,
             authMethod,

--- a/apps/registry/src/lib/aomi-auth-adapter/providers/privy.tsx
+++ b/apps/registry/src/lib/aomi-auth-adapter/providers/privy.tsx
@@ -409,7 +409,11 @@ function AomiPrivyAdapterProvider({
             status: "connected",
             isConnected: true,
             address: smartAddress,
-            chainId: chainId ?? undefined,
+            // Fall back to the selected EVM network while wagmi hasn't resolved
+            // the connected chain, so the chain reported to the backend (via
+            // setUser) matches the network selector instead of defaulting to
+            // Ethereum mainnet server-side.
+            chainId: chainId ?? selectedEvmChainId,
             svmAddress,
             walletProvider: "privy",
             authProvider,


### PR DESCRIPTION
## Summary
- pin onboarding BFF routes to the Node serverless runtime
- stop defaulting onboarding activations to the staging target tag
- configure chat-portal Vercel Production and Preview(main) envs for onboarding deploy calls

## Validation
- pnpm --filter portal lint
- pnpm --filter portal type-check
- env -u HTTPS_PROXY -u HTTP_PROXY -u ALL_PROXY -u https_proxy -u http_proxy -u all_proxy pnpm --filter portal build