### PR TITLE
launch: deploy by app_source_id + lock chat to the activated bot

### DIFF
--- a/apps/portal/src/components/portal-aomi-frame.tsx
+++ b/apps/portal/src/components/portal-aomi-frame.tsx
@@ -1,10 +1,14 @@
 "use client";
 
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { Settings } from "lucide-react";
 import { AomiFrame } from "@aomi-labs/widget-lib";
-import { type AomiClientOptions, usePerThreadControl } from "@aomi-labs/react";
+import {
+  type AomiClientOptions,
+  useAomiRuntime,
+  usePerThreadControl,
+} from "@aomi-labs/react";
 import { RequiredSecretsGate } from "@portal/components/required-secrets-gate";
 import { x402Client } from "@x402/core/client";
 import { ExactEvmScheme } from "@x402/evm/exact/client";
@@ -14,22 +18,49 @@ import { useConfig, useWalletClient } from "wagmi";
 import { getConnectorClient } from "wagmi/actions";
 import { getBackendUrl } from "@portal/lib/settings-api";
 
-function getRequestedAppFromSearch(search: string): string | null {
+type RequestedAppConfig = {
+  app: string | null;
+  locked: boolean;
+};
+
+function getRequestedAppConfig(search: string): RequestedAppConfig {
   const params = new URLSearchParams(search);
+  let app: string | null = null;
 
   for (const key of ["aomi_app", "app"] as const) {
     const value = params.get(key)?.trim();
     if (value) {
-      return value;
+      app = value;
+      break;
     }
   }
 
-  return null;
+  return {
+    app,
+    locked:
+      params.get("lock_app") === "1" ||
+      params.get("lock_app") === "true" ||
+      params.get("app_locked") === "1" ||
+      params.get("app_locked") === "true",
+  };
 }
 
-function usePortalClientOptions():
-  | Omit<AomiClientOptions, "baseUrl">
-  | undefined {
+function useRequestedAppConfig(): RequestedAppConfig {
+  const [config, setConfig] = useState<RequestedAppConfig>({
+    app: null,
+    locked: false,
+  });
+
+  useEffect(() => {
+    setConfig(getRequestedAppConfig(window.location.search));
+  }, []);
+
+  return config;
+}
+
+function usePortalClientOptions(
+  lockedApp: string | null,
+): Omit<AomiClientOptions, "baseUrl"> | undefined {
   const wagmiConfig = useConfig();
   const walletClient = useWalletClient();
   const nativeFetch = useMemo(() => globalThis.fetch.bind(globalThis), []);
@@ -143,6 +174,24 @@ function usePortalClientOptions():
       }
     };
 
+    const withLockedChatApp = (input: RequestInfo | URL): RequestInfo | URL => {
+      if (!lockedApp) {
+        return input;
+      }
+      const url = parseUrl(input);
+      if (!url || url.pathname !== "/api/chat") {
+        return input;
+      }
+      url.searchParams.set("app", lockedApp);
+      if (typeof input === "string") {
+        return url.toString();
+      }
+      if (input instanceof URL) {
+        return url;
+      }
+      return new Request(url, input);
+    };
+
     const isChatPost = (input: RequestInfo | URL, init?: RequestInit) => {
       const url = parseUrl(input);
       if (!url) return false;
@@ -176,11 +225,12 @@ function usePortalClientOptions():
     })();
 
     const routedFetch: typeof fetch = async (input, init) => {
-      if (!isChatPost(input, init)) {
-        return rawFetch(input, init);
+      const routedInput = withLockedChatApp(input);
+      if (!isChatPost(routedInput, init)) {
+        return rawFetch(routedInput, init);
       }
 
-      const firstResponse = await rawFetch(input, init);
+      const firstResponse = await rawFetch(routedInput, init);
       if (firstResponse.status !== 402 || !paymentFetch) {
         return firstResponse;
       }
@@ -188,38 +238,93 @@ function usePortalClientOptions():
       console.debug(
         "[aomi][portal-fetch] retrying /api/chat with payment transport after 402",
       );
-      return paymentFetch(input, init);
+      return paymentFetch(withLockedChatApp(input), init);
     };
 
     return {
       fetch: routedFetch,
     };
-  }, [mppClientOptions, nativeFetch, walletClient?.data]);
+  }, [lockedApp, mppClientOptions, nativeFetch, walletClient?.data]);
 }
 
