### PR TITLE
PR #3: Install-success banner + deployment ID in URL params

### DIFF
--- a/apps/portal/src/components/settings/onboarding/onboarding.tsx
+++ b/apps/portal/src/components/settings/onboarding/onboarding.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { CheckCircle2 } from "lucide-react";
 import { useAomiAuthAdapter } from "@aomi-labs/widget-lib";
 import {
   githubAppInstallUrl,
@@ -24,10 +25,26 @@ export function Onboarding() {
   const adapter = useAomiAuthAdapter();
   const actor = adapter.identity.address ?? undefined;
 
-  const [state, setState] = useState<OnboardingState>(() => loadOnboarding());
+  const [state, setState] = useState<OnboardingState>(() => {
+    const loaded = loadOnboarding();
+    if (typeof window !== "undefined") {
+      const url = new URL(window.location.href);
+      const urlDeployId = url.searchParams.get("deployment_id");
+      const urlDeployPath = url.searchParams.get("deploy_path");
+      if (urlDeployId) {
+        if (urlDeployPath === "oneshot" && !loaded.oneshot.deploymentId) {
+          loaded.oneshot.deploymentId = urlDeployId;
+        } else if (urlDeployPath === "bootstrap" && !loaded.bootstrap.deploymentId) {
+          loaded.bootstrap.deploymentId = urlDeployId;
+        }
+      }
+    }
+    return loaded;
+  });
   const [installingPath, setInstallingPath] =
     useState<OnboardingPath | null>(null);
   const [installError, setInstallError] = useState<string | null>(null);
+  const [installSuccess, setInstallSuccess] = useState(false);
 
   const update = useCallback((next: OnboardingState) => {
     setState(next);
@@ -52,6 +69,7 @@ export function Onboarding() {
         null,
       );
       update(next);
+      setInstallSuccess(true);
     }
 
     // Strip GitHub's params so a refresh doesn't re-trigger hydration.
@@ -66,6 +84,33 @@ export function Onboarding() {
     if (changed) window.history.replaceState({}, "", url.toString());
     // `update` is a stable useCallback ([] deps), so this still runs once.
   }, [update]);
+
+  // --- auto-dismiss the install-success banner after 6s ---------------------
+  useEffect(() => {
+    if (!installSuccess) return;
+    const id = setTimeout(() => setInstallSuccess(false), 6000);
+    return () => clearTimeout(id);
+  }, [installSuccess]);
+
+  // --- sync deploymentId to URL params -------------------------------------
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const id = state.oneshot.deploymentId || state.bootstrap.deploymentId;
+    const path = state.path;
+    const url = new URL(window.location.href);
+    const currentId = url.searchParams.get("deployment_id");
+    if (id && path) {
+      if (id !== currentId) {
+        url.searchParams.set("deployment_id", id);
+        url.searchParams.set("deploy_path", path);
+        window.history.replaceState({}, "", url.toString());
+      }
+    } else if (currentId) {
+      url.searchParams.delete("deployment_id");
+      url.searchParams.delete("deploy_path");
+      window.history.replaceState({}, "", url.toString());
+    }
+  }, [state.oneshot.deploymentId, state.bootstrap.deploymentId, state.path]);
 
   // --- actions handed to the picker / wizards -------------------------------
   const choose = useCallback(
@@ -122,29 +167,44 @@ export function Onboarding() {
 
   if (state.path === "oneshot") {
     return (
-      <OneshotWizard
-        progress={state.oneshot}
-        actor={actor}
-        onBack={back}
-        beginInstall={makeBeginInstall("oneshot")}
-        beginAuthorize={makeBeginInstall("oneshot", "authorize")}
-        installing={installingPath === "oneshot"}
-        installError={installError}
-        patch={makePatch("oneshot")}
-      />
+      <>
+        {installSuccess && <InstallSuccessBanner />}
+        <OneshotWizard
+          progress={state.oneshot}
+          actor={actor}
+          onBack={back}
+          beginInstall={makeBeginInstall("oneshot")}
+          beginAuthorize={makeBeginInstall("oneshot", "authorize")}
+          installing={installingPath === "oneshot"}
+          installError={installError}
+          patch={makePatch("oneshot")}
+        />
+      </>
     );
   }
 
   return (
-    <BootstrapWizard
-      progress={state.bootstrap}
-      actor={actor}
-      onBack={back}
-      beginInstall={makeBeginInstall("bootstrap")}
-      beginAuthorize={makeBeginInstall("bootstrap", "authorize")}
-      installing={installingPath === "bootstrap"}
-      installError={installError}
-      patch={makePatch("bootstrap")}
-    />
+    <>
+      {installSuccess && <InstallSuccessBanner />}
+      <BootstrapWizard
+        progress={state.bootstrap}
+        actor={actor}
+        onBack={back}
+        beginInstall={makeBeginInstall("bootstrap")}
+        beginAuthorize={makeBeginInstall("bootstrap", "authorize")}
+        installing={installingPath === "bootstrap"}
+        installError={installError}
+        patch={makePatch("bootstrap")}
+      />
+    </>
+  );
+}
+
+function InstallSuccessBanner() {
+  return (
+    <div className="mb-4 rounded-2xl border border-green-500/40 bg-green-500/10 p-3 text-sm text-green-600">
+      <CheckCircle2 className="-mt-0.5 mr-1.5 inline-block h-4 w-4 align-middle" />
+      GitHub App installed successfully
+    </div>
   );
 }


### PR DESCRIPTION
## What

Two remaining UX polish items from the deploy experience audit:

### Green confirmation banner
After the GitHub App install redirect hydrates, the user now sees a green banner reading *"GitHub App installed successfully"* for 6 seconds before it auto-dismisses. Previously the wizard silently advanced to the next step with no visual confirmation.

### Deployment ID in URL params
When a deploy is kicked off, `?deployment_id=<id>\&deploy_path=oneshot|bootstrap` is written to the URL so users can share/bookmark the URL mid-deploy. On page load the params are read as a fallback if localStorage was cleared.

## Files changed
- `apps/portal/src/components/settings/onboarding/onboarding.tsx` — added `installSuccess` state, banner component, auto-dismiss timer, URL sync effect, and URL param hydration on load.

## Verification
- `pnpm run lint` — clean
- `pnpm run typecheck` — clean (root lib + portal)
- `pnpm run build:portal` — compiled successfully