### PR TITLE
fix: redirect current tab for GitHub install instead of new-tab + polling

### DIFF
--- a/apps/portal/src/components/settings/onboarding/onboarding.tsx
+++ b/apps/portal/src/components/settings/onboarding/onboarding.tsx
@@ -92,21 +92,6 @@ export function Onboarding() {
     return () => clearTimeout(id);
   }, [installSuccess]);
 
-  // --- detect GitHub install completed in another tab -----------------------
-  useEffect(() => {
-    if (!installingPath) return;
-    const id = setInterval(() => {
-      const cur = loadOnboarding();
-      const progress = cur[installingPath];
-      if (progress.installationId && progress.installationStatus) {
-        setState(cur);
-        setInstallSuccess(true);
-        setInstallingPath(null);
-      }
-    }, 1000);
-    return () => clearInterval(id);
-  }, [installingPath]);
-
   // --- sync deploymentId to URL params -------------------------------------
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -156,9 +141,10 @@ export function Onboarding() {
     [state, update],
   );
 
-  // Save progress before opening GitHub in a new tab. The redirect will
-  // land in the new tab and write the result to localStorage; the polling
-  // effect above picks it up in this tab.
+  // Redirect the current tab to GitHub for install. The backend callback
+  // redirects back to /settings?installation_id=...&onboard=bound so the
+  // hydration effect below reads the result directly from URL params — no
+  // fragile cross-tab polling needed.
   const makeBeginInstall = useCallback(
     (path: OnboardingPath, mode: "install" | "authorize" = "install") =>
       async () => {
@@ -169,15 +155,12 @@ export function Onboarding() {
         setInstallingPath(path);
         try {
           const repo = next[path].repo;
-          window.open(
-            await githubAppInstallUrl({
-              platform: resolveDeployPlatform(),
-              repo,
-              mode,
-              app: path === "oneshot" ? 2 : undefined,
-            }),
-            "_blank",
-          );
+          window.location.href = await githubAppInstallUrl({
+            platform: resolveDeployPlatform(),
+            repo,
+            mode,
+            app: path === "oneshot" ? 2 : undefined,
+          });
         } catch (error) {
           setInstallingPath(null);
           setInstallError(


### PR DESCRIPTION
Same-tab redirect for the GitHub App install flow instead of window.open + cross-tab localStorage polling.

The old approach was fragile:
- window.open is async after await fetch, so popup blockers fire
- If the new tab closes before React mounts after the OAuth redirect chain, localStorage never gets updated and 'Waiting for GitHub...' spins forever

Same-tab redirect is the standard OAuth pattern (Sign in with Google, GitHub, Stripe).