### PR TITLE
launch: id-first deploy resolution + client cleanup

### DIFF
--- a/apps/portal/src/components/settings/onboarding/deploy-step.tsx
+++ b/apps/portal/src/components/settings/onboarding/deploy-step.tsx
@@ -200,23 +200,21 @@ export function DeployStep({
     setError(null);
     statusFailuresRef.current = 0;
     try {
+      // Deploy commits against a stable source row id. The first deploy after
+      // an install has none yet, so a dry run mints it (and primes the
+      // preview); afterwards we go straight through by id.
       let appSourceId = progress.appSourceId;
-      if (!deployment) {
-        const dryResult = await launchDryRun({
-          installationId,
-          repo,
-          appSourceId,
-          actor,
-        });
+      if (!appSourceId) {
+        const dryResult = await launchDryRun({ installationId, repo, actor });
         applyDeployment(dryResult);
-        appSourceId = dryResult.appSourceId ?? appSourceId;
+        appSourceId = dryResult.appSourceId;
       }
-      const result = await launchDeploy({
-        installationId,
-        repo,
-        appSourceId,
-        actor,
-      });
+      if (!appSourceId) {
+        throw new Error(
+          "Could not resolve a source to deploy. Run a dry run first.",
+        );
+      }
+      const result = await launchDeploy({ appSourceId, actor });
       applyDeployment(result);
       const id = result.deployment.id;
       setDeploymentId(id);
@@ -239,7 +237,6 @@ export function DeployStep({
   }, [
     actor,
     applyDeployment,
-    deployment,
     installationId,
     onProgress,
     progress.appSourceId,

--- a/apps/portal/src/features/launch/client.ts
+++ b/apps/portal/src/features/launch/client.ts
@@ -7,6 +7,7 @@ import {
   type LaunchCreateRepoResult,
   type LaunchDeployInput,
   type LaunchDeployResult,
+  type LaunchDryRunInput,
   type LaunchRedeployResult,
   type LaunchStatus,
   type LaunchSyncInstalledResult,
@@ -41,162 +42,84 @@ export async function githubAppInstallUrl(args: {
   return result.install_url;
 }
 
-async function postLaunchDeploy(
-  path: "/api/launch/dry-run" | "/api/launch/deploy",
-  input: LaunchDeployInput,
-): Promise<LaunchDeployResult> {
-  const res = await fetch(path, {
+// Every launch BFF route returns the payload on success or `{ error }` on
+// failure. Centralize that contract so each call site stays a one-liner.
+async function launchFetch<T>(
+  path: string,
+  label: string,
+  init?: RequestInit,
+): Promise<T> {
+  const res = await fetch(path, init);
+  const json = (await res.json().catch(() => ({}))) as T & { error?: string };
+  if (!res.ok) {
+    throw new Error(json.error || `${label} failed (${res.status})`);
+  }
+  return json;
+}
+
+function postJson<T>(path: string, label: string, input: unknown): Promise<T> {
+  return launchFetch<T>(path, label, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(input),
   });
-  const json = (await res.json().catch(() => ({}))) as
-    | LaunchDeployResult
-    | { error?: string };
-  if (!res.ok) {
-    const msg =
-      "error" in json && json.error
-        ? json.error
-        : `launch deploy failed (${res.status})`;
-    throw new Error(msg);
-  }
-  return json as LaunchDeployResult;
 }
 
 export function launchDryRun(
-  input: LaunchDeployInput,
+  input: LaunchDryRunInput,
 ): Promise<LaunchDeployResult> {
-  return postLaunchDeploy("/api/launch/dry-run", input);
+  return postJson("/api/launch/dry-run", "launch dry run", input);
 }
 
 export function launchDeploy(
   input: LaunchDeployInput,
 ): Promise<LaunchDeployResult> {
-  return postLaunchDeploy("/api/launch/deploy", input);
+  return postJson("/api/launch/deploy", "launch deploy", input);
 }
 
-export async function launchRedeploy(input: {
+export function launchRedeploy(input: {
   appSourceId: number;
 }): Promise<LaunchRedeployResult> {
-  const res = await fetch("/api/launch/redeploy", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(input),
-  });
-  const json = (await res.json().catch(() => ({}))) as
-    | LaunchRedeployResult
-    | { error?: string };
-  if (!res.ok) {
-    const msg =
-      "error" in json && json.error
-        ? json.error
-        : `launch redeploy failed (${res.status})`;
-    throw new Error(msg);
-  }
-  return json as LaunchRedeployResult;
+  return postJson("/api/launch/redeploy", "launch redeploy", input);
 }
 
-export async function launchCreateRepo(input: {
+export function launchCreateRepo(input: {
   installationId: string;
   repoName?: string;
 }): Promise<LaunchCreateRepoResult> {
-  const res = await fetch("/api/launch/create", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(input),
-  });
-  const json = (await res.json().catch(() => ({}))) as
-    | LaunchCreateRepoResult
-    | { error?: string };
-  if (!res.ok) {
-    const msg =
-      "error" in json && json.error
-        ? json.error
-        : `launch repo creation failed (${res.status})`;
-    throw new Error(msg);
-  }
-  return json as LaunchCreateRepoResult;
+  return postJson("/api/launch/create", "launch repo creation", input);
 }
 
-export async function launchStatus(
-  deploymentId: string,
-): Promise<LaunchStatus> {
-  const res = await fetch(
+export function launchStatus(deploymentId: string): Promise<LaunchStatus> {
+  return launchFetch(
     `/api/launch/status?deploymentId=${encodeURIComponent(deploymentId)}`,
+    "launch status",
   );
-  const json = (await res.json().catch(() => ({}))) as
-    | LaunchStatus
-    | { error?: string };
-  if (!res.ok) {
-    const msg =
-      "error" in json && json.error
-        ? json.error
-        : `launch status failed (${res.status})`;
-    throw new Error(msg);
-  }
-  return json as LaunchStatus;
 }
 
-export async function launchActivate(input: {
+export function launchActivate(input: {
   releaseTags: string[];
   apps?: string[];
   actor?: string;
 }): Promise<LaunchActivateResult> {
-  const res = await fetch("/api/launch/activate", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(input),
-  });
-  const json = (await res.json().catch(() => ({}))) as
-    | LaunchActivateResult
-    | { error?: string };
-  if (!res.ok) {
-    const msg =
-      "error" in json && json.error
-        ? json.error
-        : `launch activation failed (${res.status})`;
-    throw new Error(msg);
-  }
-  return json as LaunchActivateResult;
+  return postJson("/api/launch/activate", "launch activation", input);
 }
 
-export async function launchAppStatus(input: {
+export function launchAppStatus(input: {
   name: string;
   releaseTag?: string;
 }): Promise<LaunchAppStatus> {
   const params = new URLSearchParams({ name: input.name });
   if (input.releaseTag) params.set("releaseTag", input.releaseTag);
-  const res = await fetch(`/api/launch/app?${params}`);
-  const json = (await res.json().catch(() => ({}))) as
-    | LaunchAppStatus
-    | { error?: string };
-  if (!res.ok) {
-    const msg =
-      "error" in json && json.error
-        ? json.error
-        : `launch app status failed (${res.status})`;
-    throw new Error(msg);
-  }
-  return json as LaunchAppStatus;
+  return launchFetch(`/api/launch/app?${params}`, "launch app status");
 }
 
-export async function launchSyncInstalled(input: {
+export function launchSyncInstalled(input: {
   repo: string;
 }): Promise<LaunchSyncInstalledResult> {
-  const res = await fetch("/api/launch/sync-installed", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(input),
-  });
-  const json = (await res.json().catch(() => ({}))) as
-    | LaunchSyncInstalledResult
-    | { error?: string };
-  if (!res.ok) {
-    const msg =
-      "error" in json && json.error
-        ? json.error
-        : `launch installed app sync failed (${res.status})`;
-    throw new Error(msg);
-  }
-  return json as LaunchSyncInstalledResult;
+  return postJson(
+    "/api/launch/sync-installed",
+    "launch installed app sync",
+    input,
+  );
 }

--- a/apps/portal/src/features/launch/contracts.ts
+++ b/apps/portal/src/features/launch/contracts.ts
@@ -51,13 +51,23 @@ export type LaunchProgress = {
   live?: boolean;
 };
 
-export type LaunchDeployInput = {
-  /** Backend source row id. When present, deploy can skip source syncing. */
+/**
+ * Dry-run / preview input. This is the one place a repo may stand in for a
+ * source row: the dry run materializes the backend source and returns its
+ * `appSourceId`.
+ */
+export type LaunchDryRunInput = {
   appSourceId?: number;
-  /** GitHub App installation that owns the source repo. Kept for wizard context. */
+  /** GitHub App installation that owns the source repo. Wizard context only. */
   installationId?: string;
-  /** `owner/name` repo used to sync the backend source when appSourceId is absent. */
+  /** `owner/name` repo used to mint the backend source when appSourceId is absent. */
   repo?: string;
+  actor?: string;
+};
+
+/** Commit a deploy against a stable, already-resolved source row. */
+export type LaunchDeployInput = {
+  appSourceId: number;
   actor?: string;
 };
 

--- a/apps/portal/src/server/bff/launch/routes.test.ts
+++ b/apps/portal/src/server/bff/launch/routes.test.ts
@@ -38,24 +38,12 @@ describe("launchDeployRoute", () => {
   });
 
   it("propagates BackendError status codes (400-599)", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        Response.json({
-          ok: true,
-          source: {
-            id: 123,
-            installation_id: 555,
-            repository_link: "alice/bot",
-          },
-        }),
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ error: "deploy rejected" }), {
-          status: 409,
-          headers: { "Content-Type": "application/json" },
-        }),
-      );
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "deploy rejected" }), {
+        status: 409,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
 
     vi.stubGlobal("fetch", fetchMock);
 
@@ -66,18 +54,18 @@ describe("launchDeployRoute", () => {
         origin: "http://localhost:3000",
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ installationId: "555", repo: "alice/bot" }),
+      body: JSON.stringify({ appSourceId: 123 }),
     });
 
     const res = await POST(req);
     const body = await res.json();
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(res.status).toBe(409);
     expect(body).toEqual({ error: "deploy rejected" });
   });
 
-  it("syncs source id by repo before deploying when appSourceId is absent", async () => {
+  it("dry run mints the source row by repo, then previews by app source id", async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
@@ -102,8 +90,8 @@ describe("launchDeployRoute", () => {
       );
     vi.stubGlobal("fetch", fetchMock);
 
-    const POST = launchDeployRoute(false);
-    const req = new Request("http://localhost:3000/api/launch/deploy", {
+    const POST = launchDeployRoute(true);
+    const req = new Request("http://localhost:3000/api/launch/dry-run", {
       method: "POST",
       headers: {
         origin: "http://localhost:3000",
@@ -115,7 +103,7 @@ describe("launchDeployRoute", () => {
     const res = await POST(req);
     const body = await res.json();
 
-    expect(res.status).toBe(202);
+    expect(res.status).toBe(200);
     expect(body.repo).toBe("alice/bot");
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
@@ -133,6 +121,25 @@ describe("launchDeployRoute", () => {
         body: expect.stringContaining('"app_source_id":123'),
       }),
     );
+  });
+
+  it("real deploy rejects a repo-only request without an app source id", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const POST = launchDeployRoute(false);
+    const req = new Request("http://localhost:3000/api/launch/deploy", {
+      method: "POST",
+      headers: {
+        origin: "http://localhost:3000",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ installationId: "555", repo: "alice/bot" }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("deploys directly by appSourceId when the source identity is already known", async () => {
@@ -232,7 +239,7 @@ describe("launchDeployRoute", () => {
         origin: "http://localhost:3000",
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ installationId: "555", repo: "alice/bot" }),
+      body: JSON.stringify({ appSourceId: 123 }),
     });
 
     const res = await POST(req);

--- a/apps/portal/src/server/bff/launch/routes.ts
+++ b/apps/portal/src/server/bff/launch/routes.ts
@@ -46,52 +46,6 @@ function isValidAppSourceId(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
 }
 
-type ResolvedAppSource = {
-  appSourceId: number;
-  installationId?: string;
-  repo?: string;
-};
-
-function sourceIdentity(source: {
-  id: number;
-  installationId?: number | null;
-  repositoryLink?: string | null;
-}): ResolvedAppSource {
-  if (!isValidAppSourceId(source.id)) {
-    throw new Error("backend did not return a valid app source id");
-  }
-  return {
-    appSourceId: source.id,
-    installationId:
-      typeof source.installationId === "number" &&
-      Number.isSafeInteger(source.installationId) &&
-      source.installationId > 0
-        ? String(source.installationId)
-        : undefined,
-    repo: source.repositoryLink?.trim() || undefined,
-  };
-}
-
-async function resolveAppSource(args: {
-  client: Awaited<ReturnType<typeof deploymentClient>>;
-  platform: string;
-  appSourceId?: unknown;
-  repo?: string;
-}): Promise<ResolvedAppSource> {
-  if (isValidAppSourceId(args.appSourceId)) {
-    return { appSourceId: args.appSourceId, repo: args.repo };
-  }
-  if (!args.repo) {
-    throw new Error("missing appSourceId or repo");
-  }
-  return sourceIdentity(
-    await args.client.syncSource({
-      platform: args.platform,
-      repo: args.repo,
-    }),
-  );
-}
-
 export function launchDeployRoute(dryRun: boolean) {
   return async function POST(req: Request): Promise<NextResponse> {
     const blocked = checkWrite(req);
@@ -113,25 +67,42 @@ export function launchDeployRoute(dryRun: boolean) {
     if (body.repo !== undefined && !isValidRepo(body.repo)) {
       return NextResponse.json({ error: "invalid `repo`" }, { status: 400 });
     }
-    if (!isValidAppSourceId(body.appSourceId) && !isValidRepo(body.repo)) {
-      return NextResponse.json(
-        { error: "missing `appSourceId` or `repo`" },
-        { status: 400 },
-      );
-    }
 
     try {
       const config = launchConfig();
       const client = await deploymentClient();
-      const source = await resolveAppSource({
-        client,
-        platform: config.platform,
-        appSourceId: body.appSourceId,
-        repo: body.repo as string | undefined,
-      });
+
+      // A deploy always commits against a stable source row id. Resolving (or
+      // minting) that row from a repo is a separate concern: it happens here
+      // only for a dry run — the preview that materializes the row — or via the
+      // dedicated /sync-installed route. The committing deploy never silently
+      // creates or re-resolves a source by repo.
+      let appSourceId: number;
+      if (isValidAppSourceId(body.appSourceId)) {
+        appSourceId = body.appSourceId;
+      } else if (dryRun && isValidRepo(body.repo)) {
+        const synced = await client.syncSource({
+          platform: config.platform,
+          repo: body.repo as string,
+        });
+        if (!isValidAppSourceId(synced.id)) {
+          throw new Error("backend did not return a valid app source id");
+        }
+        appSourceId = synced.id;
+      } else {
+        return NextResponse.json(
+          {
+            error: dryRun
+              ? "missing `appSourceId` or `repo`"
+              : "missing `appSourceId`",
+          },
+          { status: 400 },
+        );
+      }
+
       const { deployment } = await client.deploy({
         platform: config.platform,
-        appSourceId: source.appSourceId,
+        appSourceId,
         sourceRef: config.sourceRef,
         aomiTomlPaths: config.aomiTomlPaths,
         dryRun,
@@ -141,15 +112,12 @@ export function launchDeployRoute(dryRun: boolean) {
         {
           ok: true,
           repo:
-            source.repo ??
-            (body.repo as string | undefined) ??
-            deployment.source.repositoryLink,
-          installationId:
-            source.installationId ??
-            (deployment.source.installationId
-              ? String(deployment.source.installationId)
-              : undefined),
-          appSourceId: source.appSourceId,
+            deployment.source.repositoryLink ??
+            (body.repo as string | undefined),
+          installationId: deployment.source.installationId
+            ? String(deployment.source.installationId)
+            : undefined,
+          appSourceId,
           deployment,
           releaseTags: releaseTagsFromDeployment(deployment),
           apps: appNamesFromDeployment(deployment),


### PR DESCRIPTION
## Why

The deploy BFF route silently resolved/created a source row **by repo** (`resolveAppSource` → `syncSource`) whenever `appSourceId` was absent — so the *committing* deploy could re-resolve or mint a source off a natural key. That pulled FE resolution in the opposite direction from the backend's id-first model (app rows resolved by stable `application_id`; repo/name are only hints).

## What changed

- **`server/bff/launch/routes.ts`** — real deploy (`dryRun=false`) now **requires a valid `appSourceId`** and rejects repo-only with `400` *before* any backend call. Repo → source materialization happens **only in the dry run** (the preview that mints the row) or via the dedicated `/sync-installed` route. Removed `resolveAppSource()` / `sourceIdentity()` / `ResolvedAppSource`.
- **`components/settings/onboarding/deploy-step.tsx`** — gate resolution on **`!appSourceId`** (was `!deployment`), so the dry run that mints the id is keyed on the *missing id*, not on a missing local deployment object. The commit call is id-only: `launchDeploy({ appSourceId, actor })`.
- **`features/launch/contracts.ts`** — split `LaunchDryRunInput` (may carry `repo`) from `LaunchDeployInput` (`appSourceId` required) so the compiler enforces the boundary.
- **`features/launch/client.ts`** — collapsed 9 duplicated `fetch → json → if(!ok) throw` blocks into one `launchFetch`/`postJson` helper (−115 / +38).

Net: **−227 / +132** across 5 files. Repo is now a one-time natural-key lookup at the dry-run/install boundary; the actual deploy is keyed on the stable `appSourceId` — consistent with backend #706.

## Verification

- Portal unit tests **18/18 pass** (`routes.test.ts`, `deploy-step.test.tsx`), updated to the id-first contract (real deploy rejects repo-only; dry run mints by repo).
- `tsc --noEmit`: 0 errors. ESLint on touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)