### PR TITLE
fix(deploy): scope access tokens, handle releasing/pending states, wire chatUrl

### DIFF
--- a/apps/portal/src/app/api/onboard/deploy/route.ts
+++ b/apps/portal/src/app/api/onboard/deploy/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 export const runtime = "nodejs";
 
 import {
+  activationEnv,
   appNamesFromDeployment,
   type BackendDeployResult,
   backendRequest,
@@ -25,7 +26,7 @@ export async function POST(req: Request) {
         { status: 400 },
       );
     }
-    const env = readOnboardDeployEnv();
+    const env = await activationEnv(readOnboardDeployEnv());
     const appSourceId = await resolveAppSourceId({
       env,
       installationId: body.installationId,

--- a/apps/portal/src/app/api/onboard/dry-run/route.ts
+++ b/apps/portal/src/app/api/onboard/dry-run/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 export const runtime = "nodejs";
 
 import {
+  activationEnv,
   appNamesFromDeployment,
   type BackendDeployResult,
   backendRequest,
@@ -24,7 +25,7 @@ export async function POST(req: Request) {
         { status: 400 },
       );
     }
-    const env = readOnboardDeployEnv();
+    const env = await activationEnv(readOnboardDeployEnv());
     const appSourceId = await resolveAppSourceId({
       env,
       installationId: body.installationId,

--- a/apps/portal/src/app/api/onboard/status/route.ts
+++ b/apps/portal/src/app/api/onboard/status/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 export const runtime = "nodejs";
 
 import {
+  activationEnv,
   BackendRequestError,
   type BackendDeploymentStatusResult,
   backendRequest,
@@ -32,7 +33,7 @@ export async function GET(req: Request) {
   }
 
   try {
-    const env = readOnboardDeployEnv();
+    const env = await activationEnv(readOnboardDeployEnv());
     const result = await backendRequest<BackendDeploymentStatusResult>(
       env,
       `/api/platforms/${encodeURIComponent(env.platform)}/deployments/${encodeURIComponent(
@@ -45,10 +46,12 @@ export async function GET(req: Request) {
     });
   } catch (err) {
     if (isPendingDeploymentStatusError(err)) {
+      const message = err instanceof Error ? err.message : String(err);
       return NextResponse.json({
-        state: "building",
+        state: "pending",
         releaseTags: [],
-        message: err instanceof Error ? err.message : String(err),
+        message,
+        retryIn: 3000,
       });
     }
     return NextResponse.json(

--- a/apps/portal/src/components/settings/onboarding/bootstrap-wizard.tsx
+++ b/apps/portal/src/components/settings/onboarding/bootstrap-wizard.tsx
@@ -180,7 +180,16 @@ export function BootstrapWizard({
         </div>
       )}
 
-      {step === "live" && <LivePanel repo={progress.repo} />}
+      {step === "live" && (
+        <LivePanel
+          repo={progress.repo}
+          chatUrl={
+            progress.apps?.[0]
+              ? `https://chat.aomi.dev?app=${encodeURIComponent(progress.apps[0])}`
+              : undefined
+          }
+        />
+      )}
     </div>
   );
 }

--- a/apps/portal/src/components/settings/onboarding/deploy-step.tsx
+++ b/apps/portal/src/components/settings/onboarding/deploy-step.tsx
@@ -29,6 +29,7 @@ type Phase =
   | "dry_ready"
   | "deploying"
   | "building"
+  | "releasing"
   | "ready"
   | "activating"
   | "verifying"
@@ -160,7 +161,7 @@ export function DeployStep({
   }, [actor, applyDeployment, installationId, onProgress, path, repo]);
 
   useEffect(() => {
-    if (!deploymentId || (phase !== "building" && phase !== "deploying"))
+    if (!deploymentId || (phase !== "building" && phase !== "deploying" && phase !== "releasing"))
       return;
     let cancelled = false;
     const tick = async () => {
@@ -181,6 +182,16 @@ export function DeployStep({
         onProgress(patch);
         if (status.state === "ready") {
           setPhase("ready");
+          return;
+        }
+        if (status.state === "releasing") {
+          setPhase("releasing");
+          pollRef.current = setTimeout(tick, 3000);
+          return;
+        }
+        if (status.state === "pending") {
+          setPhase("building");
+          pollRef.current = setTimeout(tick, 6000);
           return;
         }
         if (status.state === "failed") {
@@ -356,6 +367,7 @@ export function DeployStep({
           "dry_running",
           "deploying",
           "building",
+          "releasing",
           "activating",
           "verifying",
         ].includes(phase) && (
@@ -369,6 +381,8 @@ export function DeployStep({
         {phase === "deploying" &&
           "Creating or updating the platform deploy branch."}
         {phase === "building" && "Waiting for platform CI and release assets."}
+        {phase === "releasing" &&
+          "Release built — verifying assets."}
         {phase === "ready" && "Build is ready for activation."}
         {phase === "activating" &&
           "Promoting the built release into the live branch."}
@@ -569,6 +583,8 @@ function statusLabel(phase: Phase): string {
       return "Preview ready";
     case "building":
       return "CI pending";
+    case "releasing":
+      return "Verifying assets";
     case "ready":
       return "CI passed";
     case "activating":

--- a/apps/portal/src/components/settings/onboarding/oneshot-wizard.tsx
+++ b/apps/portal/src/components/settings/onboarding/oneshot-wizard.tsx
@@ -174,7 +174,16 @@ export function OneshotWizard({
         </div>
       )}
 
-      {step === "live" && <LivePanel repo={progress.repo} />}
+      {step === "live" && (
+        <LivePanel
+          repo={progress.repo}
+          chatUrl={
+            progress.apps?.[0]
+              ? `https://chat.aomi.dev?app=${encodeURIComponent(progress.apps[0])}`
+              : undefined
+          }
+        />
+      )}
     </div>
   );
 }

--- a/apps/portal/src/lib/onboarding.ts
+++ b/apps/portal/src/lib/onboarding.ts
@@ -390,7 +390,7 @@ export async function onboardCreateRepo(input: {
 }
 
 export type OnboardStatus = {
-  state: "building" | "releasing" | "ready" | "failed";
+  state: "building" | "releasing" | "ready" | "failed" | "pending";
   deployment?: OnboardDeployPayload;
   releaseTags: string[];
   apps?: Array<{


### PR DESCRIPTION
## High Priority Fixes

### Security
- **Activation token**: All backend routes (deploy, dry-run, status) now use `activationEnv()` to mint a scoped platform token instead of using `AOMI_ADMIN_SECRET` directly as a bearer token. Only the activate route was doing this before.

### State Machine
- **Releasing state**: The backend returns `"releasing"` as a valid status but the frontend fell through to `"building"`. Now handled explicitly with its own UI text and poll interval.
- **Pending state**: 404/first-poll errors now return `"pending"` (not `"building"`) so the frontend can distinguish 'not yet created' from 'actively building' and poll at a longer interval.

### UX
- **chatUrl → LivePanel**: Both `OneshotWizard` and `BootstrapWizard` now pass `chatUrl` to `LivePanel` (constructed as `https://chat.aomi.dev?app=<firstAppName>` from `progress.apps`). The 'Open in chat' link was dead code before.

### Files Changed
```
 apps/portal/src/app/api/onboard/deploy/route.ts           | 4 +++-
 apps/portal/src/app/api/onboard/dry-run/route.ts           | 4 +++-
 apps/portal/src/app/api/onboard/status/route.ts            | 8 +++++---
 apps/portal/src/components/settings/onboarding/bootstrap-wizard.tsx | 8 +++++++-
 apps/portal/src/components/settings/onboarding/deploy-step.tsx     | 16 +++++++++++++---
 apps/portal/src/components/settings/onboarding/oneshot-wizard.tsx  | 8 +++++++-
 apps/portal/src/lib/onboarding.ts                          | 2 +-
 7 files changed, 38 insertions(+), 10 deletions(-)
```