### PR TITLE
chore(client): bump @aomi-labs/client to 0.1.42 to publish /api/chat fix

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/client",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "description": "Platform-agnostic TypeScript client for the Aomi backend API",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Why

The published `@aomi-labs/client@0.1.41` posted `POST /api/chat` params (`message`, `app`, …) in the JSON **body**, but the deployed backend reads them from the **query string** → every `aomi chat` failed with `HTTP 400`.

The actual code fix (query-param `sendMessage` + rebuilt `dist/`) **already landed on `main`** as part of the client refactor / OpenAPI route-manifest work. `main`'s `dist/` is in sync with source (verified: a clean `pnpm build` produces zero drift).

The only thing missing is a **version bump**: `main` is still `0.1.41`, which is the *broken* release already occupying that version on npm. Without a bump there's nothing new to publish.

## Change

One line: `package.json` `0.1.41` → `0.1.42`.

(This PR was originally a dist rebuild from a stale branch; rebased onto current `main` it collapses to just the version bump, since main already carries the fix.)

## After merge

Publish `@aomi-labs/client@0.1.42` so installed CLIs pick up the fix.

## Follow-up

Committing a hand-maintained `dist/` is what let the artifact drift from source originally. Worth building `dist/` in CI on publish so it can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)