### PR TITLE
Portal UI: configurable chat URL via NEXT_PUBLIC_CHAT_URL, remove mock code

### DIFF
--- a/apps/portal/src/components/settings/onboarding/bootstrap-wizard.tsx
+++ b/apps/portal/src/components/settings/onboarding/bootstrap-wizard.tsx
@@ -10,6 +10,7 @@ import {
   TEMPLATE_GENERATE_URL,
   type PathProgress,
 } from "@portal/lib/onboarding";
+import { chatAppUrl } from "@portal/lib/chat-url";
 import { Stepper } from "./stepper";
 import { DeployStep } from "./deploy-step";
 import { LivePanel } from "./live-panel";
@@ -255,11 +256,7 @@ export function BootstrapWizard({
       {step === "live" && (
         <LivePanel
           repo={progress.repo}
-          chatUrl={
-            progress.apps?.[0]
-              ? `https://chat.aomi.dev?app=${encodeURIComponent(progress.apps[0])}`
-              : undefined
-          }
+          chatUrl={progress.apps?.[0] ? chatAppUrl(progress.apps[0]) : undefined}
         />
       )}
     </div>

--- a/apps/portal/src/components/settings/onboarding/oneshot-wizard.tsx
+++ b/apps/portal/src/components/settings/onboarding/oneshot-wizard.tsx
@@ -15,6 +15,7 @@ import {
   oneshotStep,
   type PathProgress,
 } from "@portal/lib/onboarding";
+import { chatAppUrl } from "@portal/lib/chat-url";
 import { Stepper } from "./stepper";
 import { DeployStep } from "./deploy-step";
 import { LivePanel } from "./live-panel";
@@ -177,11 +178,7 @@ export function OneshotWizard({
       {step === "live" && (
         <LivePanel
           repo={progress.repo}
-          chatUrl={
-            progress.apps?.[0]
-              ? `https://chat.aomi.dev?app=${encodeURIComponent(progress.apps[0])}`
-              : undefined
-          }
+          chatUrl={progress.apps?.[0] ? chatAppUrl(progress.apps[0]) : undefined}
         />
       )}
     </div>

--- a/apps/portal/src/lib/chat-url.ts
+++ b/apps/portal/src/lib/chat-url.ts
@@ -1,0 +1,16 @@
+/**
+ * Resolves the base chat URL from the NEXT_PUBLIC_CHAT_URL env var.
+ * Falls back to the canonical chat.aomi.dev host when the env is not set.
+ */
+export function resolveChatUrl(): string {
+  return process.env.NEXT_PUBLIC_CHAT_URL?.trim() || "https://chat.aomi.dev";
+}
+
+/**
+ * Returns the deep-link URL for a specific app in the chat UI.
+ * @param appName - The app identifier to open in chat.
+ */
+export function chatAppUrl(appName: string): string {
+  const base = resolveChatUrl();
+  return `${base}?app=${encodeURIComponent(appName)}`;
+}

--- a/apps/portal/src/lib/onboarding.ts
+++ b/apps/portal/src/lib/onboarding.ts
@@ -124,21 +124,6 @@ function empty(): OnboardingState {
   return { path: null, oneshot: {}, bootstrap: {}, pendingInstall: null };
 }
 
-function stripMockProgress(progress: PathProgress): PathProgress {
-  if (
-    progress.applicationId !== "mock-app-1" &&
-    !progress.releaseTag?.startsWith("apps-playground-example-")
-  ) {
-    return progress;
-  }
-  const next: PathProgress = {};
-  if (progress.installationId) next.installationId = progress.installationId;
-  if (progress.installationStatus) {
-    next.installationStatus = progress.installationStatus;
-  }
-  if (progress.repo) next.repo = progress.repo;
-  return next;
-}
 
 export function loadOnboarding(): OnboardingState {
   if (typeof window === "undefined") return empty();
@@ -148,8 +133,8 @@ export function loadOnboarding(): OnboardingState {
     const parsed = JSON.parse(raw) as Partial<OnboardingState>;
     return {
       path: parsed.path ?? null,
-      oneshot: stripMockProgress(parsed.oneshot ?? {}),
-      bootstrap: stripMockProgress(parsed.bootstrap ?? {}),
+      oneshot: parsed.oneshot ?? {},
+      bootstrap: parsed.bootstrap ?? {},
       pendingInstall: parsed.pendingInstall ?? null,
     };
   } catch {


### PR DESCRIPTION
## Problem

`Open in chat` was hardcoded to `https://chat.aomi.dev`. `stripMockProgress()` was leftover mock code.

## Changes

- `resolveChatUrl()` reads `NEXT_PUBLIC_CHAT_URL`, falls back to `https://chat.aomi.dev`
- Both wizards use `chatAppUrl()` instead of hardcoded strings
- Deleted `stripMockProgress()` and both call sites from `lib/onboarding.ts`

## Validation

- `pnpm exec tsc --noEmit`