### PR TITLE
CLI: deploy status and activate subcommands

### DIFF
--- a/packages/client/src/cli/commands/activate.ts
+++ b/packages/client/src/cli/commands/activate.ts
@@ -1,0 +1,104 @@
+import { DeployCliError } from "../errors";
+import { readDeploymentState, writeDeploymentState } from "../../lib/deployment-state";
+
+type ActivateArgs = Record<string, unknown>;
+
+function str(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function requireToken(args: ActivateArgs): string {
+  const token = str(args["activation-token"]) ?? process.env.AOMI_DEPLOY_TOKEN;
+  if (!token) {
+    throw new DeployCliError(
+      "VALIDATION_ERROR",
+      "`--activation-token` is required. Pass it or set the AOMI_DEPLOY_TOKEN env var.",
+    );
+  }
+  return token;
+}
+
+function resolveBackendUrl(args: ActivateArgs): string {
+  return (
+    str(args["backend-url"]) ??
+    process.env.AOMI_BACKEND_URL ??
+    "https://api.aomi.dev"
+  ).replace(/\/+$/, "");
+}
+
+function resolvePlatform(args: ActivateArgs): string {
+  return (
+    str(args.platform) ??
+    process.env.AOMI_DEPLOY_PLATFORM ??
+    "community"
+  );
+}
+
+async function extractError(res: Response): Promise<string> {
+  try {
+    const text = await res.text();
+    const json = JSON.parse(text);
+    if (json && typeof json === "object" && json.error) return json.error as string;
+    return text || `${res.status} ${res.statusText}`;
+  } catch {
+    return `${res.status} ${res.statusText}`;
+  }
+}
+
+export async function activateCommand(args: ActivateArgs): Promise<void> {
+  const state = await readDeploymentState();
+
+  const deploymentId = str(args["deployment-id"]) ?? state?.deploymentId;
+  const releaseTagsRaw = str(args["release-tags"]);
+  const releaseTags =
+    releaseTagsRaw !== undefined
+      ? releaseTagsRaw
+          .split(",")
+          .map((t) => t.trim())
+          .filter(Boolean)
+      : (state?.releaseTags ?? []);
+
+  if (!deploymentId || releaseTags.length === 0) {
+    throw new DeployCliError(
+      "VALIDATION_ERROR",
+      "No deployment found. Run `aomi deploy` first, or pass --deployment-id and --release-tags.",
+    );
+  }
+
+  const activationToken = requireToken(args);
+  const backendUrl = resolveBackendUrl(args);
+  const platform = resolvePlatform(args);
+
+  const url = `${backendUrl}/api/platforms/${encodeURIComponent(platform)}/apps/activate`;
+  const body = { target: { kind: "release_tags", value: releaseTags } };
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${activationToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    throw new DeployCliError(
+      "NETWORK_ERROR",
+      `Activation request failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!res.ok) {
+    const msg = await extractError(res);
+    const code = res.status === 401 || res.status === 403 ? "AUTH_FAILED" : "BACKEND_ERROR";
+    throw new DeployCliError(code, `Activation failed (${res.status}): ${msg}`);
+  }
+
+  // Update timestamp in deployment.json on success
+  if (state) {
+    await writeDeploymentState({ ...state, timestamp: new Date().toISOString() });
+  }
+
+  console.log(" Activation succeeded.");
+}

--- a/packages/client/src/cli/commands/defs/activate.ts
+++ b/packages/client/src/cli/commands/defs/activate.ts
@@ -1,0 +1,35 @@
+import { defineCommand } from "citty";
+
+export const activateDef = defineCommand({
+  meta: {
+    name: "activate",
+    description: "Activate a deployment by promoting release tags",
+  },
+  args: {
+    "deployment-id": {
+      type: "string",
+      description: "Deployment ID (reads .aomi/deployment.json if absent)",
+    },
+    "release-tags": {
+      type: "string",
+      description:
+        "Comma-separated release tags to activate (reads .aomi/deployment.json if absent)",
+    },
+    "activation-token": {
+      type: "string",
+      description: "Platform activation token (or set AOMI_DEPLOY_TOKEN env)",
+    },
+    "backend-url": {
+      type: "string",
+      description: "Backend URL (default: https://api.aomi.dev)",
+    },
+    platform: {
+      type: "string",
+      description: "Deploy platform (default: community; or set AOMI_DEPLOY_PLATFORM env)",
+    },
+  },
+  async run({ args }) {
+    const { activateCommand } = await import("../activate");
+    await activateCommand(args);
+  },
+});

--- a/packages/client/src/cli/commands/defs/deploy.ts
+++ b/packages/client/src/cli/commands/defs/deploy.ts
@@ -1,5 +1,7 @@
 import { defineCommand } from "citty";
 import { globalArgs } from "./shared";
+import { statusDef } from "./status";
+import { activateDef } from "./activate";
 
 export const deployDef = defineCommand({
   meta: {
@@ -45,5 +47,9 @@ export const deployDef = defineCommand({
   async run({ args }) {
     const { deployCommand } = await import("../deploy");
     await deployCommand(args);
+  },
+  subCommands: {
+    status: statusDef,
+    activate: activateDef,
   },
 });

--- a/packages/client/src/cli/commands/defs/status.ts
+++ b/packages/client/src/cli/commands/defs/status.ts
@@ -1,0 +1,34 @@
+import { defineCommand } from "citty";
+
+export const statusDef = defineCommand({
+  meta: {
+    name: "status",
+    description: "Show current deployment status",
+  },
+  args: {
+    "deployment-id": {
+      type: "string",
+      description: "Deployment ID (reads .aomi/deployment.json if absent)",
+    },
+    watch: {
+      type: "boolean",
+      description: "Poll until a terminal state is reached",
+    },
+    "activation-token": {
+      type: "string",
+      description: "Platform activation token (or set AOMI_DEPLOY_TOKEN env)",
+    },
+    "backend-url": {
+      type: "string",
+      description: "Backend URL (default: https://api.aomi.dev)",
+    },
+    platform: {
+      type: "string",
+      description: "Deploy platform (default: community; or set AOMI_DEPLOY_PLATFORM env)",
+    },
+  },
+  async run({ args }) {
+    const { statusCommand } = await import("../status");
+    await statusCommand(args);
+  },
+});

--- a/packages/client/src/cli/commands/status.ts
+++ b/packages/client/src/cli/commands/status.ts
@@ -1,0 +1,189 @@
+import { DeployCliError } from "../errors";
+import { readDeploymentState } from "../../lib/deployment-state";
+
+type StatusArgs = Record<string, unknown>;
+
+interface DeploymentAppStatus {
+  name: string;
+  releaseTag: string;
+  releaseReady: boolean;
+  message?: string | null;
+}
+
+interface DeploymentStatus {
+  state: "building" | "releasing" | "ready" | "failed" | "pending";
+  deployment?: Record<string, unknown>;
+  releaseTags: string[];
+  apps?: DeploymentAppStatus[];
+  ci?: { status?: string; url?: string; commitHash?: string };
+  message?: string;
+}
+
+function str(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function requireToken(args: StatusArgs): string {
+  const token = str(args["activation-token"]) ?? process.env.AOMI_DEPLOY_TOKEN;
+  if (!token) {
+    throw new DeployCliError(
+      "VALIDATION_ERROR",
+      "`--activation-token` is required. Pass it or set the AOMI_DEPLOY_TOKEN env var.",
+    );
+  }
+  return token;
+}
+
+function resolveBackendUrl(args: StatusArgs): string {
+  return (
+    str(args["backend-url"]) ??
+    process.env.AOMI_BACKEND_URL ??
+    "https://api.aomi.dev"
+  ).replace(/\/+$/, "");
+}
+
+function resolvePlatform(args: StatusArgs): string {
+  return (
+    str(args.platform) ??
+    process.env.AOMI_DEPLOY_PLATFORM ??
+    "community"
+  );
+}
+
+async function fetchStatus(
+  deploymentId: string,
+  platform: string,
+  activationToken: string,
+  backendUrl: string,
+): Promise<DeploymentStatus> {
+  const url = `${backendUrl}/api/platforms/${encodeURIComponent(platform)}/deployments/${encodeURIComponent(deploymentId)}/status`;
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${activationToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (err) {
+    throw new DeployCliError(
+      "NETWORK_ERROR",
+      `Status request failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const text = await res.text();
+  if (!res.ok) {
+    const message = (() => {
+      try {
+        const json = JSON.parse(text);
+        if (json && typeof json === "object" && json.error) return json.error as string;
+      } catch {}
+      return `${res.status} ${res.statusText}`;
+    })();
+    if (res.status === 401 || res.status === 403) {
+      throw new DeployCliError("AUTH_FAILED", `Status request failed (${res.status}): ${message}`);
+    }
+    throw new DeployCliError("BACKEND_ERROR", `Status request failed (${res.status}): ${message}`);
+  }
+
+  try {
+    return JSON.parse(text) as DeploymentStatus;
+  } catch {
+    throw new DeployCliError("BACKEND_ERROR", "Backend returned invalid JSON.");
+  }
+}
+
+function printStatus(status: DeploymentStatus): void {
+  const CYAN = "\x1b[36m";
+  const DIM = "\x1b[2m";
+  const RESET = "\x1b[0m";
+
+  console.log(`${CYAN}State:${RESET} ${status.state}`);
+
+  if (status.ci?.url) {
+    console.log(`${DIM}CI:${RESET}    ${status.ci.url}`);
+  }
+
+  if (status.deployment) {
+    const platform = (status.deployment as Record<string, unknown>)?.platform as Record<string, unknown> | undefined;
+    if (platform?.pr_url) {
+      console.log(`${DIM}PR:${RESET}    ${platform.pr_url}`);
+    }
+  }
+
+  if (status.apps && status.apps.length > 0) {
+    for (const app of status.apps) {
+      const tag = app.releaseTag ? ` (${app.releaseTag})` : "";
+      console.log(`${DIM}App:${RESET}   ${app.name}${tag}`);
+    }
+  } else if (status.releaseTags && status.releaseTags.length > 0) {
+    for (const tag of status.releaseTags) {
+      console.log(`${DIM}Tag:${RESET}   ${tag}`);
+    }
+  }
+
+  if (status.message) {
+    console.log(`${DIM}Msg:${RESET}   ${status.message}`);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function statusCommand(args: StatusArgs): Promise<void> {
+  const deploymentId =
+    str(args["deployment-id"]) ??
+    (await readDeploymentState())?.deploymentId;
+
+  if (!deploymentId) {
+    throw new DeployCliError(
+      "VALIDATION_ERROR",
+      "No deployment ID found. Pass --deployment-id or run `aomi deploy` first.",
+    );
+  }
+
+  const activationToken = requireToken(args);
+  const backendUrl = resolveBackendUrl(args);
+  const platform = resolvePlatform(args);
+  const watch = args.watch === true;
+
+  if (!watch) {
+    const status = await fetchStatus(deploymentId, platform, activationToken, backendUrl);
+    printStatus(status);
+    return;
+  }
+
+  // --watch: poll with exponential backoff
+  const MAX_FAILURES = 8;
+  const BASE_DELAY_MS = 3_000;
+  const MAX_DELAY_MS = 30_000;
+  let failures = 0;
+
+  while (true) {
+    try {
+      const status = await fetchStatus(deploymentId, platform, activationToken, backendUrl);
+      printStatus(status);
+      failures = 0;
+
+      if (status.state === "ready") {
+        process.exit(0);
+        return;
+      }
+      if (status.state === "failed") {
+        process.exit(1);
+        return;
+      }
+
+      await sleep(BASE_DELAY_MS);
+    } catch (err) {
+      failures++;
+      if (failures >= MAX_FAILURES) {
+        throw err;
+      }
+      const backoffMs = Math.min(BASE_DELAY_MS * Math.pow(2, failures), MAX_DELAY_MS);
+      await sleep(backoffMs);
+    }
+  }
+}


### PR DESCRIPTION
## Problem

No CLI workflow existed for checking build progress or promoting a release.

## Changes

- `aomi deploy status` — reads deploymentId from `.aomi/deployment.json` or `--deployment-id`; displays state, CI link, apps
- `aomi deploy status --watch` — polls with exponential backoff until ready or failed
- `aomi deploy activate` — promotes a built release using stored or passed deployment config
- Both registered as `subCommands` of `deploy`

## Validation

- `pnpm exec vitest run packages/client/test/cli`