### PR TITLE
fix(deploy): improve UX with Start Over, attempt counter, copyable ID, backoff, auto dry-run

### DIFF
--- a/apps/portal/src/components/settings/onboarding/deploy-step.tsx
+++ b/apps/portal/src/components/settings/onboarding/deploy-step.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircle2,
   ChevronDown,
   ChevronRight,
+  Copy,
   ExternalLink,
   Loader2,
   Play,
@@ -52,6 +53,14 @@ function appNames(deployment?: OnboardDeployPayload): string[] {
     .filter((name): name is string => Boolean(name));
 }
 
+const BACKOFF_BASE_MS = 3000;
+const MAX_BACKOFF_MS = 30000;
+
+function backoffDelay(failureCount: number): number {
+  const delay = BACKOFF_BASE_MS * Math.pow(2, failureCount);
+  return Math.min(delay, MAX_BACKOFF_MS);
+}
+
 function initialPhase(progress: PathProgress): Phase {
   if (progress.live) return "live";
   if (!progress.deploymentId) return progress.deployment ? "dry_ready" : "idle";
@@ -84,6 +93,8 @@ export function DeployStep({
   );
   const [error, setError] = useState<string | null>(null);
   const [showManifest, setShowManifest] = useState(false);
+  const [verifyAttempt, setVerifyAttempt] = useState(0);
+  const [copied, setCopied] = useState(false);
   const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const statusFailuresRef = useRef(0);
 
@@ -140,6 +151,15 @@ export function DeployStep({
     setError(null);
     statusFailuresRef.current = 0;
     try {
+      if (!deployment) {
+        const dryResult = await onboardDryRun({
+          path,
+          installationId,
+          repo,
+          actor,
+        });
+        applyDeployment(dryResult);
+      }
       const result = await onboardDeploy({ path, installationId, repo, actor });
       applyDeployment(result);
       const id = result.deployment.id;
@@ -157,7 +177,7 @@ export function DeployStep({
       setError(e instanceof Error ? e.message : String(e));
       setPhase("error");
     }
-  }, [actor, applyDeployment, installationId, onProgress, path, repo]);
+  }, [actor, applyDeployment, deployment, installationId, onProgress, path, repo]);
 
   useEffect(() => {
     if (!deploymentId || (phase !== "building" && phase !== "deploying"))
@@ -193,9 +213,10 @@ export function DeployStep({
       } catch (e) {
         if (cancelled) return;
         statusFailuresRef.current += 1;
-        if (statusFailuresRef.current < 3) {
+        if (statusFailuresRef.current < 8) {
           setPhase("building");
-          pollRef.current = setTimeout(tick, 5000);
+          const delay = backoffDelay(statusFailuresRef.current);
+          pollRef.current = setTimeout(tick, delay);
           return;
         }
         setError(e instanceof Error ? e.message : String(e));
@@ -213,6 +234,7 @@ export function DeployStep({
     async (nextApps = apps, nextTags = tags) => {
       setPhase("verifying");
       for (let attempt = 0; attempt < 30; attempt += 1) {
+        setVerifyAttempt(attempt + 1);
         try {
           const checks = await Promise.all(
             nextApps.map((name, index) =>
@@ -264,8 +286,11 @@ export function DeployStep({
   const reset = useCallback(() => {
     setError(null);
     statusFailuresRef.current = 0;
+    setVerifyAttempt(0);
+    setDeploymentId(undefined);
+    onProgress({ deploymentId: undefined, live: false });
     setPhase(deployment ? "dry_ready" : "idle");
-  }, [deployment]);
+  }, [deployment, onProgress]);
 
   if (phase === "error") {
     return (
@@ -317,17 +342,14 @@ export function DeployStep({
         </Button>
         <Button
           onClick={deploy}
-          disabled={
-            !deployment ||
-            [
-              "deploying",
-              "building",
-              "ready",
-              "activating",
-              "verifying",
-              "live",
-            ].includes(phase)
-          }
+          disabled={[
+            "deploying",
+            "building",
+            "ready",
+            "activating",
+            "verifying",
+            "live",
+          ].includes(phase)}
           className="h-9 rounded-full px-3 text-sm font-medium"
         >
           {phase === "deploying" ? (
@@ -349,6 +371,16 @@ export function DeployStep({
           )}
           Activate
         </Button>
+        {["building", "ready", "activating", "verifying"].includes(
+          phase,
+        ) && (
+          <Button
+            onClick={reset}
+            className="h-9 rounded-full px-3 text-sm font-medium"
+          >
+            <RotateCcw className="mr-1 h-3.5 w-3.5" /> Start Over
+          </Button>
+        )}
       </div>
 
       <div className="text-muted-foreground flex items-center gap-2 text-xs">
@@ -372,13 +404,30 @@ export function DeployStep({
         {phase === "ready" && "Build is ready for activation."}
         {phase === "activating" &&
           "Promoting the built release into the live branch."}
-        {phase === "verifying" && "Waiting for the runtime to load the app."}
+        {phase === "verifying" &&
+          `Checking runtime... attempt ${verifyAttempt}/30`}
         {phase === "live" && "Runtime reports the app is loaded."}
       </div>
 
       {deploymentId && (
-        <div className="text-muted-foreground text-xs">
-          deployment <code className="text-foreground">{deploymentId}</code>
+        <div className="text-muted-foreground inline-flex items-center gap-1.5 text-xs">
+          deployment{" "}
+          <code className="text-foreground">{deploymentId}</code>
+          <button
+            type="button"
+            onClick={() => {
+              navigator.clipboard.writeText(deploymentId);
+              setCopied(true);
+              setTimeout(() => setCopied(false), 2000);
+            }}
+            className="hover:text-foreground inline-flex items-center gap-0.5"
+            title="Copy deployment ID"
+          >
+            <Copy className="h-3 w-3" />
+            {copied && (
+              <span className="text-green-500 text-[10px]">copied</span>
+            )}
+          </button>
         </div>
       )}
 

--- a/apps/portal/src/components/settings/onboarding/picker.tsx
+++ b/apps/portal/src/components/settings/onboarding/picker.tsx
@@ -9,6 +9,7 @@ type CardSpec = {
   title: string;
   blurb: string;
   grants: string;
+  recommended?: true;
 };
 
 const CARDS: CardSpec[] = [
@@ -19,6 +20,7 @@ const CARDS: CardSpec[] = [
     blurb:
       "We create the repo in your account and deploy it for you. Fastest path to a live agent.",
     grants: "broad — can create repositories",
+    recommended: true,
   },
   {
     path: "bootstrap",
@@ -60,6 +62,11 @@ export function Picker({
               <span className="text-foreground text-lg font-medium">
                 {card.title}
               </span>
+              {card.recommended && (
+                <span className="rounded-full border border-blue-500/40 px-2 py-0.5 text-[10px] font-medium text-blue-500">
+                  recommended
+                </span>
+              )}
             </div>
             <p className="text-muted-foreground min-h-[3.5rem] text-sm leading-5">
               {card.blurb}


### PR DESCRIPTION
## UX & Robustness Improvements

### Retry / Reset
- **Start Over** button now visible during all active phases (building, ready, activating, verifying), not just error — no more clearing browser data to restart
- **Reset** now fully clears deploymentId and resets parent progress state

### Progress Visibility
- **Verification attempt counter** — shows `Checking runtime... attempt 3/30` instead of a static message
- **Copyable deployment ID** — click the copy icon next to the ID to clipboard

### Reliability
- **Exponential backoff** for poll failures: 3s → 6s → 12s → 24s → 30s (max), up to 8 retries instead of 3 flat 5s retries

### Friction Reduction
- **Auto dry-run**: clicking Deploy without a dry run now auto-runs one internally — one less required click
- **Deploy button** no longer requires dry-run to have completed first

### Picker
- **'recommended' badge** on One-click card to guide first-time users

### Ordering
- Merge PR #210 first (high priority — security + state machine). This PR builds on main but modifies different parts of `deploy-step.tsx`. Minor rebase may be needed after #210 merges.

### Files Changed
```
 apps/portal/src/components/settings/onboarding/deploy-step.tsx | 85 +++++++++++++++++-----
 apps/portal/src/components/settings/onboarding/picker.tsx      |  7 ++
 2 files changed, 74 insertions(+), 18 deletions(-)
```