### PR TITLE
[codex] Fix docs links to root

### DIFF
--- a/apps/landing/app/agents/build/page.tsx
+++ b/apps/landing/app/agents/build/page.tsx
@@ -111,8 +111,8 @@ export default function AgentsBuildPage() {
       </section>
 
       <p className="font-geist text-sm">
-        <Link className="underline" href="https://aomi.dev/docs/build/overview">
-          Open docs/build/overview
+        <Link className="underline" href="https://aomi.dev/docs/">
+          Open docs
         </Link>{" "}
         ·{" "}
         <Link className="underline" href="https://github.com/aomi-labs/skills">

--- a/apps/landing/app/layout-config.tsx
+++ b/apps/landing/app/layout-config.tsx
@@ -3,7 +3,7 @@ import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
 export const navLinks: NonNullable<BaseLayoutProps["links"]> = [
   {
     text: "Documentation",
-    url: "/docs/build/overview",
+    url: "https://aomi.dev/docs/",
     active: "nested-url",
   },
   {
@@ -19,7 +19,7 @@ export const navLinks: NonNullable<BaseLayoutProps["links"]> = [
 ];
 
 export const navTabs = [
-  { title: "Documentation", url: "/docs/build/overview" },
+  { title: "Documentation", url: "https://aomi.dev/docs/" },
   { title: "Examples", url: "/examples/polymarket" },
   { title: "Playground", url: "/playground/configurator" },
 ];

--- a/apps/landing/app/sections/apps.tsx
+++ b/apps/landing/app/sections/apps.tsx
@@ -507,7 +507,7 @@ export async function Apps() {
                 Build with agent
               </a>
               <a
-                href="https://aomi.dev/docs/build/overview"
+                href="https://aomi.dev/docs/"
                 className="font-geist mt-3 w-fit text-sm font-semibold text-stone-900 transition-colors hover:text-stone-700"
               >
                 Open build guide

--- a/apps/landing/app/sections/hero.tsx
+++ b/apps/landing/app/sections/hero.tsx
@@ -44,7 +44,7 @@ export function Hero() {
               Apps
             </a>
             <a
-              href="/docs/build/overview"
+              href="https://aomi.dev/docs/"
               className="font-geist text-xs font-medium text-white/70 drop-shadow-sm transition-colors hover:text-white"
             >
               Documentation
@@ -166,7 +166,7 @@ export function Hero() {
                 Apps
               </a>
               <a
-                href="/docs/build/overview"
+                href="https://aomi.dev/docs/"
                 onClick={() => setMobileMenuOpen(false)}
                 className="font-geist rounded-xl px-4 py-3 text-sm font-medium text-white transition-colors hover:bg-white/10"
               >


### PR DESCRIPTION
## Summary
- Point top-level Documentation links and build-agent docs CTA at https://aomi.dev/docs/.
- Remove the stale /docs/build/overview target that currently 404s.

## Validation
- pnpm --filter landing lint

## Notes
- Branch is based on origin/prod so this PR contains only the docs-link fix, not the rest of main.