### PR TITLE
Port #205 to prod: onboarding BFF runtime + wallet chain-identity fix

### DIFF
--- a/apps/portal/src/app/api/onboard/activate/route.ts
+++ b/apps/portal/src/app/api/onboard/activate/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+
 import {
   activationEnv,
   type BackendActivationResult,

--- a/apps/portal/src/app/api/onboard/app/route.ts
+++ b/apps/portal/src/app/api/onboard/app/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+
 import {
   type BackendAppStatusResult,
   backendRequest,

--- a/apps/portal/src/app/api/onboard/create/route.ts
+++ b/apps/portal/src/app/api/onboard/create/route.ts
@@ -1,6 +1,8 @@
 import { randomBytes } from "crypto";
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+
 import {
   type BackendAppSourceResult,
   backendRequest,

--- a/apps/portal/src/app/api/onboard/deploy/route.ts
+++ b/apps/portal/src/app/api/onboard/deploy/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+
 import {
   appNamesFromDeployment,
   type BackendDeployResult,

--- a/apps/portal/src/app/api/onboard/dry-run/route.ts
+++ b/apps/portal/src/app/api/onboard/dry-run/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+
 import {
   appNamesFromDeployment,
   type BackendDeployResult,

--- a/apps/portal/src/app/api/onboard/status/route.ts
+++ b/apps/portal/src/app/api/onboard/status/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+
 import {
   type BackendDeploymentStatusResult,
   backendRequest,

--- a/apps/portal/src/app/api/onboard/sync-installed/route.ts
+++ b/apps/portal/src/app/api/onboard/sync-installed/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+
 import {
   type BackendAppSourceResult,
   backendRequest,

--- a/apps/portal/src/lib/onboard-deploy.ts
+++ b/apps/portal/src/lib/onboard-deploy.ts
@@ -95,7 +95,7 @@ export function readOnboardDeployEnv(): OnboardDeployEnv {
     .split(",")
     .map((path) => path.trim())
     .filter(Boolean);
-  const targetTags = (process.env.APP_DEPLOY_TARGET_TAGS || "staging")
+  const targetTags = (process.env.APP_DEPLOY_TARGET_TAGS || "")
     .split(",")
     .map((tag) => tag.trim())
     .filter(Boolean);

--- a/apps/registry/src/lib/aomi-auth-adapter/providers/base-account.tsx
+++ b/apps/registry/src/lib/aomi-auth-adapter/providers/base-account.tsx
@@ -216,7 +216,11 @@ function BaseAccountAdapterInner({
             sponsored: sponsorshipEnabled,
             sponsorProvider: sponsorshipEnabled ? "coinbase" : "self",
             sponsorAccount: undefined,
-            chainId: chainId ?? undefined,
+            // Fall back to the selected EVM network while wagmi hasn't resolved
+            // the connected chain, so the chain reported to the backend (via
+            // setUser) matches the network selector instead of defaulting to
+            // Ethereum mainnet server-side.
+            chainId: chainId ?? selectedEvmChainId,
             walletProvider: "baseAccount",
             authMethod: undefined,
           }

--- a/apps/registry/src/lib/aomi-auth-adapter/providers/para.tsx
+++ b/apps/registry/src/lib/aomi-auth-adapter/providers/para.tsx
@@ -637,7 +637,13 @@ export function AomiParaAdapterProvider({
             sponsored,
             sponsorProvider,
             sponsorAccount,
-            chainId: chainId ?? undefined,
+            // Fall back to the user's selected EVM network while wagmi hasn't
+            // resolved the connected chain yet. The network selector already
+            // shows `identity.chainId ?? selectedEvmChainId`; mirroring that
+            // here keeps the chain reported to the backend (via setUser) in
+            // sync with the UI, instead of leaving it undefined (which the
+            // backend silently treats as Ethereum mainnet).
+            chainId: chainId ?? (hasEvmAddress ? selectedEvmChainId : undefined),
             svmAddress,
             walletProvider,
             authMethod,

--- a/apps/registry/src/lib/aomi-auth-adapter/providers/privy.tsx
+++ b/apps/registry/src/lib/aomi-auth-adapter/providers/privy.tsx
@@ -409,7 +409,11 @@ function AomiPrivyAdapterProvider({
             status: "connected",
             isConnected: true,
             address: smartAddress,
-            chainId: chainId ?? undefined,
+            // Fall back to the selected EVM network while wagmi hasn't resolved
+            // the connected chain, so the chain reported to the backend (via
+            // setUser) matches the network selector instead of defaulting to
+            // Ethereum mainnet server-side.
+            chainId: chainId ?? selectedEvmChainId,
             svmAddress,
             walletProvider: "privy",
             authProvider,


### PR DESCRIPTION
## Summary
Ports **all of [#205](https://github.com/aomi-labs/aomi/pull/205)** to `prod` (cherry-picked, net diff identical to #205). Two independent fixes:

### 1. Portal onboarding BFF runtime (`f4c81b97`)
- Pin onboarding BFF routes to the Node serverless runtime (`export const runtime = "nodejs"`).
- Stop defaulting onboarding activations to the `staging` target tag (`APP_DEPLOY_TARGET_TAGS` default `"staging"` → `""`).

### 2. Wallet chain-identity fix (`107b26be`)
The network selector shows `identity.chainId ?? selectedEvmChainId`, but identity only carried the wagmi-resolved `chainId`. Before wagmi resolves the connected chain (session start, Para re-init, in-flight switch), `identity.chainId` is `undefined`, so `setUser` sends no chain and the backend silently defaults to Ethereum mainnet (chain 1) — the UI shows e.g. Monad while the agent claims Ethereum. Fix: fall back to `selectedEvmChainId` in the EVM-connected identity branch of all three wallet providers (gated by an EVM address on Para, whose connected branch is also reachable Solana-only). Tx path is unaffected — it reads `wagmiChainId` directly.

## Files (11, identical set to #205)
- `apps/portal/src/app/api/onboard/{activate,app,create,deploy,dry-run,status,sync-installed}/route.ts`
- `apps/portal/src/lib/onboard-deploy.ts`
- `apps/registry/src/lib/aomi-auth-adapter/providers/{para,privy,base-account}.tsx`

## Validation
- `pnpm typecheck` (lib) — clean
- `eslint` on the three provider files — clean
- vitest: registry suite 5/5 + user-state 23/23
- BFF changes are identical to the already-validated #205 and cherry-picked cleanly onto prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)