### PR TITLE
BFF: TokenCache with TTL, 30s fetch timeout, 401/403 invalidation

### DIFF
--- a/apps/portal/src/lib/onboard-deploy.ts
+++ b/apps/portal/src/lib/onboard-deploy.ts
@@ -43,7 +43,31 @@ export type OnboardDeployEnv = {
   targetTags: string[];
 };
 
-let cachedPlatformActivationToken: string | null = null;
+const TOKEN_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+class TokenCache {
+  private entry: { token: string; expiresAt: number } | null = null;
+
+  get(): string | null {
+    if (!this.entry) return null;
+    if (Date.now() > this.entry.expiresAt) {
+      this.entry = null;
+      return null;
+    }
+    return this.entry.token;
+  }
+
+  set(token: string): void {
+    this.entry = { token, expiresAt: Date.now() + TOKEN_TTL_MS };
+  }
+
+  invalidate(): void {
+    this.entry = null;
+  }
+}
+
+// Module-level singleton (one per server process, not per request — but TTL-gated)
+const tokenCache = new TokenCache();
 
 export type BackendDeployPayload = {
   id: string;
@@ -137,8 +161,9 @@ export async function activationEnv(
   env: OnboardDeployEnv,
 ): Promise<OnboardDeployEnv> {
   if (env.activationToken) return env;
-  if (cachedPlatformActivationToken) {
-    return { ...env, bearer: cachedPlatformActivationToken };
+  const cached = tokenCache.get();
+  if (cached) {
+    return { ...env, bearer: cached };
   }
   if (!env.adminSecret) {
     throw new Error(
@@ -156,7 +181,7 @@ export async function activationEnv(
   if (!minted.token) {
     throw new Error("backend did not return a platform activation token");
   }
-  cachedPlatformActivationToken = minted.token;
+  tokenCache.set(minted.token);
   return { ...env, bearer: minted.token };
 }
 
@@ -165,14 +190,32 @@ export async function backendRequest<T>(
   path: string,
   opts: BackendRequestOptions = {},
 ): Promise<T> {
-  const res = await fetch(`${env.backendUrl}${path}`, {
-    method: opts.method ?? "GET",
-    headers: {
-      Authorization: `Bearer ${env.bearer}`,
-      ...(opts.body ? { "Content-Type": "application/json" } : {}),
-    },
-    body: opts.body ? JSON.stringify(opts.body) : undefined,
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 30_000);
+  let res: Response;
+  try {
+    res = await fetch(`${env.backendUrl}${path}`, {
+      method: opts.method ?? "GET",
+      headers: {
+        Authorization: `Bearer ${env.bearer}`,
+        ...(opts.body ? { "Content-Type": "application/json" } : {}),
+      },
+      body: opts.body ? JSON.stringify(opts.body) : undefined,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new BackendRequestError({
+        message: "Request to backend timed out after 30 seconds",
+        status: 504,
+        path,
+        body: "",
+      });
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeoutId);
+  }
   const text = await res.text();
   let json: unknown = null;
   if (text.trim()) {
@@ -187,7 +230,7 @@ export async function backendRequest<T>(
     // cached one on an auth failure so the next activation re-mints instead of
     // looping on a stale token for the lifetime of the server process.
     if (res.status === 401 || res.status === 403) {
-      cachedPlatformActivationToken = null;
+      tokenCache.invalidate();
     }
     const message =
       json && typeof json === "object" && "error" in json


### PR DESCRIPTION
## Problem

The activation token was a module-level `string | null` with no expiry — stale tokens lived for the process lifetime. Backend requests had no timeout.

## Changes

- `TokenCache` class with 5-minute TTL, invalidation on 401/403
- `backendRequest()` wraps fetch with `AbortController` — 30s timeout returns 504
- `clearTimeout` in finally block

## Validation

- `pnpm exec tsc --noEmit`