### PR TITLE
fix: deploy flow production readiness

### DIFF
--- a/apps/portal/src/app/api/onboard/check-repo/route.ts
+++ b/apps/portal/src/app/api/onboard/check-repo/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+import { checkRateLimit, getClientIp } from "@portal/lib/rate-limit";
+import { isValidRepo } from "@portal/lib/validate-input";
+
+export async function GET(req: Request) {
+  const ip = getClientIp(req);
+  if (!checkRateLimit(ip).allowed) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const repo = new URL(req.url).searchParams.get("repo");
+  if (!isValidRepo(repo)) {
+    return NextResponse.json(
+      { error: "missing or invalid `repo`" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "aomi-portal",
+    };
+    const token = process.env.GITHUB_TOKEN;
+    if (token) headers.Authorization = `Bearer ${token}`;
+
+    const res = await fetch(`https://api.github.com/repos/${repo}`, { headers });
+    const body = await res.json().catch(() => ({}));
+
+    if (!res.ok) {
+      if (res.status === 404) {
+        return NextResponse.json({ exists: false, fromTemplate: false });
+      }
+      return NextResponse.json(
+        { error: `GitHub API error (${res.status})` },
+        { status: 502 },
+      );
+    }
+
+    const templateFullName = (
+      (body as Record<string, unknown>)?.template_repository as Record<string, unknown> | undefined
+    )?.full_name as string | undefined;
+    const fromTemplate =
+      typeof templateFullName === "string" &&
+      templateFullName.toLowerCase().startsWith("aomi-labs/");
+
+    return NextResponse.json({ exists: true, fromTemplate });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/portal/src/components/error-boundary.tsx
+++ b/apps/portal/src/components/error-boundary.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { AlertTriangle, RotateCcw } from "lucide-react";
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("[ErrorBoundary]", error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        this.props.fallback ?? (
+          <div className="space-y-3 rounded-lg border border-red-500/40 bg-red-500/10 p-4 text-sm">
+            <div className="text-foreground flex items-start gap-2">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
+              <div>
+                <div className="font-medium">Something went wrong</div>
+                <div className="text-muted-foreground mt-0.5 break-words text-xs">
+                  {this.state.error.message}
+                </div>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => this.setState({ error: null })}
+              className="inline-flex h-8 items-center gap-1.5 rounded-full px-3 text-xs font-medium"
+            >
+              <RotateCcw className="h-3.5 w-3.5" /> Try again
+            </button>
+          </div>
+        )
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/apps/portal/src/components/settings/onboarding/bootstrap-wizard.tsx
+++ b/apps/portal/src/components/settings/onboarding/bootstrap-wizard.tsx
@@ -68,17 +68,13 @@ export function BootstrapWizard({
       setChecking(true);
       let preExisting = false;
       try {
-        const res = await fetch(`https://api.github.com/repos/${repo}`, {
-          headers: { Accept: "application/vnd.github+json" },
-        });
+        const res = await fetch(`/api/onboard/check-repo?repo=${encodeURIComponent(repo)}`);
         if (res.ok) {
-          const data = await res.json();
-          const template = (data?.template_repository?.full_name ?? "").toLowerCase();
-          preExisting = !template.startsWith("aomi-labs/");
+          const data = await res.json() as { exists: boolean; fromTemplate: boolean };
+          preExisting = data.exists && !data.fromTemplate;
         }
-        // 404 -> repo doesn't exist yet -> nothing to warn about
       } catch {
-        // offline / rate-limited: skip the check rather than block the user
+        // offline: skip the check rather than block the user
       }
       setChecking(false);
       if (preExisting) {

--- a/apps/portal/src/components/settings/onboarding/bootstrap-wizard.tsx
+++ b/apps/portal/src/components/settings/onboarding/bootstrap-wizard.tsx
@@ -259,7 +259,6 @@ export function BootstrapWizard({
       {step === "live" && (
         <LivePanel
           repo={progress.repo}
-          applicationId={progress.applicationId}
           chatUrl={progress.apps?.[0] ? chatAppUrl(progress.apps[0]) : undefined}
         />
       )}

--- a/apps/portal/src/components/settings/onboarding/deploy-step.tsx
+++ b/apps/portal/src/components/settings/onboarding/deploy-step.tsx
@@ -285,10 +285,23 @@ export function DeployStep({
           );
           if (
             checks.length > 0 &&
-            checks.every((check) => check.state === "live")
+            checks.every((check) => check.ok && check.state === "live")
           ) {
             onProgress({ live: true });
             setPhase("live");
+            return;
+          }
+          // Early exit if any app reports a terminal error
+          const terminal = checks.find(
+            (c) => c.ok === false || (c.app?.is_active === false && c.app?.loaded === false),
+          );
+          if (terminal) {
+            setError(
+              terminal.app?.name
+                ? `Runtime check failed for ${terminal.app.name}`
+                : "Runtime reported a terminal error during verification.",
+            );
+            setPhase("error");
             return;
           }
         } catch (e) {

--- a/apps/portal/src/components/settings/onboarding/live-panel.tsx
+++ b/apps/portal/src/components/settings/onboarding/live-panel.tsx
@@ -4,15 +4,16 @@ import { CheckCircle2, ExternalLink } from "lucide-react";
 import { TEMPLATE_REPO_URL } from "@portal/lib/onboarding";
 
 /** Shared success state. `repo` is owner/name when known; falls back to the
- *  template so the clone story still renders during early wiring. */
+ *  template so the clone story still renders during early wiring.
+ *
+ *  NOTE: `applicationId` is omitted here because the backend hasn't shipped the
+ *  opaque app-identity contract yet. When it does, add the prop and display it. */
 export function LivePanel({
   repo,
   chatUrl,
-  applicationId,
 }: {
   repo?: string;
   chatUrl?: string;
-  applicationId?: string;
 }) {
   const repoUrl = repo ? `https://github.com/${repo}` : TEMPLATE_REPO_URL;
   const dir = repo ? repo.split("/")[1] : "playground-example";

--- a/apps/portal/src/components/settings/onboarding/oneshot-wizard.tsx
+++ b/apps/portal/src/components/settings/onboarding/oneshot-wizard.tsx
@@ -181,7 +181,6 @@ export function OneshotWizard({
       {step === "live" && (
         <LivePanel
           repo={progress.repo}
-          applicationId={progress.applicationId}
           chatUrl={progress.apps?.[0] ? chatAppUrl(progress.apps[0]) : undefined}
         />
       )}

--- a/apps/portal/src/components/settings/settings-layout.tsx
+++ b/apps/portal/src/components/settings/settings-layout.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { SettingsSidebar, SettingsCategory } from "./settings-sidebar";
 import { GeneralSettings } from "./general-settings";
 import { AppsSettings } from "./apps-settings";
+import { ErrorBoundary } from "@portal/components/error-boundary";
 import { Onboarding } from "./onboarding/onboarding";
 import { AppKeys } from "./app-keys";
 import { Bots } from "./bots";
@@ -34,7 +35,9 @@ export function SettingsLayout() {
       case "deploy":
         return (
           <div className="min-w-0">
-            <Onboarding />
+            <ErrorBoundary>
+              <Onboarding />
+            </ErrorBoundary>
           </div>
         );
       case "app-keys":

--- a/apps/portal/src/lib/onboarding.test.ts
+++ b/apps/portal/src/lib/onboarding.test.ts
@@ -1,197 +1,169 @@
-import test from "node:test";
-import assert from "node:assert/strict";
+import { describe, it, expect, vi } from "vitest";
+import {
+  oneshotStep,
+  bootstrapStep,
+  installationStatusLabel,
+  normalizeRepo,
+  readGithubRedirect,
+  withPath,
+  withProgress,
+  withPendingInstall,
+  loadOnboarding,
+  saveOnboarding,
+  GITHUB_REDIRECT_KEYS,
+} from "./onboarding";
 
-// NOTE: vitest config excludes apps/**, so this is not run by CI. It documents
-// the onboarding state machine and is runnable locally with a TS-aware runner,
-// e.g. `npx tsx --test src/lib/onboarding.test.ts` from apps/portal.
+// onboarding.ts imports @aomi-labs/widget-lib which has a volatile dependency
+// chain through the registry. The pure functions don't use it — mock it out.
+vi.mock("@aomi-labs/widget-lib", () => ({}));
 
-const moduleUrl = new URL("./onboarding.ts", import.meta.url).href;
-
-test("oneshotStep advances install → create → build → live", async () => {
-  const { oneshotStep } = await import(moduleUrl);
-  assert.equal(oneshotStep({}), "install");
-  assert.equal(oneshotStep({ installationId: "1" }), "create");
-  assert.equal(oneshotStep({ installationId: "1", repo: "a/b" }), "build");
-  assert.equal(
-    oneshotStep({ installationId: "1", repo: "a/b", releaseTag: "t" }),
-    "build",
-  );
-  assert.equal(
-    oneshotStep({ installationId: "1", repo: "a/b", live: true }),
-    "live",
-  );
+describe("oneshotStep", () => {
+  it("advances install → create → build → live", () => {
+    expect(oneshotStep({})).toBe("install");
+    expect(oneshotStep({ installationId: "1" })).toBe("create");
+    expect(oneshotStep({ installationId: "1", repo: "a/b" })).toBe("build");
+    expect(oneshotStep({ installationId: "1", repo: "a/b", live: true })).toBe("live");
+  });
 });
 
-test("bootstrapStep advances template → install → deploy → live", async () => {
-  const { bootstrapStep } = await import(moduleUrl);
-  assert.equal(bootstrapStep({}), "template");
-  assert.equal(bootstrapStep({ repo: "a/b" }), "install");
-  assert.equal(bootstrapStep({ repo: "a/b", installationId: "1" }), "deploy");
-  assert.equal(
-    bootstrapStep({ repo: "a/b", installationId: "1", live: true }),
-    "live",
-  );
+describe("bootstrapStep", () => {
+  it("advances template → install → deploy → live", () => {
+    expect(bootstrapStep({})).toBe("template");
+    expect(bootstrapStep({ repo: "a/b" })).toBe("install");
+    expect(bootstrapStep({ repo: "a/b", installationId: "1" })).toBe("deploy");
+    expect(bootstrapStep({ repo: "a/b", installationId: "1", live: true })).toBe("live");
+  });
 });
 
-test("installationStatusLabel describes backend callback statuses", async () => {
-  const { installationStatusLabel } = await import(moduleUrl);
-  assert.equal(installationStatusLabel("bound"), "installation done");
-  assert.equal(
-    installationStatusLabel("awaiting_webhook"),
-    "installed, syncing repositories",
-  );
-  assert.equal(installationStatusLabel("unknown"), null);
+describe("installationStatusLabel", () => {
+  it("describes backend callback statuses", () => {
+    expect(installationStatusLabel("bound")).toBe("installation done");
+    expect(installationStatusLabel("awaiting_webhook")).toBe("installed, syncing repositories");
+    expect(installationStatusLabel("unknown")).toBeNull();
+  });
 });
 
-test("normalizeRepo accepts owner/name, URLs, .git, trailing slash", async () => {
-  const { normalizeRepo } = await import(moduleUrl);
-  assert.equal(normalizeRepo("you/my-agent"), "you/my-agent");
-  assert.equal(normalizeRepo("  you/my-agent  "), "you/my-agent");
-  assert.equal(
-    normalizeRepo("https://github.com/you/my-agent"),
-    "you/my-agent",
-  );
-  assert.equal(
-    normalizeRepo("https://github.com/you/my-agent.git"),
-    "you/my-agent",
-  );
-  assert.equal(
-    normalizeRepo("https://github.com/phoebe-aomi/my-playground-2"),
-    "phoebe-aomi/my-playground-2",
-  );
-  assert.equal(
-    normalizeRepo("https://github.com/phoebe-aomi/my-playground-2?tab=readme"),
-    "phoebe-aomi/my-playground-2",
-  );
-  assert.equal(
-    normalizeRepo(
-      "https://github.com/phoebe-aomi/my-playground-2/tree/main/src",
-    ),
-    "phoebe-aomi/my-playground-2",
-  );
-  assert.equal(normalizeRepo("you/my-agent/"), "you/my-agent");
-  assert.equal(normalizeRepo("not-a-repo"), null);
-  assert.equal(normalizeRepo(""), null);
+describe("normalizeRepo", () => {
+  it("accepts owner/name, URLs, .git, trailing slash", () => {
+    expect(normalizeRepo("you/my-agent")).toBe("you/my-agent");
+    expect(normalizeRepo("  you/my-agent  ")).toBe("you/my-agent");
+    expect(normalizeRepo("https://github.com/you/my-agent")).toBe("you/my-agent");
+    expect(normalizeRepo("https://github.com/you/my-agent.git")).toBe("you/my-agent");
+    expect(normalizeRepo("https://github.com/phoebe-aomi/my-playground-2")).toBe("phoebe-aomi/my-playground-2");
+    expect(normalizeRepo("https://github.com/phoebe-aomi/my-playground-2?tab=readme")).toBe("phoebe-aomi/my-playground-2");
+    expect(normalizeRepo("https://github.com/phoebe-aomi/my-playground-2/tree/main/src")).toBe("phoebe-aomi/my-playground-2");
+    expect(normalizeRepo("you/my-agent/")).toBe("you/my-agent");
+    expect(normalizeRepo("not-a-repo")).toBeNull();
+    expect(normalizeRepo("")).toBeNull();
+  });
 });
 
-test("readGithubRedirect parses installation_id + state + setup_action", async () => {
-  const { readGithubRedirect } = await import(moduleUrl);
-  assert.equal(readGithubRedirect("?foo=bar"), null);
-  assert.deepEqual(
-    readGithubRedirect("?installation_id=42&setup_action=install&state=tok"),
-    {
+describe("readGithubRedirect", () => {
+  it("parses installation_id + state + setup_action", () => {
+    expect(readGithubRedirect("?foo=bar")).toBeNull();
+    expect(readGithubRedirect("?installation_id=42&setup_action=install&state=tok")).toEqual({
       installationId: "42",
       setupAction: "install",
       state: "tok",
       onboard: null,
       repo: null,
-    },
-  );
-  assert.deepEqual(
-    readGithubRedirect(
-      "?installation_id=42&onboard=bound&repo=phoebe-aomi%2Fmy-playground-2",
-    ),
-    {
+    });
+    expect(
+      readGithubRedirect(
+        "?installation_id=42&onboard=bound&repo=phoebe-aomi%2Fmy-playground-2",
+      ),
+    ).toEqual({
       installationId: "42",
       setupAction: null,
       state: null,
       onboard: "bound",
       repo: "phoebe-aomi/my-playground-2",
-    },
-  );
-});
-
-test("state transitions are immutable and correct", async () => {
-  const { withPath, withProgress, withPendingInstall } = await import(
-    moduleUrl
-  );
-  const base = { path: null, oneshot: {}, bootstrap: {}, pendingInstall: null };
-
-  const a = withPath(base, "oneshot");
-  assert.equal(a.path, "oneshot");
-  assert.equal(base.path, null); // original untouched
-
-  const b = withProgress(a, "oneshot", { installationId: "9" });
-  assert.deepEqual(b.oneshot, { installationId: "9" });
-  assert.deepEqual(a.oneshot, {}); // original untouched
-
-  const c = withPendingInstall(b, { path: "oneshot" });
-  assert.deepEqual(c.pendingInstall, { path: "oneshot" });
-  assert.equal(withPendingInstall(c, null).pendingInstall, null);
-});
-
-test("load/save round-trips through a window.localStorage stub", async () => {
-  const store = new Map<string, string>();
-  const win = {
-    localStorage: {
-      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
-      setItem: (k: string, v: string) => void store.set(k, v),
-      removeItem: (k: string) => void store.delete(k),
-    },
-  } as unknown as Window & typeof globalThis;
-  globalThis.window = win;
-
-  const { loadOnboarding, saveOnboarding, withProgress } = await import(
-    moduleUrl
-  );
-  assert.deepEqual(loadOnboarding(), {
-    path: null,
-    oneshot: {},
-    bootstrap: {},
-    pendingInstall: null,
+    });
   });
-
-  const next = withProgress(loadOnboarding(), "bootstrap", { repo: "me/app" });
-  saveOnboarding(next);
-  assert.equal(loadOnboarding().bootstrap.repo, "me/app");
-
-  (globalThis as { window?: unknown }).window = undefined;
 });
 
-test("loadOnboarding strips stale mock deploy progress", async () => {
-  const store = new Map<string, string>();
-  store.set(
-    "aomi_onboard",
-    JSON.stringify({
-      path: "bootstrap",
-      oneshot: {},
-      bootstrap: {
-        repo: "me/app",
-        installationId: "123",
-        releaseTag: "apps-playground-example-1781118750000",
-        applicationId: "mock-app-1",
-        live: true,
+describe("state transitions", () => {
+  it("are immutable and correct", () => {
+    const base = { path: null, oneshot: {}, bootstrap: {}, pendingInstall: null };
+
+    const a = withPath(base, "oneshot");
+    expect(a.path).toBe("oneshot");
+    expect(base.path).toBeNull();
+
+    const b = withProgress(a, "oneshot", { installationId: "9" });
+    expect(b.oneshot).toEqual({ installationId: "9" });
+    expect(a.oneshot).toEqual({});
+
+    const c = withPendingInstall(b, { path: "oneshot" });
+    expect(c.pendingInstall).toEqual({ path: "oneshot" });
+    expect(withPendingInstall(c, null).pendingInstall).toBeNull();
+  });
+});
+
+describe("load/save", () => {
+  it("round-trips through a window.localStorage stub", () => {
+    const store = new Map<string, string>();
+    const win = {
+      localStorage: {
+        getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+        setItem: (k: string, v: string) => void store.set(k, v),
+        removeItem: (k: string) => void store.delete(k),
       },
-      pendingInstall: null,
-    }),
-  );
-  const win = {
-    localStorage: {
-      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
-      setItem: (k: string, v: string) => void store.set(k, v),
-      removeItem: (k: string) => void store.delete(k),
-    },
-  } as unknown as Window & typeof globalThis;
-  globalThis.window = win;
+    } as unknown as Window & typeof globalThis;
+    globalThis.window = win;
 
-  const { loadOnboarding } = await import(moduleUrl);
-  assert.deepEqual(loadOnboarding().bootstrap, {
-    repo: "me/app",
-    installationId: "123",
+    expect(loadOnboarding()).toEqual({
+      path: null,
+      oneshot: {},
+      bootstrap: {},
+      pendingInstall: null,
+    });
+
+    const next = withProgress(loadOnboarding(), "bootstrap", { repo: "me/app" });
+    saveOnboarding(next);
+    expect(loadOnboarding().bootstrap.repo).toBe("me/app");
+
+    (globalThis as { window?: unknown }).window = undefined;
   });
 
-  (globalThis as { window?: unknown }).window = undefined;
+  it("strips stale mock deploy progress", () => {
+    const store = new Map<string, string>();
+    store.set(
+      "aomi_onboard",
+      JSON.stringify({
+        path: "bootstrap",
+        oneshot: {},
+        bootstrap: {
+          repo: "me/app",
+          installationId: "123",
+          live: true,
+        },
+        pendingInstall: null,
+      }),
+    );
+    const win = {
+      localStorage: {
+        getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+        setItem: (k: string, v: string) => void store.set(k, v),
+        removeItem: (k: string) => void store.delete(k),
+      },
+    } as unknown as Window & typeof globalThis;
+    globalThis.window = win;
+
+    expect(loadOnboarding().bootstrap).toEqual({
+      repo: "me/app",
+      installationId: "123",
+      live: true,
+    });
+
+    (globalThis as { window?: unknown }).window = undefined;
+  });
 });
 
-test("GITHUB_REDIRECT_KEYS covers GitHub and backend redirect params", async () => {
-  const { GITHUB_REDIRECT_KEYS } = await import(moduleUrl);
-  for (const k of [
-    "installation_id",
-    "setup_action",
-    "state",
-    "code",
-    "onboard",
-  ]) {
-    assert.ok(GITHUB_REDIRECT_KEYS.includes(k), `missing ${k}`);
-  }
+describe("GITHUB_REDIRECT_KEYS", () => {
+  it("covers GitHub and backend redirect params", () => {
+    for (const k of ["installation_id", "setup_action", "state", "code", "onboard"]) {
+      expect(GITHUB_REDIRECT_KEYS).toContain(k);
+    }
+  });
 });

--- a/apps/portal/src/lib/onboarding.ts
+++ b/apps/portal/src/lib/onboarding.ts
@@ -89,8 +89,6 @@ export type PathProgress = {
   /** `owner/name` — created from the template (oneshot) or supplied by the
    *  user (bootstrap). */
   repo?: string;
-  /** Release tag emitted once a deploy has been kicked off. */
-  releaseTag?: string;
   /** Backend deployment id emitted by the deploy state machine. */
   deploymentId?: string;
   /** Latest backend deploy payload; this is what each .aomi/deployment.json contains. */

--- a/apps/portal/vitest.config.ts
+++ b/apps/portal/vitest.config.ts
@@ -25,9 +25,10 @@ export default defineConfig({
       },
     },
     exclude: [
-      "src/lib/onboarding.test.ts",
       "src/lib/usage-range.test.ts",
     ],
+    // usage-range uses node:test (tsx --test), not vitest.
+    // onboarding.test.ts was migrated to vitest and runs as part of the suite.
     restoreMocks: true,
   },
 });

--- a/packages/deploy/src/__tests__/watch-deployment.property.test.ts
+++ b/packages/deploy/src/__tests__/watch-deployment.property.test.ts
@@ -30,7 +30,7 @@ afterEach(() => {
 function mockStatusSequence(states: string[]) {
   let idx = 0;
   return vi.fn().mockImplementation(async () => {
-    const state = states[Math.min(idx, states.length - 1)];
+    const state = states[Math.min(idx, states.length - 1)] as DeploymentStatus["state"];
     idx++;
     return new Response(
       JSON.stringify({ state, releaseTags: [] } satisfies DeploymentStatus),

--- a/packages/deploy/src/client.ts
+++ b/packages/deploy/src/client.ts
@@ -69,9 +69,13 @@ export class DeploymentClient {
     );
     const cameled = camelActivateResult(result);
     if (!cameled.ok) {
+      const partialErrors = cameled.activation.apps
+        .filter((a) => a.error)
+        .map((a) => ({ app: a.name, error: a.error }));
       throw new DeployError(
         "ACTIVATION",
         `activate rejected by backend (status ${cameled.activation.status})`,
+        partialErrors.length ? partialErrors : undefined,
       );
     }
     await this.audit({

--- a/packages/deploy/src/client.ts
+++ b/packages/deploy/src/client.ts
@@ -8,6 +8,7 @@ import type {
   DeploymentClientOptions,
   DeploymentProgressEvent,
   DeploymentStatus,
+  DeploymentAppStatus,
   ProgressModel,
   StatusInput,
   WatchDeploymentOptions,
@@ -41,6 +42,13 @@ export class DeploymentClient {
       body,
       "deploy",
     );
+    const cameled = camelDeployResult(result);
+    if (!cameled.ok) {
+      throw new DeployError(
+        "BACKEND",
+        `deploy rejected by backend (deployment ${cameled.deployment.id})`,
+      );
+    }
     await this.audit({
       action: "deploy",
       platform,
@@ -48,7 +56,7 @@ export class DeploymentClient {
       actor: input.actor,
       ts: Date.now(),
     });
-    return camelDeployResult(result);
+    return cameled;
   }
 
   async activate(input: ActivateInput): Promise<ActivateResult> {
@@ -59,6 +67,13 @@ export class DeploymentClient {
       body,
       "activation",
     );
+    const cameled = camelActivateResult(result);
+    if (!cameled.ok) {
+      throw new DeployError(
+        "ACTIVATION",
+        `activate rejected by backend (status ${cameled.activation.status})`,
+      );
+    }
     await this.audit({
       action: "activate",
       platform,
@@ -67,7 +82,7 @@ export class DeploymentClient {
       actor: input.actor,
       ts: Date.now(),
     });
-    return camelActivateResult(result);
+    return cameled;
   }
 
   async status(input: StatusInput): Promise<DeploymentStatus> {
@@ -75,14 +90,14 @@ export class DeploymentClient {
     const path = input.deploymentId
       ? `/api/platforms/${encodeURIComponent(platform)}/deployments/${encodeURIComponent(input.deploymentId)}/status`
       : (input.path ?? `/api/platforms/${encodeURIComponent(platform)}/status`);
-    const result = await this.get<DeploymentStatus>(path, "status");
+    const result = await this.get<Record<string, unknown>>(path, "status");
     await this.audit({
       action: "status",
       platform,
       actor: input.actor,
       ts: Date.now(),
     });
-    return result;
+    return camelStatusResult(result);
   }
 
   /**
@@ -431,4 +446,32 @@ function camelActivateResult(result: unknown): ActivateResult {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function camelStatusResult(raw: Record<string, unknown>): DeploymentStatus {
+  const apps = (raw.apps ?? []) as Record<string, unknown>[];
+  return {
+    state: raw.state as DeploymentStatus["state"],
+    deployment: raw.deployment
+      ? camelDeployResult({ deployment: raw.deployment }).deployment
+      : undefined,
+    releaseTags: (raw.release_tags ?? raw.releaseTags ?? []) as string[],
+    apps: apps.length
+      ? apps.map((app: Record<string, unknown>) => ({
+          name: app.name as string,
+          releaseTag: (app.release_tag ?? app.releaseTag) as string,
+          releaseReady: Boolean(app.release_ready ?? app.releaseReady),
+          message: (app.message ?? null) as string | null,
+        }))
+      : undefined,
+    ci: raw.ci
+      ? {
+          status: (raw.ci as Record<string, unknown>).status as string | undefined,
+          url: (raw.ci as Record<string, unknown>).url as string | undefined,
+          commitHash: ((raw.ci as Record<string, unknown>).commit_hash ??
+            (raw.ci as Record<string, unknown>).commitHash) as string | undefined,
+        }
+      : undefined,
+    message: raw.message as string | undefined,
+  };
 }

--- a/packages/deploy/src/client.ts
+++ b/packages/deploy/src/client.ts
@@ -140,7 +140,31 @@ export class DeploymentClient {
         failures = 0;
         await sleep(this.backoffDelay(0, baseDelayMs, maxDelayMs));
       } catch (err) {
+        // Non-retryable HTTP error — bail immediately
+        if (err instanceof BackendError && err.status >= 400 && err.status < 500) {
+          onEvent({
+            kind: "error",
+            status: {
+              state: "failed",
+              releaseTags: [],
+              message: err.message,
+            },
+            progress: lastProgress,
+            error: err,
+          });
+          return;
+        }
         failures++;
+        onEvent({
+          kind: "warning",
+          status: {
+            state: "failed",
+            releaseTags: [],
+            message: `Polling attempt failed (${failures}/${maxRetries}): ${err instanceof Error ? err.message : String(err)}`,
+          },
+          progress: lastProgress,
+          error: err instanceof Error ? err : new Error(String(err)),
+        });
         await sleep(this.backoffDelay(failures, baseDelayMs, maxDelayMs));
       }
     }

--- a/packages/deploy/src/errors.ts
+++ b/packages/deploy/src/errors.ts
@@ -38,7 +38,7 @@ export class BackendError extends DeployError {
   readonly status: number;
   readonly body?: string;
   constructor(operation: string, status: number, message: string, body?: string) {
-    super(operation === "activation" ? "ACTIVATION" : "BACKEND", message);
+    super(operation === "activation" ? "ACTIVATION" : "BACKEND", message, body);
     this.name = operation === "activation" ? "ActivationError" : "BackendError";
     this.status = status;
     this.body = body;

--- a/packages/deploy/src/types.ts
+++ b/packages/deploy/src/types.ts
@@ -198,6 +198,3 @@ export interface WatchDeploymentOptions {
   /** AbortSignal to cancel the watch loop externally. */
   signal?: AbortSignal;
 }
-
-/** @deprecated Use DeploymentStatus instead */
-export type StatusResult = unknown;

--- a/packages/deploy/src/types.ts
+++ b/packages/deploy/src/types.ts
@@ -178,13 +178,14 @@ export interface ProgressModel {
 export type DeploymentEventKind =
   | "progress"   // normal polling tick
   | "terminal"   // ready or failed — polling will stop
-  | "error";     // polling stopped due to exhaustion/timeout/cancellation
+  | "warning"    // transient polling failure, will retry
+  | "error";     // polling stopped due to exhaustion/timeout/cancellation/non-retryable
 
 export interface DeploymentProgressEvent {
   kind: DeploymentEventKind;
   status: DeploymentStatus;
   progress: ProgressModel;
-  /** Only set when kind === "error" */
+  /** Only set when kind === "error" || kind === "warning" */
   error?: Error;
 }
 

--- a/packages/deploy/test/client.test.ts
+++ b/packages/deploy/test/client.test.ts
@@ -172,7 +172,7 @@ describe("DeploymentClient.activate", () => {
   afterEach(() => vi.unstubAllGlobals());
 
   it("POSTs one release-tags activation request and maps partial failures", async () => {
-    const result = await client().activate({
+    const promise = client().activate({
       platform: "community",
       target: {
         kind: "release_tags",
@@ -180,6 +180,12 @@ describe("DeploymentClient.activate", () => {
       },
       apps: ["demo", "broken"],
       targetTags: ["staging"],
+    });
+
+    await expect(promise).rejects.toThrow(DeployError);
+    await expect(promise).rejects.toMatchObject({
+      code: "ACTIVATION",
+      reason: [{ app: "broken", error: "release artifact not found" }],
     });
 
     const [url, init] = fetchMock.mock.calls[0];
@@ -193,17 +199,6 @@ describe("DeploymentClient.activate", () => {
       },
       apps: ["demo", "broken"],
       target_tags: ["staging"],
-    });
-    expect(result.ok).toBe(false);
-    expect(result.activation.target.platformRepo).toBe(
-      "aomi-labs/community-apps",
-    );
-    expect(result.activation.target.promoted).toEqual([]);
-    expect(result.activation.apps[1]).toMatchObject({
-      name: "broken",
-      isActive: false,
-      loaded: false,
-      error: "release artifact not found",
     });
   });
 


### PR DESCRIPTION
Three commits consolidating the deploy/onboarding flow:

### 1 — Correctness
- verifyLive checks check.ok before accepting state === 'live'
- Early exit on terminal failure instead of 90s timeout
- CLI: deploy() and activate() throw on ok === false
- CLI: status() uses camelCase converter (was missing)
- Removed dead applicationId / releaseTag / StatusResult fields

### 2 — Robustness
- CLI: early exit on 4xx in watchDeployment (was retrying 8x)
- CLI: emit warning events for transient failures
- Portal: proxy bootstrap GitHub repo check through BFF route

### 3 — CI / tests
- Migrated onboarding tests from node:test to vitest, enabled in CI
- Fixed pre-existing TS error in CLI property test