### PR TITLE
[codex] fix client query params

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -388,17 +388,15 @@ export class AomiClient {
     const app = options?.app ?? "default";
     const apiKey = options?.apiKey ?? this.apiKey;
     const normalizedUserState = UserState.normalize(options?.userState);
-
-    const payload: Record<string, unknown> = { message, app };
-    if (options?.publicKey) {
-      payload.public_key = options.publicKey;
-    }
-    if (normalizedUserState) {
-      payload.user_state = JSON.stringify(normalizedUserState);
-    }
-    if (options?.clientId) {
-      payload.client_id = options.clientId;
-    }
+    const url = buildApiUrl(this.baseUrl, "/api/chat", {
+      app,
+      message,
+      public_key: options?.publicKey,
+      user_state: normalizedUserState
+        ? JSON.stringify(normalizedUserState)
+        : undefined,
+      client_id: options?.clientId,
+    });
 
     this.logger?.debug("[aomi][client] POST /api/chat prepared", {
       sessionId,
@@ -409,15 +407,35 @@ export class AomiClient {
       messagePreview: previewText(message),
     });
 
-    return postState<AomiChatResponse>(
-      this.baseUrl,
-      "/api/chat",
-      payload,
+    const headers = new Headers(withSessionHeader(sessionId));
+    if (apiKey) {
+      headers.set(APP_KEY_HEADER, apiKey);
+    }
+
+    this.logger?.debug("[aomi][client] POST start", {
+      path: "/api/chat",
       sessionId,
-      this.fetchImpl,
-      apiKey,
-      this.logger,
-    );
+      hasApiKey: Boolean(apiKey),
+      url,
+    });
+
+    const response = await this.fetchImpl(url, {
+      method: "POST",
+      headers,
+    });
+
+    this.logger?.debug("[aomi][client] POST response", {
+      path: "/api/chat",
+      sessionId,
+      status: response.status,
+      ok: response.ok,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    return (await response.json()) as AomiChatResponse;
   }
 
   /**
@@ -913,27 +931,32 @@ export class AomiClient {
     created: boolean;
   }> {
     const apiKey = options?.apiKey ?? this.apiKey;
-    const payload: Record<string, unknown> = { rig };
-    if (options?.app) {
-      payload.app = options.app;
-    }
-    if (options?.clientId) {
-      payload.client_id = options.clientId;
+    const url = buildApiUrl(this.baseUrl, "/api/session/model", {
+      rig,
+      app: options?.app,
+      client_id: options?.clientId,
+    });
+
+    const headers = new Headers(withSessionHeader(sessionId));
+    if (apiKey) {
+      headers.set(APP_KEY_HEADER, apiKey);
     }
 
-    return postState<{
+    const response = await this.fetchImpl(url, {
+      method: "POST",
+      headers,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to set model: HTTP ${response.status}`);
+    }
+
+    return (await response.json()) as {
       success: boolean;
       rig: string;
       baml: string;
       created: boolean;
-    }>(
-      this.baseUrl,
-      "/api/session/model",
-      payload,
-      sessionId,
-      this.fetchImpl,
-      apiKey,
-    );
+    };
   }
 
   /**

--- a/packages/client/test/client.unit.test.ts
+++ b/packages/client/test/client.unit.test.ts
@@ -120,6 +120,76 @@ describe("AomiClient account profile", () => {
       vi.stubGlobal("fetch", originalFetch);
     }
   });
+
+  it("sends chat messages as query params instead of a JSON body", async () => {
+    const response = {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: vi.fn(async () => ({ messages: [], is_processing: false })),
+    } as unknown as Response;
+    const nativeFetch = vi.fn(async () => response);
+    const originalFetch = globalThis.fetch;
+    vi.stubGlobal("fetch", nativeFetch);
+
+    try {
+      const client = new AomiClient({ baseUrl: "http://unit.test" });
+
+      await client.sendMessage("session-1", "swap 20 mon to usdc", {
+        app: "default",
+        publicKey: "0xabc",
+        clientId: "client-1",
+      });
+
+      const [url, init] = nativeFetch.mock.calls[0] ?? [];
+      expect(String(url)).toBe(
+        "http://unit.test/api/chat?app=default&message=swap+20+mon+to+usdc&public_key=0xabc&client_id=client-1",
+      );
+      expect((init as RequestInit | undefined)?.body).toBeUndefined();
+      expect(new Headers((init as RequestInit).headers).get("X-Session-Id")).toBe(
+        "session-1",
+      );
+    } finally {
+      vi.stubGlobal("fetch", originalFetch);
+    }
+  });
+
+  it("sends setModel as query params instead of a JSON body", async () => {
+    const response = {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: vi.fn(async () => ({
+        success: true,
+        rig: "gpt-5",
+        baml: "gpt-5-nano",
+        created: false,
+      })),
+    } as unknown as Response;
+    const nativeFetch = vi.fn(async () => response);
+    const originalFetch = globalThis.fetch;
+    vi.stubGlobal("fetch", nativeFetch);
+
+    try {
+      const client = new AomiClient({ baseUrl: "http://unit.test" });
+
+      await client.setModel("session-1", "gpt-5", {
+        app: "default",
+        clientId: "client-1",
+      });
+
+      const [url, init] = nativeFetch.mock.calls[0] ?? [];
+      expect(String(url)).toBe(
+        "http://unit.test/api/session/model?rig=gpt-5&app=default&client_id=client-1",
+      );
+      expect((init as RequestInit | undefined)?.body).toBeUndefined();
+      expect(new Headers((init as RequestInit).headers).get("X-Session-Id")).toBe(
+        "session-1",
+      );
+    } finally {
+      vi.stubGlobal("fetch", originalFetch);
+    }
+  });
 });
 
 const encoder = new TextEncoder();


### PR DESCRIPTION
## What changed
- Send `POST /api/chat` with query params instead of a JSON body.
- Send `POST /api/session/model` with query params instead of a JSON body.
- Add unit tests that lock the request shape in place.

## Why
The backend routes in `aomi/bin/backend/src/endpoint/session/chat.rs` and `aomi/bin/backend/src/endpoint/session/model.rs` read their inputs from the query string. Posting JSON to those endpoints caused `HTTP 400: Bad Request` on localhost.

## Impact
Fixes the failed message send path and model switch path in the client.

## Validation
- `pnpm vitest run packages/client/test/client.unit.test.ts`
- `pnpm vitest run src/components/runtime-tx-handler.test.tsx --config vitest.config.ts`
