### PR TITLE
SDK: watchDeployment with exponential backoff + property tests

### DIFF
--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -29,5 +29,7 @@
   "engines": {
     "node": ">=18"
   },
-  "dependencies": {}
+  "devDependencies": {
+    "fast-check": "^4.8.0"
+  }
 }

--- a/packages/deploy/src/__tests__/watch-deployment.property.test.ts
+++ b/packages/deploy/src/__tests__/watch-deployment.property.test.ts
@@ -1,0 +1,243 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fc from "fast-check";
+
+import { DeploymentClient } from "../client";
+import type {
+  DeploymentProgressEvent,
+  DeploymentStatus,
+  ProgressModel,
+} from "../types";
+
+// Shared client reused in unit-level property tests (Properties 4)
+let client: DeploymentClient;
+
+beforeEach(() => {
+  client = new DeploymentClient({
+    aomi: {
+      backendUrl: "https://staging-api.example.com",
+      activationToken: "act-token",
+    },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+// Helper: build a fetch mock that returns states in order, then repeats the last
+function mockStatusSequence(states: string[]) {
+  let idx = 0;
+  return vi.fn().mockImplementation(async () => {
+    const state = states[Math.min(idx, states.length - 1)];
+    idx++;
+    return new Response(
+      JSON.stringify({ state, releaseTags: [] } satisfies DeploymentStatus),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+}
+
+// Helper: collect events from watchDeployment with fake timers
+async function runWatch(
+  states: string[],
+  signal?: AbortSignal,
+): Promise<DeploymentProgressEvent[]> {
+  const events: DeploymentProgressEvent[] = [];
+  const fetchMock = mockStatusSequence(states);
+  vi.stubGlobal("fetch", fetchMock);
+
+  const promise = client.watchDeployment("dep_1", "community", (e) =>
+    events.push(e),
+    { baseDelayMs: 1, maxDelayMs: 5, maxRetries: 3, signal },
+  );
+
+  await vi.advanceTimersByTimeAsync(5000);
+  await promise;
+  return events;
+}
+
+// Feature: deploy-flow-production-ready, Property 1: watchDeployment terminates on terminal state
+describe("Property 1 — terminates on terminal state", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("always emits a terminal event last and stops polling after it", () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.array(
+          fc.constantFrom("pending", "building", "releasing", "ready", "failed"),
+          { minLength: 1, maxLength: 8 },
+        ),
+        async (states) => {
+          // Ensure at least one terminal state somewhere in the sequence
+          const hasTerminal = states.some(
+            (s) => s === "ready" || s === "failed",
+          );
+          if (!hasTerminal) return; // skip non-terminal sequences for this property
+
+          const events = await runWatch(states);
+
+          expect(events.length).toBeGreaterThanOrEqual(1);
+          const lastEvent = events[events.length - 1];
+          expect(lastEvent.kind).toBe("terminal");
+          expect(["ready", "failed"]).toContain(lastEvent.status.state);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});
+
+// Feature: deploy-flow-production-ready, Property 2: Every emitted event carries valid ProgressModel
+describe("Property 2 — every event has a valid ProgressModel", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("all progress events carry a valid ProgressModel", () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.array(
+          fc.constantFrom("pending", "building", "releasing", "ready", "failed"),
+          { minLength: 1, maxLength: 8 },
+        ),
+        async (states) => {
+          const events = await runWatch(states);
+
+          for (const event of events) {
+            expect(event.progress).toBeDefined();
+            expect(event.progress.total).toBeGreaterThan(0);
+            expect(event.progress.completed).toBeGreaterThanOrEqual(0);
+            expect(event.progress.completed).toBeLessThanOrEqual(
+              event.progress.total,
+            );
+            expect(event.progress.label.length).toBeGreaterThan(0);
+          }
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});
+
+// Feature: deploy-flow-production-ready, Property 3: ProgressModel.completed is monotonically non-decreasing
+describe("Property 3 — monotonically non-decreasing completed", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("completed never decreases across successive events", () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.array(
+          fc.constantFrom("pending", "building", "releasing", "ready", "failed"),
+          { minLength: 2, maxLength: 8 },
+        ),
+        async (states) => {
+          // Exclude sequences that contain "failed" followed by a non-terminal state
+          // (failed resets completed to 0 which would appear as a decrease)
+          const failedIdx = states.indexOf("failed");
+          if (failedIdx >= 0 && failedIdx < states.length - 1) return;
+
+          const events = await runWatch(states);
+
+          let lastCompleted = -1;
+          for (const event of events) {
+            expect(event.progress.completed).toBeGreaterThanOrEqual(
+              lastCompleted,
+            );
+            lastCompleted = event.progress.completed;
+          }
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("clamps completed using max(mapped, lastCompleted)", () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.array(
+          fc.constantFrom("pending", "building", "releasing"),
+          { minLength: 2, maxLength: 6 },
+        ),
+        async (states) => {
+          const events = await runWatch(states);
+
+          let lastCompleted = -1;
+          for (const event of events) {
+            // The SDK clamps: completed = max(mapped, lastCompleted)
+            // So completed should never be less than the previous value
+            // when the state is not "failed"
+            expect(event.progress.completed).toBeGreaterThanOrEqual(
+              lastCompleted,
+            );
+            lastCompleted = event.progress.completed;
+          }
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});
+
+// Feature: deploy-flow-production-ready, Property 4: Exponential backoff delay grows with failure count
+describe("Property 4 — exponential backoff is non-decreasing", () => {
+  it("delay at failure n is always >= delay at failure n-1", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 7 }),
+        (n) => {
+          const delayN = (client as any).backoffDelay(n, 3000, 30000) as number;
+          const delayNminus1 = (client as any).backoffDelay(
+            n - 1,
+            3000,
+            30000,
+          ) as number;
+          expect(delayN).toBeGreaterThanOrEqual(delayNminus1);
+        },
+      ),
+      { numRuns: 50 },
+    );
+  });
+
+  it("delay at failure 0 equals the base delay", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 100, max: 5000 }),
+        fc.integer({ min: 5000, max: 60000 }),
+        (baseMs, maxMs) => {
+          const delay = (client as any).backoffDelay(
+            0,
+            baseMs,
+            maxMs,
+          ) as number;
+          expect(delay).toBe(baseMs);
+        },
+      ),
+      { numRuns: 50 },
+    );
+  });
+
+  it("delay never exceeds maxDelayMs", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 20 }),
+        fc.integer({ min: 100, max: 5000 }),
+        fc.integer({ min: 5000, max: 60000 }),
+        (failures, baseMs, maxMs) => {
+          const delay = (client as any).backoffDelay(
+            failures,
+            baseMs,
+            maxMs,
+          ) as number;
+          expect(delay).toBeLessThanOrEqual(maxMs);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/packages/deploy/src/__tests__/watch-deployment.property.test.ts
+++ b/packages/deploy/src/__tests__/watch-deployment.property.test.ts
@@ -44,6 +44,7 @@ async function runWatch(
   states: string[],
   signal?: AbortSignal,
 ): Promise<DeploymentProgressEvent[]> {
+  vi.useFakeTimers();
   const events: DeploymentProgressEvent[] = [];
   const fetchMock = mockStatusSequence(states);
   vi.stubGlobal("fetch", fetchMock);
@@ -60,10 +61,6 @@ async function runWatch(
 
 // Feature: deploy-flow-production-ready, Property 1: watchDeployment terminates on terminal state
 describe("Property 1 — terminates on terminal state", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-
   it("always emits a terminal event last and stops polling after it", () => {
     fc.assert(
       fc.asyncProperty(
@@ -93,10 +90,6 @@ describe("Property 1 — terminates on terminal state", () => {
 
 // Feature: deploy-flow-production-ready, Property 2: Every emitted event carries valid ProgressModel
 describe("Property 2 — every event has a valid ProgressModel", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-
   it("all progress events carry a valid ProgressModel", () => {
     fc.assert(
       fc.asyncProperty(
@@ -125,10 +118,6 @@ describe("Property 2 — every event has a valid ProgressModel", () => {
 
 // Feature: deploy-flow-production-ready, Property 3: ProgressModel.completed is monotonically non-decreasing
 describe("Property 3 — monotonically non-decreasing completed", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-
   it("completed never decreases across successive events", () => {
     fc.assert(
       fc.asyncProperty(

--- a/packages/deploy/src/client.ts
+++ b/packages/deploy/src/client.ts
@@ -6,8 +6,11 @@ import type {
   DeployInput,
   DeployResult,
   DeploymentClientOptions,
+  DeploymentProgressEvent,
+  DeploymentStatus,
+  ProgressModel,
   StatusInput,
-  StatusResult,
+  WatchDeploymentOptions,
 } from "./types";
 
 /**
@@ -67,11 +70,12 @@ export class DeploymentClient {
     return camelActivateResult(result);
   }
 
-  async status(input: StatusInput): Promise<StatusResult> {
+  async status(input: StatusInput): Promise<DeploymentStatus> {
     const platform = cleanPlatform(input.platform);
-    const path =
-      input.path ?? `/api/platforms/${encodeURIComponent(platform)}/status`;
-    const result = await this.get<StatusResult>(path, "status");
+    const path = input.deploymentId
+      ? `/api/platforms/${encodeURIComponent(platform)}/deployments/${encodeURIComponent(input.deploymentId)}/status`
+      : (input.path ?? `/api/platforms/${encodeURIComponent(platform)}/status`);
+    const result = await this.get<DeploymentStatus>(path, "status");
     await this.audit({
       action: "status",
       platform,
@@ -81,9 +85,92 @@ export class DeploymentClient {
     return result;
   }
 
+  /**
+   * Poll GET /api/platforms/:platform/deployments/:id/status until a terminal
+   * state is reached or retries are exhausted. Calls onEvent for every tick.
+   */
+  async watchDeployment(
+    deploymentId: string,
+    platform: string,
+    onEvent: (event: DeploymentProgressEvent) => void,
+    options?: WatchDeploymentOptions,
+  ): Promise<void> {
+    const baseDelayMs = options?.baseDelayMs ?? 3000;
+    const maxDelayMs = options?.maxDelayMs ?? 30000;
+    const maxRetries = options?.maxRetries ?? 8;
+    const signal = options?.signal;
+
+    let failures = 0;
+    let lastCompleted = 0;
+    let lastProgress: ProgressModel = { completed: 0, total: 8, label: "Waiting for build" };
+
+    while (!signal?.aborted && failures < maxRetries) {
+      try {
+        const status = await this.status({ platform, deploymentId });
+        const mapped = this.buildProgressModel(status, lastCompleted);
+        const completed = Math.max(mapped.completed, lastCompleted);
+        const progress: ProgressModel = { ...mapped, completed };
+        lastCompleted = completed;
+        lastProgress = progress;
+
+        const isTerminal = status.state === "ready" || status.state === "failed";
+        onEvent({
+          kind: isTerminal ? "terminal" : "progress",
+          status,
+          progress,
+        });
+
+        if (isTerminal) return;
+
+        failures = 0;
+        await sleep(this.backoffDelay(0, baseDelayMs, maxDelayMs));
+      } catch (err) {
+        failures++;
+        await sleep(this.backoffDelay(failures, baseDelayMs, maxDelayMs));
+      }
+    }
+
+    // Loop exited without a terminal state — emit error event
+    const errorMsg = signal?.aborted
+      ? "Watch cancelled"
+      : `Polling stopped after ${maxRetries} consecutive failures`;
+    onEvent({
+      kind: "error",
+      status: {
+        state: "failed",
+        releaseTags: [],
+        message: errorMsg,
+      },
+      progress: lastProgress,
+      error: new Error(errorMsg),
+    });
+  }
+
   endpoint(path: string): string {
     const cleanPath = path.startsWith("/") ? path : `/${path}`;
     return `${this.baseUrl}${cleanPath}`;
+  }
+
+  private buildProgressModel(status: DeploymentStatus, lastCompleted: number): ProgressModel {
+    const total = 8;
+    switch (status.state) {
+      case "pending":
+        return { completed: 1, total, label: "Waiting for build" };
+      case "building":
+        return { completed: 2, total, label: "Building CI" };
+      case "releasing":
+        return { completed: 5, total, label: "Verifying release assets" };
+      case "ready":
+        return { completed: 8, total, label: "Build ready" };
+      case "failed":
+        return { completed: lastCompleted, total, label: "Build failed" };
+      default:
+        return { completed: lastCompleted, total, label: "Waiting for build" };
+    }
+  }
+
+  private backoffDelay(failures: number, baseMs: number, maxMs: number): number {
+    return Math.min(baseMs * Math.pow(2, failures), maxMs);
   }
 
   private async get<Resp>(path: string, operation: string): Promise<Resp> {
@@ -340,4 +427,8 @@ function camelActivateResult(result: unknown): ActivateResult {
       })),
     },
   };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/deploy/test/watch-deployment.pbt.test.ts
+++ b/packages/deploy/test/watch-deployment.pbt.test.ts
@@ -1,0 +1,272 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fc from "fast-check";
+
+import { DeploymentClient } from "../src/client";
+import type {
+  DeploymentProgressEvent,
+  DeploymentStatus,
+  ProgressModel,
+} from "../src/types";
+
+describe("watchDeployment — property-based", () => {
+  it("buildProgressModel produces monotonic completed", () => {
+    const client = new DeploymentClient({
+      aomi: {
+        backendUrl: "https://staging-api.example.com",
+        activationToken: "act-token",
+      },
+    });
+
+    fc.assert(
+      fc.property(
+        fc
+          .record({
+            state: fc.constantFrom(
+              "pending",
+              "building",
+              "releasing",
+              "ready",
+              "failed",
+            ),
+            lastCompleted: fc.integer({ min: 0, max: 8 }),
+          })
+          .filter(({ state, lastCompleted }) =>
+            state !== "failed" ? true : lastCompleted >= 0,
+          ),
+        ({ state, lastCompleted }) => {
+          const model = (client as any).buildProgressModel(
+            { state, releaseTags: [] } as DeploymentStatus,
+            lastCompleted,
+          ) as ProgressModel;
+
+          expect(model.total).toBe(8);
+          expect(model.completed).toBeGreaterThanOrEqual(0);
+          expect(model.completed).toBeLessThanOrEqual(model.total);
+          expect(model.label).toBeTruthy();
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("backoffDelay doubles each failure up to maxDelayMs", () => {
+    const client = new DeploymentClient({
+      aomi: {
+        backendUrl: "https://staging-api.example.com",
+        activationToken: "act-token",
+      },
+    });
+
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 20 }),
+        fc.integer({ min: 100, max: 5000 }),
+        fc.integer({ min: 5000, max: 60000 }),
+        (failures, baseMs, maxMs) => {
+          const delay = (client as any).backoffDelay(
+            failures,
+            baseMs,
+            maxMs,
+          ) as number;
+
+          expect(delay).toBeGreaterThanOrEqual(0);
+          expect(delay).toBeLessThanOrEqual(maxMs);
+          if (failures === 0) {
+            expect(delay).toBe(baseMs);
+          }
+          if (failures > 0) {
+            expect(delay).toBe(Math.min(baseMs * Math.pow(2, failures), maxMs));
+          }
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("terminal states (ready, failed) are detected correctly", () => {
+    const client = new DeploymentClient({
+      aomi: {
+        backendUrl: "https://staging-api.example.com",
+        activationToken: "act-token",
+      },
+    });
+
+    fc.assert(
+      fc.property(
+        fc.constantFrom(
+          ...(["pending", "building", "releasing", "ready", "failed"] as const),
+        ),
+        (state) => {
+          const isTerminal = state === "ready" || state === "failed";
+          const model = (client as any).buildProgressModel(
+            { state, releaseTags: [] } as DeploymentStatus,
+            0,
+          ) as ProgressModel;
+
+          expect(model.total).toBe(8);
+          if (state === "ready") {
+            expect(model.completed).toBe(8);
+          }
+          if (state === "failed") {
+            expect(model.completed).toBe(0); // passes lastCompleted=0
+          }
+          if (state === "pending") {
+            expect(model.completed).toBe(1);
+          }
+          if (state === "building") {
+            expect(model.completed).toBe(2);
+          }
+          if (state === "releasing") {
+            expect(model.completed).toBe(5);
+          }
+        },
+      ),
+      { numRuns: 50 },
+    );
+  });
+
+  it("terminates when terminal state received (Property 1)", async () => {
+    vi.useFakeTimers();
+
+    const terminalState: DeploymentStatus = {
+      state: "ready",
+      releaseTags: ["v1.0"],
+      apps: [],
+    };
+
+    const states: DeploymentStatus[] = [
+      { state: "pending", releaseTags: [] },
+      { state: "building", releaseTags: [] },
+      terminalState,
+    ];
+
+    let callCount = 0;
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify(states[0]),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    // Override per-call via mockImplementation
+    fetchMock.mockImplementation(async () => {
+      const s = states[Math.min(callCount, states.length - 1)];
+      callCount++;
+      return new Response(JSON.stringify(s), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const client = new DeploymentClient({
+        aomi: {
+          backendUrl: "https://staging-api.example.com",
+          activationToken: "act-token",
+        },
+      });
+
+      const events: DeploymentProgressEvent[] = [];
+
+      const promise = client.watchDeployment(
+        "dep_1",
+        "community",
+        (e) => events.push(e),
+        {
+          baseDelayMs: 1,
+          maxDelayMs: 5,
+          maxRetries: 3,
+        },
+      );
+
+      // Advance time to let all polls complete
+      // Each tick: status call (instant) + sleep(baseDelayMs=1)
+      await vi.advanceTimersByTimeAsync(100);
+
+      await promise;
+
+      expect(events.length).toBeGreaterThanOrEqual(1);
+      const lastEvent = events[events.length - 1];
+      expect(lastEvent.kind).toBe("terminal");
+      expect(lastEvent.status.state).toBe("ready");
+
+      // Verify no more fetches happen after terminal
+      const fetchCountAfterTerminal = callCount;
+      await vi.advanceTimersByTimeAsync(100);
+      expect(callCount).toBe(fetchCountAfterTerminal);
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+  });
+
+  it("emits error event on poll exhaustion (Property 1b)", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network error"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const client = new DeploymentClient({
+        aomi: {
+          backendUrl: "https://staging-api.example.com",
+          activationToken: "act-token",
+        },
+      });
+
+      const events: DeploymentProgressEvent[] = [];
+
+      const promise = client.watchDeployment(
+        "dep_1",
+        "community",
+        (e) => events.push(e),
+        { baseDelayMs: 1, maxDelayMs: 5, maxRetries: 3 },
+      );
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await promise;
+
+      expect(events.length).toBeGreaterThanOrEqual(1);
+      const lastEvent = events[events.length - 1];
+      expect(lastEvent.kind).toBe("error");
+      expect(lastEvent.progress).toBeDefined();
+      expect(lastEvent.error).toBeDefined();
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+  });
+
+  it("progress model labels are non-empty strings", () => {
+    const client = new DeploymentClient({
+      aomi: {
+        backendUrl: "https://staging-api.example.com",
+        activationToken: "act-token",
+      },
+    });
+
+    fc.assert(
+      fc.property(
+        fc.constantFrom(
+          "pending",
+          "building",
+          "releasing",
+          "ready",
+          "failed",
+          "unknown_state",
+        ),
+        (state) => {
+          const model = (client as any).buildProgressModel(
+            { state, releaseTags: [] } as DeploymentStatus,
+            3,
+          ) as ProgressModel;
+
+          expect(model.label).toBeTruthy();
+          expect(typeof model.label).toBe("string");
+          expect(model.label.length).toBeGreaterThan(0);
+        },
+      ),
+      { numRuns: 50 },
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -759,7 +759,11 @@ importers:
         specifier: ^2.47.11
         version: 2.47.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
 
-  packages/deploy: {}
+  packages/deploy:
+    devDependencies:
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
 
   packages/react:
     dependencies:
@@ -5567,6 +5571,7 @@ packages:
   '@stellar/stellar-base@14.1.0':
     resolution: {integrity: sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw==}
     engines: {node: '>=20.0.0'}
+    deprecated: This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.
 
   '@stellar/stellar-sdk@14.6.1':
     resolution: {integrity: sha512-A1rQWDLdUasXkMXnYSuhgep+3ZZzyuXJKdt5/KAIc0gkmSp906HTvUpbT4pu+bVr41tu0+J4Ugz9J4BQAGGytg==}
@@ -8430,6 +8435,10 @@ packages:
     resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
     engines: {node: '> 0.1.90'}
 
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
   fast-copy@3.0.2:
     resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
 
@@ -11044,6 +11053,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   qrcode-with-logos@1.1.1:
     resolution: {integrity: sha512-vh0LWvwalp7471ODXd4rcXrbKgRpfwfdrjfb3pdr9+Zz/s27+5clRHFxzh5orTm1rusStfHGMACP7GWVAkzpKQ==}
@@ -33791,6 +33803,10 @@ snapshots:
 
   eyes@0.1.8: {}
 
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-copy@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
@@ -37468,6 +37484,8 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  pure-rand@8.4.0: {}
 
   qrcode-with-logos@1.1.1:
     dependencies:


### PR DESCRIPTION
## Problem

`DeploymentClient.status()` returned `Promise<unknown>` — every caller cast the result. Portal and CLI each wrote their own polling loop with different backoff logic.

## Changes

- `status()` returns `Promise<DeploymentStatus>` — type-safe, no casts
- `watchDeployment()` — shared polling with exponential backoff (3s base, 30s cap), monotonic progress clamping
- Property-based tests for termination, valid ProgressModel, monotonic completed, backoff

## Validation

- `pnpm exec vitest run packages/deploy`