-function AppSelectUrlBootstrap() {
+function AppSelectUrlBootstrap({
+  requestedApp,
+  locked,
+}: {
+  requestedApp: string | null;
+  locked: boolean;
+}) {
+  const { createThread, currentThreadId } = useAomiRuntime();
   const { onAppSelect } = usePerThreadControl().actions;
   const hasAppliedRequestedAppRef = useRef(false);
+  const hasStartedLockedThreadRef = useRef<string | null>(null);
+  const isDisposedRef = useRef(false);
+  const [lockedThreadId, setLockedThreadId] = useState<string | null>(null);
+
+  useEffect(() => {
+    return () => {
+      isDisposedRef.current = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (hasAppliedRequestedAppRef.current) {
       return;
     }
 
-    const requestedApp = getRequestedAppFromSearch(window.location.search);
     if (!requestedApp) {
+      return;
+    }
+
+    if (!locked) {
+      onAppSelect(requestedApp);
+      hasAppliedRequestedAppRef.current = true;
+      return;
+    }
+
+    if (hasStartedLockedThreadRef.current === requestedApp) {
+      return;
+    }
+    hasStartedLockedThreadRef.current = requestedApp;
+    void createThread()
+      .then((threadId) => {
+        if (
+          !isDisposedRef.current &&
+          hasStartedLockedThreadRef.current === requestedApp
+        ) {
+          setLockedThreadId(threadId);
+        }
+      })
+      .catch((error) => {
+        console.error("[aomi][portal-frame] failed to create locked thread", {
+          app: requestedApp,
+          error,
+        });
+      });
+  }, [createThread, locked, onAppSelect, requestedApp]);
+
+  useEffect(() => {
+    if (
+      hasAppliedRequestedAppRef.current ||
+      !locked ||
+      !requestedApp ||
+      !lockedThreadId ||
+      currentThreadId !== lockedThreadId
+    ) {
       return;
     }
 
     onAppSelect(requestedApp);
     hasAppliedRequestedAppRef.current = true;
-  }, [onAppSelect]);
+  }, [currentThreadId, locked, lockedThreadId, onAppSelect, requestedApp]);
 
   return null;
 }
 
 export function PortalAomiFrame() {
-  const clientOptions = usePortalClientOptions();
+  const requestedApp = useRequestedAppConfig();
+  const lockedApp = requestedApp.locked ? requestedApp.app : null;
+  const clientOptions = usePortalClientOptions(lockedApp);
   const backendUrl = getBackendUrl();
 
   return (
@@ -233,7 +338,10 @@ export function PortalAomiFrame() {
         className="rounded-none border-0 shadow-none"
         clientOptions={clientOptions}
       >
-        <AppSelectUrlBootstrap />
+        <AppSelectUrlBootstrap
+          requestedApp={requestedApp.app}
+          locked={Boolean(lockedApp)}
+        />
         <AomiFrame.Header>
           <Link
             href="/settings"
@@ -247,6 +355,7 @@ export function PortalAomiFrame() {
           withControl
           controlBarProps={{
             hideApiKey: true,
+            hideApp: Boolean(lockedApp),
           }}
         />
         <RequiredSecretsGate />

--- a/apps/portal/src/components/settings/onboarding/bootstrap-wizard.tsx
+++ b/apps/portal/src/components/settings/onboarding/bootstrap-wizard.tsx
@@ -1,11 +1,19 @@
 "use client";
 
-import { useState } from "react";
-import { ExternalLink, Check, RotateCcw, ArrowLeft, AlertTriangle } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import {
+  ExternalLink,
+  Check,
+  Loader2,
+  RotateCcw,
+  ArrowLeft,
+  AlertTriangle,
+} from "lucide-react";
 import { Button, Input } from "@aomi-labs/widget-lib";
 import {
   bootstrapStep,
   installationStatusLabel,
+  launchSyncInstalled,
   normalizeRepo,
   TEMPLATE_GENERATE_URL,
   type LaunchProgress,
@@ -239,13 +247,10 @@ export function BootstrapWizard({
               <ArrowLeft className="mr-1 h-3.5 w-3.5 shrink-0" /> Back
             </button>
           </div>
-          <DeployStep
-            path="bootstrap"
-            installationId={progress.installationId}
-            repo={progress.repo}
-            actor={actor}
+          <BootstrapDeployStep
             progress={progress}
-            onProgress={patch}
+            patch={patch}
+            actor={actor}
             onReconnectInstall={beginAuthorize}
             onReset={onReset}
           />
@@ -258,6 +263,105 @@ export function BootstrapWizard({
           chatUrl={progress.apps?.[0] ? chatAppUrl(progress.apps[0]) : undefined}
         />
       )}
+    </div>
+  );
+}
+
+/**
+ * Bootstrap reaches deploy with a connected repo but no source id yet. Resolve
+ * it from the installed repo (`sync-installed`) once, then hand a stable
+ * `appSourceId` to `DeployStep` — deploy is source-id-driven end to end.
+ */
+function BootstrapDeployStep({
+  progress,
+  patch,
+  actor,
+  onReconnectInstall,
+  onReset,
+}: {
+  progress: LaunchProgress;
+  patch: (patch: Partial<LaunchProgress>) => void;
+  actor?: string;
+  onReconnectInstall?: () => void;
+  onReset?: () => void;
+}) {
+  const [resolving, setResolving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const repo = progress.repo;
+  const appSourceId = progress.appSourceId;
+
+  const resolveSource = useCallback(async () => {
+    if (!repo) return;
+    setResolving(true);
+    setError(null);
+    try {
+      const result = await launchSyncInstalled({ repo });
+      if (!result.appSourceId) {
+        throw new Error("backend did not return a source id for this repo");
+      }
+      patch({ appSourceId: result.appSourceId, repo: result.repo });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setResolving(false);
+    }
+  }, [repo, patch]);
+
+  useEffect(() => {
+    if (!appSourceId && !resolving && !error) {
+      void resolveSource();
+    }
+  }, [appSourceId, resolving, error, resolveSource]);
+
+  if (appSourceId) {
+    return (
+      <DeployStep
+        appSourceId={appSourceId}
+        repo={progress.repo}
+        actor={actor}
+        progress={progress}
+        onProgress={patch}
+        onReconnectInstall={onReconnectInstall}
+        onReset={onReset}
+      />
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-3 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+        <div className="text-foreground flex items-start gap-2">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+          <div>
+            <div className="font-medium">Couldn’t connect your repository</div>
+            <div className="text-muted-foreground mt-0.5 break-words text-xs">
+              {error}
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            onClick={resolveSource}
+            className="h-8 rounded-full px-3 text-xs font-medium"
+          >
+            <RotateCcw className="mr-1 h-3.5 w-3.5" /> Retry
+          </Button>
+          {onReconnectInstall && (
+            <Button
+              onClick={onReconnectInstall}
+              className="h-8 rounded-full px-3 text-xs font-medium"
+            >
+              <RotateCcw className="mr-1 h-3.5 w-3.5" /> Verify existing install
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-muted-foreground flex items-center gap-2 text-sm">
+      <Loader2 className="h-4 w-4 animate-spin" /> Connecting your repository…
     </div>
   );
 }

--- a/apps/portal/src/components/settings/onboarding/deploy-dashboard.tsx
+++ b/apps/portal/src/components/settings/onboarding/deploy-dashboard.tsx
@@ -250,6 +250,7 @@ function SourceCard({ source }: { source: UserSource }) {
   const [progress, setProgress] = useState<LaunchProgress>(() => ({
     installationId: String(source.installationId),
     repo,
+    appSourceId: source.id,
     apps: source.apps.map((a) => a.name),
     releaseTags: source.apps
       .map((a) => a.appReleaseTag ?? "")
@@ -286,8 +287,7 @@ function SourceCard({ source }: { source: UserSource }) {
       </div>
 
       <DeployStep
-        path="bootstrap"
-        installationId={String(source.installationId)}
+        appSourceId={source.id}
         repo={repo}
         progress={progress}
         onProgress={patch}
@@ -305,7 +305,7 @@ function ChatEmbed({ appName }: { appName: string }) {
         Chat with your agent
       </div>
       <iframe
-        src={chatAppUrl(appName)}
+        src={chatAppUrl(appName, { locked: true })}
         title={`Chat with ${appName}`}
         className="border-input bg-background h-[600px] w-full rounded-xl border"
       />

--- a/apps/portal/src/components/settings/onboarding/deploy-step.tsx
+++ b/apps/portal/src/components/settings/onboarding/deploy-step.tsx
@@ -20,7 +20,6 @@ import {
   launchDryRun,
   launchStatus,
   type LaunchDeployPayload,
-  type LaunchPath,
   type LaunchProgress,
 } from "@portal/features/launch";
 
@@ -92,8 +91,7 @@ function initialPhase(progress: LaunchProgress): Phase {
 }
 
 export function DeployStep({
-  path,
-  installationId,
+  appSourceId,
   repo,
   actor,
   progress,
@@ -101,8 +99,8 @@ export function DeployStep({
   onReconnectInstall,
   onReset,
 }: {
-  path: LaunchPath;
-  installationId: string;
+  /** The connected source row to deploy. Resolved before this step renders. */
+  appSourceId: number;
   repo?: string;
   actor?: string;
   progress: LaunchProgress;
@@ -166,14 +164,14 @@ export function DeployStep({
     setError(null);
     statusFailuresRef.current = 0;
     try {
-      const result = await launchDryRun({ path, installationId, repo, actor });
+      const result = await launchDryRun({ appSourceId, actor });
       applyDeployment(result);
       setPhase("dry_ready");
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
       setPhase("error");
     }
-  }, [actor, applyDeployment, installationId, path, repo]);
+  }, [actor, applyDeployment, appSourceId]);
 
   const deploy = useCallback(async () => {
     setPhase("deploying");
@@ -181,15 +179,10 @@ export function DeployStep({
     statusFailuresRef.current = 0;
     try {
       if (!deployment) {
-        const dryResult = await launchDryRun({
-          path,
-          installationId,
-          repo,
-          actor,
-        });
+        const dryResult = await launchDryRun({ appSourceId, actor });
         applyDeployment(dryResult);
       }
-      const result = await launchDeploy({ path, installationId, repo, actor });
+      const result = await launchDeploy({ appSourceId, actor });
       applyDeployment(result);
       const id = result.deployment.id;
       setDeploymentId(id);
@@ -206,7 +199,7 @@ export function DeployStep({
       setError(e instanceof Error ? e.message : String(e));
       setPhase("error");
     }
-  }, [actor, applyDeployment, deployment, installationId, onProgress, path, repo]);
+  }, [actor, appSourceId, applyDeployment, deployment, onProgress, repo]);
 
   useEffect(() => {
     if (!deploymentId || (phase !== "building" && phase !== "deploying" && phase !== "releasing"))

--- a/apps/portal/src/components/settings/onboarding/oneshot-wizard.tsx
+++ b/apps/portal/src/components/settings/onboarding/oneshot-wizard.tsx
@@ -64,6 +64,7 @@ export function OneshotWizard({
       patch({
         installationId: result.installationId,
         repo: result.repo,
+        appSourceId: result.appSourceId,
       });
     } catch (err) {
       setCreateError(err instanceof Error ? err.message : String(err));
@@ -161,14 +162,13 @@ export function OneshotWizard({
         </div>
       )}
 
-      {step === "build" && progress.installationId && (
+      {step === "build" && progress.appSourceId && (
         <div className="border-input space-y-3 rounded-2xl border p-4">
           <div className="text-foreground text-sm font-medium">
             Step 3 — Build and activate
           </div>
           <DeployStep
-            path="oneshot"
-            installationId={progress.installationId}
+            appSourceId={progress.appSourceId}
             repo={progress.repo}
             actor={actor}
             progress={progress}

--- a/apps/portal/src/features/launch/contracts.ts
+++ b/apps/portal/src/features/launch/contracts.ts
@@ -41,6 +41,9 @@ export type LaunchProgress = {
   installationId?: string;
   installationStatus?: string;
   repo?: string;
+  /** Resolved source row id from create/sync — lets deploy skip re-resolving
+   *  by (installation, repo), which races webhook sync for fresh repos. */
+  appSourceId?: number;
   deploymentId?: string;
   deployment?: LaunchDeployPayload;
   releaseTags?: string[];
@@ -50,9 +53,9 @@ export type LaunchProgress = {
 };
 
 export type LaunchDeployInput = {
-  path: LaunchPath;
-  installationId: string;
-  repo?: string;
+  /** The connected source row to deploy. Resolved up front by create
+   *  (one-shot), sync-installed (bootstrap), or the dashboard listing. */
+  appSourceId: number;
   actor?: string;
 };
 

--- a/apps/portal/src/lib/chat-url.test.ts
+++ b/apps/portal/src/lib/chat-url.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { resolveChatUrl, chatAppUrl } from "./chat-url";
 
 beforeEach(() => {
@@ -60,5 +60,11 @@ describe("chatAppUrl", () => {
 
   it("handles numeric app names", () => {
     expect(chatAppUrl("123")).toBe("https://chat.aomi.dev?app=123");
+  });
+
+  it("can lock the frame to the requested app", () => {
+    expect(chatAppUrl("my-bot", { locked: true })).toBe(
+      "https://chat.aomi.dev?app=my-bot&lock_app=1",
+    );
   });
 });

--- a/apps/portal/src/lib/chat-url.ts
+++ b/apps/portal/src/lib/chat-url.ts
@@ -10,7 +10,11 @@ export function resolveChatUrl(): string {
  * Returns the deep-link URL for a specific app in the chat UI.
  * @param appName - The app identifier to open in chat.
  */
-export function chatAppUrl(appName: string): string {
+export function chatAppUrl(
+  appName: string,
+  options: { locked?: boolean } = {},
+): string {
   const base = resolveChatUrl();
-  return `${base}?app=${encodeURIComponent(appName)}`;
+  const query = `app=${encodeURIComponent(appName)}`;
+  return options.locked ? `${base}?${query}&lock_app=1` : `${base}?${query}`;
 }

--- a/apps/portal/src/server/bff/launch/routes.test.ts
+++ b/apps/portal/src/server/bff/launch/routes.test.ts
@@ -18,20 +18,13 @@ describe("launchDeployRoute", () => {
   });
 
   it("propagates BackendError status codes (400-599)", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ source: { id: 123 } }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ error: "deploy rejected" }), {
-          status: 409,
-          headers: { "Content-Type": "application/json" },
-        }),
-      );
+    // Deploy is a single backend call now — by appSourceId, no resolve step.
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "deploy rejected" }), {
+        status: 409,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
 
     vi.stubGlobal("fetch", fetchMock);
 
@@ -42,16 +35,34 @@ describe("launchDeployRoute", () => {
         origin: "http://localhost:3000",
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({
-        installationId: "123456789",
-      }),
+      body: JSON.stringify({ appSourceId: 123 }),
     });
 
     const res = await POST(req);
     const body = await res.json();
 
+    expect(fetchMock).toHaveBeenCalledOnce();
     expect(res.status).toBe(409);
     expect(body).toEqual({ error: "deploy rejected" });
+  });
+
+  it("rejects a missing appSourceId before calling the backend", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const POST = launchDeployRoute(false);
+    const req = new Request("http://localhost:3000/api/launch/deploy", {
+      method: "POST",
+      headers: {
+        origin: "http://localhost:3000",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ installationId: "123456789" }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("returns 502 for non-BackendError exceptions", async () => {
@@ -65,9 +76,7 @@ describe("launchDeployRoute", () => {
         origin: "http://localhost:3000",
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({
-        installationId: "123456789",
-      }),
+      body: JSON.stringify({ appSourceId: 123 }),
     });
 
     const res = await POST(req);

--- a/apps/portal/src/server/bff/launch/routes.ts
+++ b/apps/portal/src/server/bff/launch/routes.ts
@@ -46,21 +46,8 @@ function defaultRepoName() {
   return `${normalized}-${randomBytes(4).toString("hex")}`;
 }
 
-async function resolveAppSourceId(args: {
-  client: Awaited<ReturnType<typeof deploymentClient>>;
-  platform: string;
-  installationId: string;
-  repo?: string;
-}): Promise<number> {
-  const source = await args.client.resolveSource({
-    platform: args.platform,
-    installationId: Number(args.installationId),
-    repo: args.repo,
-  });
-  if (!Number.isSafeInteger(source.id) || source.id <= 0) {
-    throw new Error("backend did not return a valid app source id");
-  }
-  return source.id;
+function isValidAppSourceId(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
 }
 
 export function launchDeployRoute(dryRun: boolean) {
@@ -69,28 +56,19 @@ export function launchDeployRoute(dryRun: boolean) {
     if (blocked) return blocked;
 
     const body = (await req.json().catch(() => ({}))) as Record<string, unknown>;
-    if (!isValidInstallationId(body.installationId)) {
+    if (!isValidAppSourceId(body.appSourceId)) {
       return NextResponse.json(
-        { error: "invalid `installationId`" },
+        { error: "missing or invalid `appSourceId`" },
         { status: 400 },
       );
-    }
-    if (body.repo !== undefined && !isValidRepo(body.repo)) {
-      return NextResponse.json({ error: "invalid `repo`" }, { status: 400 });
     }
 
     try {
       const config = launchConfig();
       const client = await deploymentClient();
-      const appSourceId = await resolveAppSourceId({
-        client,
-        platform: config.platform,
-        installationId: body.installationId as string,
-        repo: body.repo as string | undefined,
-      });
       const { deployment } = await client.deploy({
         platform: config.platform,
-        appSourceId,
+        appSourceId: body.appSourceId,
         sourceRef: config.sourceRef,
         aomiTomlPaths: config.aomiTomlPaths,
         dryRun,
@@ -99,9 +77,7 @@ export function launchDeployRoute(dryRun: boolean) {
       return NextResponse.json(
         {
           ok: true,
-          repo:
-            (body.repo as string | undefined) ??
-            deployment.source.repositoryLink,
+          repo: deployment.source.repositoryLink,
           deployment,
           releaseTags: releaseTagsFromDeployment(deployment),
           apps: appNamesFromDeployment(deployment),

--- a/packages/client/test/client.unit.test.ts
+++ b/packages/client/test/client.unit.test.ts
@@ -10,7 +10,7 @@ describe("AomiClient route manifest", () => {
         `${endpoint.method} ${endpoint.path} [${endpoint.auth.join(", ")}]`,
     );
 
-    expect(routeKeys).toHaveLength(74);
+    expect(routeKeys).toHaveLength(78);
     expect(new Set(routeKeys).size).toBe(routeKeys.length);
     expect(routeKeys).toContain("GET /api/session/apps [session]");
     expect(routeKeys).toContain("POST /api/platforms/:name/deploy [activation]");

--- a/packages/client/test/fixtures/backend-openapi.json
+++ b/packages/client/test/fixtures/backend-openapi.json
@@ -27,6 +27,23 @@
         "x-aomi-auth": []
       }
     },
+    "/metrics": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "serviceBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
     "/api/chat": {
       "post": {
         "responses": {
@@ -956,6 +973,51 @@
         },
         "security": [],
         "x-aomi-auth": []
+      }
+    },
+    "/api/integrations/github-app/oauth/result": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": []
+      }
+    },
+    "/api/integrations/github-app/oauth/exchange": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "serviceBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/sources": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "serviceBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/platforms/{name}/sources/create-from-template": {

--- a/packages/client/test/generated/backend-routes.ts
+++ b/packages/client/test/generated/backend-routes.ts
@@ -115,8 +115,23 @@ export const AOMI_BACKEND_ENDPOINTS = [
   },
   {
     method: "GET",
+    path: "/api/integrations/github-app/oauth/exchange",
+    auth: ["service"],
+  },
+  {
+    method: "GET",
+    path: "/api/integrations/github-app/oauth/result",
+    auth: [],
+  },
+  {
+    method: "GET",
     path: "/api/integrations/github-app/oauth/start",
     auth: [],
+  },
+  {
+    method: "GET",
+    path: "/api/integrations/github-app/user/sources",
+    auth: ["service"],
   },
   {
     method: "GET",
@@ -207,6 +222,11 @@ export const AOMI_BACKEND_ENDPOINTS = [
     method: "GET",
     path: "/health",
     auth: [],
+  },
+  {
+    method: "GET",
+    path: "/metrics",
+    auth: ["service"],
   },
   {
     method: "PATCH",

--- a/packages/deploy/src/client.ts
+++ b/packages/deploy/src/client.ts
@@ -21,7 +21,6 @@ import type {
   MintedToken,
   PlatformApp,
   ProgressModel,
-  ResolveSourceInput,
   RevokeTokenInput,
   ScaffoldInput,
   StatusInput,
@@ -356,40 +355,6 @@ export class DeploymentClient {
     );
     await this.audit({
       action: "sync_source",
-      platform,
-      repo,
-      actor: input.actor,
-      ts: Date.now(),
-    });
-    return camelAppSource(raw.source);
-  }
-
-  /**
-   * Look up an existing source row by installation (+ optional repo) without
-   * syncing. `GET /api/platforms/:platform/sources/resolve`.
-   */
-  async resolveSource(input: ResolveSourceInput): Promise<AppSource> {
-    const platform = cleanPlatform(input.platform);
-    const installationId = Number(input.installationId);
-    if (!Number.isSafeInteger(installationId) || installationId <= 0) {
-      throw new DeployError(
-        "INVALID_REQUEST",
-        "resolveSource requires a positive installationId",
-      );
-    }
-    const params = new URLSearchParams({
-      installation_id: String(installationId),
-    });
-    const repo = input.repo?.trim();
-    if (repo) params.set("repo", repo);
-    const bearer = this.resolveBearer(input.bearer);
-    const raw = await this.get<{ ok?: boolean; source?: unknown }>(
-      `/api/platforms/${encodeURIComponent(platform)}/sources/resolve?${params.toString()}`,
-      "resolve_source",
-      bearer,
-    );
-    await this.audit({
-      action: "resolve_source",
       platform,
       repo,
       actor: input.actor,

--- a/packages/deploy/src/index.ts
+++ b/packages/deploy/src/index.ts
@@ -52,7 +52,6 @@ export type {
   RevokeTokenInput,
   AppSource,
   SyncSourceInput,
-  ResolveSourceInput,
   ScaffoldInput,
   ListAppsInput,
   GetAppInput,

--- a/packages/deploy/src/types.ts
+++ b/packages/deploy/src/types.ts
@@ -29,7 +29,6 @@ export interface AuditEvent {
     | "list_tokens"
     | "revoke_token"
     | "sync_source"
-    | "resolve_source"
     | "scaffold"
     | "list_apps"
     | "get_app"
@@ -307,12 +306,6 @@ export interface SyncSourceInput extends BearerOverride {
   repo: string;
 }
 
-export interface ResolveSourceInput extends BearerOverride {
-  platform: string;
-  installationId: number;
-  /** Optional `owner/name` filter within the installation. */
-  repo?: string;
-}
 
 export interface ScaffoldInput extends BearerOverride {
   platform: string;

--- a/packages/deploy/test/bootstrap.test.ts
+++ b/packages/deploy/test/bootstrap.test.ts
@@ -192,20 +192,6 @@ describe("DeploymentClient bootstrap — sources", () => {
     });
   });
 
-  it("resolves a source via query params", async () => {
-    jsonOnce(fetchMock, sourceBody);
-    await client({ activationToken: "plat-tok" }).resolveSource({
-      platform: "playground",
-      installationId: 555,
-      repo: "alice/alice-bot",
-    });
-    const [url, init] = fetchMock.mock.calls[0];
-    expect((init as RequestInit).method).toBe("GET");
-    expect(url).toBe(
-      "https://staging-api.example.com/api/platforms/playground/sources/resolve?installation_id=555&repo=alice%2Falice-bot",
-    );
-  });
-
   it("scaffolds from the default template and maps the source", async () => {
     jsonOnce(fetchMock, sourceBody);
     const src = await client({ activationToken: "plat-tok" }).scaffold({


### PR DESCRIPTION
Two related changes to the launch/onboarding flow. Builds on the merged #255.

## 1. Deploy by `app_source_id` only

Removes the `(installation_id, repo)` → source resolution from the deploy path; the source id is resolved once, up front, and carried through.

- `LaunchDeployInput` → `{ appSourceId }`
- BFF `launchDeployRoute` requires `appSourceId`; `resolveAppSourceId` deleted
- one-shot uses `create`'s returned id, bootstrap resolves via `sync-installed` before deploying, the dashboard uses `source.id`
- `@aomi-labs/deploy`: drop the now-unused `resolveSource` client method + type

**Pairs with backend [product-mono#703](https://github.com/aomi-labs/product-mono/pull/703)** (removes `GET /api/platforms/:name/sources/resolve`). Together they delete the racy `lookup_by_repository_link` + exact-`installation_id` filter that 404'd freshly-created one-shot repos (`no app source found for installation … and repo …`). **Ship together** — the portal no longer calls the endpoint, the backend no longer serves it.

## 2. Lock chat to the activated bot

After activation the embedded chat is pinned to the target app so the user can't end up talking to a different bot:

- `chatAppUrl(name, { locked: true })` → `?app=…&lock_app=1`
- `PortalAomiFrame` reads `lock_app`, then: forces `app=<name>` on every `/api/chat` request (incl. the 402 payment retry), hides the app switcher (`hideApp`), and starts a fresh thread bound to the activated app.

Note: this is client-side UX enforcement (not a security boundary) and pins by app **name** (exact for the one-bot happy path).

## Test plan
- `@aomi-labs/deploy`: tsc + build + 40 tests
- portal: tsc clean; 73 tests (launch / bff / onboarding / chat-url)

🤖 Generated with [Claude Code](https://claude.com/claude-code)