### PR TITLE
feat(cli): add aomi deploy subcommand with --activation-token

### DIFF
--- a/packages/client/src/cli/commands/defs/deploy.ts
+++ b/packages/client/src/cli/commands/defs/deploy.ts
@@ -1,0 +1,45 @@
+import { defineCommand } from "citty";
+import { globalArgs } from "./shared";
+
+export const deployDef = defineCommand({
+  meta: {
+    name: "deploy",
+    description: "Deploy your app to the Aomi platform via aomi-build",
+  },
+  args: {
+    ...globalArgs,
+    "activation-token": {
+      type: "string",
+      description:
+        "Platform activation token (required; or set AOMI_DEPLOY_TOKEN env)",
+    },
+    "app-source-id": {
+      type: "string",
+      description:
+        "Backend app source ID (required; or set AOMI_APP_SOURCE_ID env)",
+    },
+    "dry-run": {
+      type: "boolean",
+      description: "Preview the deployment manifest without applying it",
+    },
+    branch: {
+      type: "string",
+      description:
+        "Git branch to deploy (default: current branch via git rev-parse)",
+    },
+    "aomi-toml-paths": {
+      type: "string",
+      description:
+        "Comma-separated paths to aomi.toml files (default: aomi.toml)",
+    },
+    platform: {
+      type: "string",
+      description:
+        "Deploy platform (default: community; or set AOMI_DEPLOY_PLATFORM env)",
+    },
+  },
+  async run({ args }) {
+    const { deployCommand } = await import("../deploy");
+    await deployCommand(args);
+  },
+});

