### PR TITLE
fix: show green check on final stepper step instead of spinner

### DIFF
--- a/apps/portal/src/components/settings/onboarding/stepper.tsx
+++ b/apps/portal/src/components/settings/onboarding/stepper.tsx
@@ -25,7 +25,9 @@ export function Stepper({
             : i === currentIndex
               ? failed
                 ? "failed"
-                : "active"
+                : i === steps.length - 1
+                  ? "done"
+                  : "active"
               : "pending";
         return (
           <li key={step.key} className="flex flex-1 items-center last:flex-none">


### PR DESCRIPTION
When the deployment reaches the final step (Live), the stepper now renders a green checkmark instead of a loading spinner — the terminal state should show completion, not ongoing activity.