### PR TITLE
fix(deploy): per-step Back in fork flow + warn on existing-repo collision

### DIFF
--- a/apps/portal/src/components/settings/onboarding/bootstrap-wizard.tsx
+++ b/apps/portal/src/components/settings/onboarding/bootstrap-wizard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ExternalLink, Check, RotateCcw } from "lucide-react";
+import { ExternalLink, Check, RotateCcw, ArrowLeft, AlertTriangle } from "lucide-react";
 import { Button, Input } from "@aomi-labs/widget-lib";
 import {
   bootstrapStep,
@@ -45,15 +45,50 @@ export function BootstrapWizard({
   const installStatus = installationStatusLabel(progress.installationStatus);
   const [repoInput, setRepoInput] = useState("");
   const [repoError, setRepoError] = useState<string | null>(null);
+  const [repoWarning, setRepoWarning] = useState<string | null>(null);
+  const [checking, setChecking] = useState(false);
 
-  const confirmRepo = () => {
+  const confirmRepo = async () => {
     const repo = normalizeRepo(repoInput);
     if (!repo) {
       setRepoError("Enter your repo as owner/name.");
       return;
     }
     setRepoError(null);
+    // Guard against pointing at a repo you already own. This flow is meant to
+    // deploy a FRESH repo created from the template — pasting an existing repo
+    // installs the app on it as-is, which risks touching real work. Warn first,
+    // then let the user proceed on a second confirm if it's intentional.
+    if (!repoWarning) {
+      setChecking(true);
+      let exists = false;
+      try {
+        const res = await fetch(`https://api.github.com/repos/${repo}`);
+        exists = res.ok;
+      } catch {
+        // offline / rate-limited: skip the check rather than block the user
+      }
+      setChecking(false);
+      if (exists) {
+        setRepoWarning(
+          `${repo} already exists. If it isn't a fresh repo from the template above, deploying will install on it as-is. Create a new one from the template to avoid touching existing code, or click Confirm again to use this repo anyway.`,
+        );
+        return;
+      }
+    }
+    setRepoWarning(null);
     patch({ repo });
+  };
+
+  // step back one stage by clearing the field that advanced it (no full reset)
+  const backToTemplate = () => {
+    patch({ repo: undefined, installationId: undefined, installationStatus: undefined });
+    setRepoInput("");
+    setRepoError(null);
+    setRepoWarning(null);
+  };
+  const backToInstall = () => {
+    patch({ installationId: undefined, installationStatus: undefined });
   };
 
   return (
@@ -105,7 +140,11 @@ export function BootstrapWizard({
               <div className="flex-1">
                 <Input
                   value={repoInput}
-                  onChange={(e) => setRepoInput(e.target.value)}
+                  onChange={(e) => {
+                    setRepoInput(e.target.value);
+                    setRepoError(null);
+                    setRepoWarning(null);
+                  }}
                   placeholder="your-account/my-agent"
                   onKeyDown={(e) => e.key === "Enter" && confirmRepo()}
                 />
@@ -114,13 +153,20 @@ export function BootstrapWizard({
                     {repoError}
                   </p>
                 )}
+                {repoWarning && (
+                  <p className="mt-1 flex items-start gap-1 pl-1 text-xs text-amber-500">
+                    <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                    <span>{repoWarning}</span>
+                  </p>
+                )}
               </div>
               <Button
                 onClick={confirmRepo}
-                disabled={!repoInput.trim()}
+                disabled={!repoInput.trim() || checking}
                 className="h-10 rounded-full px-4 text-sm font-medium"
               >
-                <Check className="mr-1 h-4 w-4" /> Confirm
+                <Check className="mr-1 h-4 w-4" />
+                {checking ? "Checking..." : repoWarning ? "Use anyway" : "Confirm"}
               </Button>
             </div>
           </div>
@@ -157,6 +203,14 @@ export function BootstrapWizard({
                 <RotateCcw className="mr-1 h-4 w-4 shrink-0" />
                 {installing ? "Opening GitHub..." : "Verify existing install"}
               </Button>
+              <button
+                type="button"
+                onClick={backToTemplate}
+                disabled={installing}
+                className="text-muted-foreground hover:text-foreground inline-flex h-10 items-center rounded-full px-3 text-sm disabled:opacity-50"
+              >
+                <ArrowLeft className="mr-1 h-4 w-4 shrink-0" /> Change repo
+              </button>
             </div>
           </div>
           <WizardError message={installError} />
@@ -165,8 +219,17 @@ export function BootstrapWizard({
 
       {step === "deploy" && progress.installationId && (
         <div className="border-input space-y-3 rounded-2xl border p-4">
-          <div className="text-foreground text-sm font-medium">
-            Step 3 — Deploy your app
+          <div className="flex items-center justify-between">
+            <div className="text-foreground text-sm font-medium">
+              Step 3 — Deploy your app
+            </div>
+            <button
+              type="button"
+              onClick={backToInstall}
+              className="text-muted-foreground hover:text-foreground inline-flex items-center text-xs"
+            >
+              <ArrowLeft className="mr-1 h-3.5 w-3.5 shrink-0" /> Back
+            </button>
           </div>
           <DeployStep
             path="bootstrap"


### PR DESCRIPTION
## What

Two fixes to the **fork & customize** onboarding wizard (`bootstrap-wizard.tsx`), both found while running the flow end to end as a first user.

### 1. No per-step Back
The only Back control (`WizardHeader`) resets all the way to the path picker. Because the step is computed from `progress`, once you confirm a repo and move to **Install**, there is no way to go back and fix the repo name short of clearing browser storage.

**Fix:** a **Change repo** button on the Install step (clears `repo` → returns to Template) and a **Back** button on the Deploy step (clears `installationId` → returns to Install). Uses the existing step-from-progress model, no new state machine.

### 2. No collision guard on the repo name
The repo input only validated the `owner/name` format. Pasting a repo you **already own** (instead of a fresh repo created from the template) silently installs the app on it as-is — a real footgun. I hit this myself by typing the name of an existing repo.

**Fix:** `confirmRepo` now checks GitHub for the repo and, if it exists, shows an amber warning explaining the risk. The user can still proceed (the button becomes **Use anyway**) if it's intentional. Offline / rate-limited checks fail open so they never block.

## Why this is separate from #211 (Start Over)

@Gordian's #211 adds a **Start Over** button — a full reset of the whole flow. That's great for 'abandon and restart from scratch.' These two fixes are the **complementary, finer-grained** controls:

- **Start Over** = throw everything away and re-pick the path.
- **Change repo / Back** = step back **one stage** to fix a single wrong input without losing the rest of your progress.

A user who just mistyped the repo name shouldn't have to nuke the whole flow to fix it. The two work together: Start Over for 'restart', per-step Back for 'correct one thing'. The collision guard then stops the most common reason you'd need either — pasting the wrong (existing) repo in the first place.

## Notes

- Frontend-only, no backend changes.
- Touches `bootstrap-wizard.tsx`, which #210 and #211 also modify — will rebase after those land.
- CI will type-check (no local deps installed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)