--- a/packages/client/src/cli/commands/deploy.ts
+++ b/packages/client/src/cli/commands/deploy.ts
@@ -1,0 +1,145 @@
+import { execSync } from "child_process";
+import { fatal } from "../errors";
+
+type DeployArgs = Record<string, unknown>;
+
+function str(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function required(value: string | undefined, flag: string, env: string): string {
+  if (value) return value;
+  fatal(`\`--${flag}\` is required. Pass it or set the ${env} env var.`);
+}
+
+function currentBranch(): string {
+  try {
+    return execSync("git rev-parse --abbrev-ref HEAD", {
+      encoding: "utf-8",
+    }).trim();
+  } catch {
+    fatal(
+      "Could not detect the current git branch. Pass \`--branch\` or run this command from a git repository.",
+    );
+  }
+}
+
+export async function deployCommand(args: DeployArgs): Promise<void> {
+  const activationToken = required(
+    str(args["activation-token"]) ?? process.env.AOMI_DEPLOY_TOKEN,
+    "activation-token",
+    "AOMI_DEPLOY_TOKEN",
+  );
+  const appSourceId = Number(
+    required(
+      str(args["app-source-id"]) ?? process.env.AOMI_APP_SOURCE_ID,
+      "app-source-id",
+      "AOMI_APP_SOURCE_ID",
+    ),
+  );
+  if (!Number.isSafeInteger(appSourceId) || appSourceId <= 0) {
+    fatal("`--app-source-id` must be a positive integer.");
+  }
+
+  const backendUrl = (
+    str(args["backend-url"]) ??
+    process.env.AOMI_BACKEND_URL ??
+    "https://api.aomi.dev"
+  ).replace(/\/+$/, "");
+  const platform =
+    str(args.platform) ??
+    process.env.AOMI_DEPLOY_PLATFORM ??
+    "community";
+  const branch = str(args.branch) ?? currentBranch();
+  const aomiTomlPaths = (
+    str(args["aomi-toml-paths"]) ?? "aomi.toml"
+  )
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean);
+  const dryRun = args["dry-run"] === true;
+
+  console.log(` Deploying to ${backendUrl} (platform: ${platform})`);
+  console.log(`   app source id: ${appSourceId}`);
+  console.log(`   branch:        ${branch}`);
+  console.log(`   aomi.toml:     ${aomiTomlPaths.join(", ")}`);
+  if (dryRun) console.log("   dry run:      yes");
+
+  const url = `${backendUrl}/api/platforms/${encodeURIComponent(platform)}/deploy`;
+  const body = {
+    app_source_id: appSourceId,
+    source_ref: { kind: "branch", value: branch },
+    aomi_toml_paths: aomiTomlPaths,
+    dry_run: dryRun,
+  };
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${activationToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    fatal(
+      `Deploy request failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const text = await res.text();
+  if (!res.ok) {
+    const message = (() => {
+      try {
+        const json = JSON.parse(text);
+        if (json && typeof json === "object" && json.error) return json.error;
+      } catch {}
+      return `${res.status} ${res.statusText}`;
+    })();
+    fatal(`Deploy failed (${res.status}): ${message}`);
+  }
+
+  let result: Record<string, unknown>;
+  try {
+    result = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    fatal("Backend returned invalid JSON.");
+  }
+
+  const deployment = result.deployment as Record<string, unknown> | undefined;
+  const platformInfo = deployment?.platform as Record<string, unknown> | undefined;
+  const sourceInfo = deployment?.source as Record<string, unknown> | undefined;
+
+  console.log();
+  if (dryRun) {
+    console.log(" Dry run complete. Review the manifest below:");
+    console.log(`   ${JSON.stringify(result, null, 2)}`);
+    return;
+  }
+
+  console.log(` Deployment created: ${deployment?.id ?? "unknown"}`);
+  console.log(`   status:  ${deployment?.status ?? "unknown"}`);
+  if (sourceInfo?.repository_link) {
+    console.log(`   source:  ${sourceInfo.repository_link}`);
+  }
+  if (platformInfo?.pr_url) {
+    console.log(`   PR:      ${platformInfo.pr_url}`);
+  }
+  if (platformInfo?.ci_url) {
+    console.log(`   CI:      ${platformInfo.ci_url}`);
+  }
+  if (platformInfo?.apps) {
+    const apps = platformInfo.apps as Array<Record<string, unknown>>;
+    for (const app of apps) {
+      const name = app.name ?? "?";
+      const tag = app.release_tag ?? app.releaseTag ?? "";
+      console.log(`   app:     ${name}${tag ? ` (${tag})` : ""}`);
+    }
+  }
+
+  if (platformInfo?.commit_hash) {
+    console.log(`   commit:  ${platformInfo.commit_hash}`);
+  }
+}

--- a/packages/client/src/cli/main.ts
+++ b/packages/client/src/cli/main.ts
@@ -14,6 +14,7 @@ const ROOT_SUBCOMMANDS = new Set([
   "config",
   "secret",
   "account",
+  "deploy",
 ]);
 
 function isPnpmExecWrapper(): boolean {
@@ -104,6 +105,9 @@ function printRootHelp(): void {
   console.log("  secret                       Secret management");
   console.log(
     "  account                      Account identity (login, whoami)",
+  );
+  console.log(
+    "  deploy                       Deploy your app (requires --activation-token)",
   );
   console.log("");
   console.log("Use aomi <command> --help for command-specific details.");

--- a/packages/client/src/cli/root.ts
+++ b/packages/client/src/cli/root.ts
@@ -9,6 +9,7 @@ import { walletDef } from "./commands/defs/wallet";
 import { configDef } from "./commands/defs/config";
 import { secretDef } from "./commands/defs/secret";
 import { accountDef } from "./commands/defs/account";
+import { deployDef } from "./commands/defs/deploy";
 import { globalArgs } from "./commands/defs/shared";
 import packageJson from "../../package.json";
 
@@ -23,6 +24,7 @@ const SUBCOMMAND_NAMES = new Set([
   "config",
   "secret",
   "account",
+  "deploy",
 ]);
 
 export const root = defineCommand({
@@ -71,5 +73,6 @@ export const root = defineCommand({
     config: configDef,
     secret: secretDef,
     account: accountDef,
+    deploy: deployDef,
   },
 });


### PR DESCRIPTION
## Problem

The `aomi-build deploy` flow mints activation tokens automatically from the server's `AOMI_ADMIN_SECRET` — the developer never provides a credential, so the admin has no control over who can push updates.

## Solution

Adds a new `aomi deploy` subcommand that **requires** an explicit `--activation-token`:

### Usage

```
aomi deploy --activation-token=<token> --app-source-id=<id>
```

| Flag | Env var | Required | Description |
|---|---|---|---|
| `--activation-token` | `AOMI_DEPLOY_TOKEN` | Yes | Platform token (admin-gated) |
| `--app-source-id` | `AOMI_APP_SOURCE_ID` | Yes | Backend app source row ID |
| `--backend-url` | `AOMI_BACKEND_URL` | No | Default `https://api.aomi.dev` |
| `--platform` | `AOMI_DEPLOY_PLATFORM` | No | Default `community` |
| `--branch` | — | No | Default: current git branch |
| `--aomi-toml-paths` | — | No | Default `aomi.toml` |
| `--dry-run` | — | No | Preview manifest without deploying |

### How it works

1. Calls `POST /api/platforms/<platform>/deploy` directly on the platform backend
2. Uses the activation token as the `Authorization: Bearer` header
3. Prints the deploy result: deployment ID, status, PR URL, CI URL, and app release tags
4. No auto-minting — the token comes from the developer, not the server's secret

### Files changed

| File | Change |
|---|---|
| `packages/client/src/cli/commands/defs/deploy.ts` | New — citty command definition with all flags |
| `packages/client/src/cli/commands/deploy.ts` | New — handler that calls the backend via `fetch` |
| `packages/client/src/cli/root.ts` | Register `deployDef` subcommand + `SUBCOMMAND_NAMES` |
| `packages/client/src/cli/main.ts` | Add `deploy` to root help text + subcommand set |

### Verification

- `pnpm run lint` — clean
- `pnpm --filter @aomi-labs/client build` — clean
- `node dist/cli.js deploy --help` — shows all options correctly