### PR TITLE
BFF: CSRF, rate-limit, validate-input security utilities

### DIFF
--- a/apps/portal/src/lib/csrf.ts
+++ b/apps/portal/src/lib/csrf.ts
@@ -1,0 +1,23 @@
+/**
+ * CSRF origin validation for BFF route handlers.
+ *
+ * Compares the request's `origin` (or `referer`) header against the configured
+ * app URL. Fails closed: if no header is present or no env var is configured,
+ * the request is rejected.
+ */
+export function validateOrigin(req: Request): boolean {
+  const origin = req.headers.get("origin") ?? req.headers.get("referer");
+  if (!origin) return false;
+
+  const allowed =
+    process.env.NEXT_PUBLIC_APP_URL ?? process.env.NEXTAUTH_URL;
+  if (!allowed) return false; // fail-closed: if not configured, reject
+
+  try {
+    const reqOrigin = new URL(origin).origin;
+    const allowedOrigin = new URL(allowed).origin;
+    return reqOrigin === allowedOrigin;
+  } catch {
+    return false;
+  }
+}

--- a/apps/portal/src/lib/rate-limit.ts
+++ b/apps/portal/src/lib/rate-limit.ts
@@ -1,0 +1,53 @@
+/**
+ * In-process per-IP rate limiting for BFF route handlers.
+ *
+ * Uses a rolling 60-second window with a maximum of 10 requests per IP.
+ * Note: This is module-level (one Map per process). In a multi-instance
+ * deployment each instance maintains its own counters — acceptable for the
+ * current use case.
+ */
+
+const WINDOW_MS = 60_000; // 60 seconds
+const MAX_REQUESTS = 10;
+
+interface WindowEntry {
+  count: number;
+  windowStart: number;
+}
+
+// In-process map — one entry per IP address
+const windows = new Map<string, WindowEntry>();
+
+/**
+ * Check whether the given IP is within the allowed rate limit.
+ * Starts a new window if none exists or the current window has expired.
+ */
+export function checkRateLimit(ip: string): { allowed: boolean } {
+  const now = Date.now();
+  const entry = windows.get(ip);
+
+  if (!entry || now - entry.windowStart > WINDOW_MS) {
+    // No entry or window expired — start a fresh window
+    windows.set(ip, { count: 1, windowStart: now });
+    return { allowed: true };
+  }
+
+  entry.count++;
+  return { allowed: entry.count <= MAX_REQUESTS };
+}
+
+/**
+ * Extract the client IP from a Request object.
+ *
+ * Priority order:
+ * 1. `x-forwarded-for` (first value when comma-separated)
+ * 2. `x-real-ip`
+ * 3. `"unknown"` as a safe fallback
+ */
+export function getClientIp(req: Request): string {
+  return (
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    req.headers.get("x-real-ip") ??
+    "unknown"
+  );
+}

--- a/apps/portal/src/lib/validate-input.ts
+++ b/apps/portal/src/lib/validate-input.ts
@@ -1,0 +1,46 @@
+/**
+ * Input validation helpers for BFF route handlers.
+ *
+ * Each function is a type guard that returns `true` only when the value
+ * is a string matching the expected shape.  All checks fail-closed on
+ * `unknown` / non-string input.
+ */
+
+/**
+ * Accepts numeric installation IDs like `"123456789"`.
+ * Rejects empty strings, floats, negative numbers, and non-digit characters.
+ */
+export function isValidInstallationId(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  return trimmed.length > 0 && /^\d+$/.test(trimmed);
+}
+
+/**
+ * Accepts `"owner/name"` — exactly two non-empty segments separated by one `/`.
+ * Rejects trailing/leading slashes, multiple slashes, and empty segments.
+ */
+export function isValidRepo(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const parts = value.trim().split("/");
+  return parts.length === 2 && parts[0].length > 0 && parts[1].length > 0;
+}
+
+/**
+ * Rejects empty strings and whitespace-only strings.
+ */
+export function isValidDeploymentId(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Accepts a non-empty array of strings where every element is non-empty
+ * after trimming.  Rejects arrays with whitespace-only elements.
+ */
+export function isValidReleaseTags(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((tag) => typeof tag === "string" && tag.trim().length > 0)
+  );
+}


### PR DESCRIPTION
## Problem

Portal BFF routes had no security middleware — no origin validation, rate limiting, or input sanitization before proxying to the backend.

## Changes

- `csrf.ts` — `validateOrigin(req)` fail-closed against `NEXT_PUBLIC_APP_URL`
- `rate-limit.ts` — `checkRateLimit(ip)` rolling 60s window, 10 req/IP max
- `validate-input.ts` — `isValidInstallationId`, `isValidRepo`, `isValidDeploymentId`, `isValidReleaseTags`

## Validation

- `pnpm exec vitest run apps/portal/src/lib/__tests__`