### PR TITLE
Align deploy client preflight flow

### DIFF
--- a/apps/portal/src/features/launch/components/bootstrap-wizard.test.tsx
+++ b/apps/portal/src/features/launch/components/bootstrap-wizard.test.tsx
@@ -52,6 +52,7 @@ vi.mock("@portal/features/launch", () => ({
       .replace(/\.git$/, "") || null,
   TEMPLATE_GENERATE_URL:
     "https://github.com/aomi-labs/playground-example/generate",
+  TEMPLATE_REPO: "aomi-labs/playground-example",
   TEMPLATE_REPO_URL: "https://github.com/aomi-labs/playground-example",
 }));
 
@@ -161,6 +162,8 @@ describe("BootstrapWizard", () => {
             installationId: 141780080,
             repositoryId: null,
             repositoryLink: "phoebe-aomi/playground-example-1",
+            sourceRef: "abc1234def5678",
+            commitHash: "abc1234def5678",
             githubAccount: null,
             githubUserId: null,
             boundPlatformId: null,

--- a/apps/portal/src/features/launch/components/bootstrap-wizard.tsx
+++ b/apps/portal/src/features/launch/components/bootstrap-wizard.tsx
@@ -81,6 +81,7 @@ export function BootstrapWizard({
       installationId: String(source.installationId),
       installationStatus: "bound",
       appSourceId: source.id,
+      sourceRef: source.sourceRef ?? source.commitHash ?? undefined,
       apps: source.apps.map((app) => app.name).filter(Boolean),
       releaseTags: source.apps
         .map((app) => app.appReleaseTag ?? "")
@@ -386,7 +387,11 @@ function BootstrapDeployStep({
       if (!result.appSourceId) {
         throw new Error("backend did not return a source id for this repo");
       }
-      patch({ appSourceId: result.appSourceId, repo: result.repo });
+      patch({
+        appSourceId: result.appSourceId,
+        repo: result.repo,
+        sourceRef: result.sourceRef,
+      });
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {

--- a/apps/portal/src/features/launch/components/deploy-dashboard.tsx
+++ b/apps/portal/src/features/launch/components/deploy-dashboard.tsx
@@ -400,6 +400,7 @@ function SourceCard({ source }: { source: UserSource }) {
     installationId: String(source.installationId),
     repo: lifecycle.repo,
     appSourceId: source.id,
+    sourceRef: source.sourceRef ?? source.commitHash ?? undefined,
     apps: lifecycle.appNames,
     releaseTags: lifecycle.releaseTags,
     live: visibleLifecycle.kind === "live",

--- a/apps/portal/src/features/launch/components/deploy-step.tsx
+++ b/apps/portal/src/features/launch/components/deploy-step.tsx
@@ -157,6 +157,7 @@ export function DeployStep({
       repo?: string;
       installationId?: string;
       appSourceId?: number;
+      sourceRef?: string;
       deployment: LaunchDeployPayload;
       releaseTags?: string[];
       apps?: string[];
@@ -170,6 +171,7 @@ export function DeployStep({
         deployment: next.deployment,
         releaseTags: nextTags,
         apps: nextApps,
+        sourceRef: next.sourceRef ?? next.deployment.source?.ref,
       };
       if (next.installationId) patch.installationId = next.installationId;
       if (next.appSourceId) patch.appSourceId = next.appSourceId;
@@ -187,6 +189,7 @@ export function DeployStep({
         installationId,
         repo,
         appSourceId: progress.appSourceId,
+        sourceRef: progress.sourceRef,
         actor,
       });
       applyDeployment(result);
@@ -195,7 +198,14 @@ export function DeployStep({
       setError(e instanceof Error ? e.message : String(e));
       setPhase("error");
     }
-  }, [actor, applyDeployment, installationId, progress.appSourceId, repo]);
+  }, [
+    actor,
+    applyDeployment,
+    installationId,
+    progress.appSourceId,
+    progress.sourceRef,
+    repo,
+  ]);
 
   const deploy = useCallback(async () => {
     setPhase("deploying");
@@ -206,21 +216,26 @@ export function DeployStep({
       // an install has none yet, so a preflight mints it (and primes the
       // preview); afterwards we go straight through by id.
       let appSourceId = progress.appSourceId;
-      if (!appSourceId) {
+      let sourceRef = progress.sourceRef ?? deployment?.source?.ref;
+      if (!appSourceId || !sourceRef) {
         const preflightResult = await launchPreflight({
           installationId,
           repo,
+          appSourceId,
+          sourceRef,
           actor,
         });
         applyDeployment(preflightResult);
         appSourceId = preflightResult.appSourceId;
+        sourceRef =
+          preflightResult.sourceRef ?? preflightResult.deployment.source?.ref;
       }
       if (!appSourceId) {
         throw new Error(
           "Could not resolve a source to deploy. Run a preflight first.",
         );
       }
-      const result = await launchDeploy({ appSourceId, actor });
+      const result = await launchDeploy({ appSourceId, sourceRef, repo, actor });
       applyDeployment(result);
       const id = result.deployment.id;
       setDeploymentId(id);
@@ -228,6 +243,7 @@ export function DeployStep({
         repo: result.repo ?? repo,
         deploymentId: id,
         deployment: result.deployment,
+        sourceRef: result.sourceRef ?? result.deployment.source?.ref,
         releaseTags: result.releaseTags,
         apps: result.apps,
         live: false,
@@ -246,7 +262,9 @@ export function DeployStep({
     installationId,
     onProgress,
     progress.appSourceId,
+    progress.sourceRef,
     repo,
+    deployment?.source?.ref,
   ]);
 
   useEffect(() => {

--- a/apps/portal/src/features/launch/components/live-panel.tsx
+++ b/apps/portal/src/features/launch/components/live-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { CheckCircle2, ExternalLink } from "lucide-react";
-import { TEMPLATE_REPO_URL } from "@portal/features/launch";
+import { TEMPLATE_REPO, TEMPLATE_REPO_URL } from "@portal/features/launch";
 
 /** Shared success state. `repo` is owner/name when known; falls back to the
  *  template so the clone story still renders during early wiring.
@@ -16,7 +16,7 @@ export function LivePanel({
   chatUrl?: string;
 }) {
   const repoUrl = repo ? `https://github.com/${repo}` : TEMPLATE_REPO_URL;
-  const dir = repo ? repo.split("/")[1] : "playground-example";
+  const dir = repo ? repo.split("/")[1] : TEMPLATE_REPO.split("/")[1];
   const chatTitle = repo ? `Chat with ${repo}` : "Chat with your agent";
 
   return (

--- a/apps/portal/src/features/launch/components/oneshot-wizard.test.tsx
+++ b/apps/portal/src/features/launch/components/oneshot-wizard.test.tsx
@@ -43,6 +43,7 @@ vi.mock("@portal/features/launch", () => ({
   },
   installationStatusLabel: () => null,
   launchCreateRepo: vi.fn(),
+  TEMPLATE_REPO: "aomi-labs/playground-example",
   TEMPLATE_REPO_URL: "https://github.com/aomi-labs/playground-example",
 }));
 

--- a/apps/portal/src/features/launch/components/oneshot-wizard.tsx
+++ b/apps/portal/src/features/launch/components/oneshot-wizard.tsx
@@ -13,6 +13,7 @@ import {
   installationStatusLabel,
   launchCreateRepo,
   oneshotStep,
+  TEMPLATE_REPO,
   type LaunchProgress,
 } from "@portal/features/launch";
 import { chatAppUrl } from "@portal/lib/chat-url";
@@ -69,6 +70,7 @@ export function OneshotWizard({
         installationId: result.installationId,
         repo: result.repo,
         appSourceId: result.appSourceId,
+        sourceRef: result.sourceRef,
       });
     } catch (err) {
       setCreateError(err instanceof Error ? err.message : String(err));
@@ -149,9 +151,8 @@ export function OneshotWizard({
               Step 2 — Create your repo
             </div>
             <p className="text-muted-foreground text-sm leading-5">
-              Creates a GitHub repo from{" "}
-              <code>aomi-labs/playground-example</code> in the account where you
-              installed <code>aomi-build-oneshot</code>.
+              Creates a GitHub repo from <code>{TEMPLATE_REPO}</code> in the
+              account where you installed <code>aomi-build-oneshot</code>.
             </p>
             <Button
               onClick={createRepo}

--- a/apps/portal/src/features/launch/contracts.ts
+++ b/apps/portal/src/features/launch/contracts.ts
@@ -6,7 +6,9 @@ import type {
 
 export type LaunchPath = "oneshot" | "bootstrap";
 
-export const TEMPLATE_REPO = "aomi-labs/playground-example";
+export const TEMPLATE_REPO =
+  process.env.NEXT_PUBLIC_APP_DEPLOY_TEMPLATE_REPO?.trim() ||
+  "aomi-labs/playground-example";
 export const TEMPLATE_REPO_URL = `https://github.com/${TEMPLATE_REPO}`;
 export const TEMPLATE_GENERATE_URL = `${TEMPLATE_REPO_URL}/generate`;
 
@@ -18,6 +20,8 @@ export type LaunchProgress = {
   repo?: string;
   /** Cached source row id from create/sync/dashboard responses. */
   appSourceId?: number;
+  /** Immutable source commit returned by source sync/create. */
+  sourceRef?: string;
   deploymentId?: string;
   deployment?: LaunchDeployPayload;
   releaseTags?: string[];
@@ -33,6 +37,7 @@ export type LaunchProgress = {
  */
 export type LaunchPreflightInput = {
   appSourceId?: number;
+  sourceRef?: string;
   /** GitHub App installation that owns the source repo. Wizard context only. */
   installationId?: string;
   /** `owner/name` repo used to mint the backend source when appSourceId is absent. */
@@ -43,6 +48,8 @@ export type LaunchPreflightInput = {
 /** Commit a deploy against a stable, already-resolved source row. */
 export type LaunchDeployInput = {
   appSourceId: number;
+  sourceRef?: string;
+  repo?: string;
   actor?: string;
 };
 
@@ -50,6 +57,7 @@ export type LaunchDeployResult = {
   repo: string;
   installationId?: string;
   appSourceId?: number;
+  sourceRef?: string;
   deployment: LaunchDeployPayload;
   releaseTags: string[];
   apps: string[];
@@ -60,6 +68,7 @@ export type LaunchCreateRepoResult = {
   repo: string;
   installationId: string;
   appSourceId?: number;
+  sourceRef?: string;
 };
 
 export type LaunchStatus = DeploymentStatus;
@@ -83,6 +92,7 @@ export type LaunchSyncInstalledResult = {
   repo: string;
   installationId: string;
   appSourceId?: number;
+  sourceRef?: string;
 };
 
 export type LaunchRedeployResult = {

--- a/apps/portal/src/features/launch/dashboard-lifecycle.test.ts
+++ b/apps/portal/src/features/launch/dashboard-lifecycle.test.ts
@@ -12,6 +12,8 @@ function source(patch: Partial<UserSource>): UserSource {
     installationId: 123,
     repositoryId: 456,
     repositoryLink: "https://github.com/alice/bot",
+    sourceRef: null,
+    commitHash: null,
     githubAccount: "alice",
     githubUserId: "42",
     boundPlatformId: 1,

--- a/apps/portal/src/features/launch/url-context.test.ts
+++ b/apps/portal/src/features/launch/url-context.test.ts
@@ -14,6 +14,8 @@ function source(
     installationId,
     repositoryId: null,
     repositoryLink,
+    sourceRef: null,
+    commitHash: null,
     githubAccount: null,
     githubUserId: null,
     boundPlatformId: null,

--- a/apps/portal/src/server/bff/launch/config.test.ts
+++ b/apps/portal/src/server/bff/launch/config.test.ts
@@ -10,18 +10,21 @@ describe("launchConfig", () => {
   it("uses community launch defaults", () => {
     const config = launchConfig();
     expect(config.platform).toBe("community");
-    expect(config.aomiTomlPaths).toEqual(["aomi.toml"]);
+    expect(config.templateRepo).toBe("aomi-labs/playground-example");
+    expect(config.createdRepoPrivate).toBe(false);
     expect(config.targetTags).toEqual([]);
   });
 
   it("honors APP_DEPLOY env overrides and comma-separated values", () => {
     vi.stubEnv("APP_DEPLOY_PLATFORM", "partners");
-    vi.stubEnv("APP_DEPLOY_AOMI_TOML_PATHS", "aomi.toml, agents/aomi.toml");
+    vi.stubEnv("APP_DEPLOY_TEMPLATE_REPO", "acme/template");
+    vi.stubEnv("APP_DEPLOY_CREATED_REPO_PRIVATE", "true");
     vi.stubEnv("APP_DEPLOY_TARGET_TAGS", "staging, launch");
 
     const config = launchConfig();
     expect(config.platform).toBe("partners");
-    expect(config.aomiTomlPaths).toEqual(["aomi.toml", "agents/aomi.toml"]);
+    expect(config.templateRepo).toBe("acme/template");
+    expect(config.createdRepoPrivate).toBe(true);
     expect(config.targetTags).toEqual(["staging", "launch"]);
   });
 });

--- a/apps/portal/src/server/bff/launch/config.ts
+++ b/apps/portal/src/server/bff/launch/config.ts
@@ -1,56 +1,40 @@
 import "server-only";
 
-import { DeployError, type SourceRef } from "@aomi-labs/deploy";
 import { resolveDeployPlatform } from "@portal/lib/deploy-platform";
 
-const TEMPLATE_REPO = "aomi-labs/playground-example";
-const CREATED_REPO_PRIVATE = false;
-const DEFAULT_AOMI_TOML_PATHS = ["aomi.toml"];
-const SOURCE_REF_ENV = "APP_DEPLOY_SOURCE_REF";
-const SOURCE_COMMIT_ENV = "APP_DEPLOY_SOURCE_COMMIT";
+const DEFAULT_TEMPLATE_REPO = "aomi-labs/playground-example";
 
 export type LaunchConfig = {
   platform: string;
   templateRepo: string;
   createdRepoPrivate: boolean;
-  aomiTomlPaths: string[];
   targetTags: string[];
 };
 
-function envValue(name: string): string | undefined {
-  return process.env[name]?.trim() || undefined;
+function envString(name: string, fallback: string): string {
+  return process.env[name]?.trim() || fallback;
 }
 
-function commaList(value: string | undefined, fallback: string[] = []): string[] {
-  const parsed = (value ?? "")
+function envBoolean(name: string, fallback: boolean): boolean {
+  const value = process.env[name]?.trim().toLowerCase();
+  if (!value) return fallback;
+  return value === "1" || value === "true" || value === "yes";
+}
+
+function envList(name: string): string[] {
+  return (process.env[name] ?? "")
     .split(",")
-    .map((part) => part.trim())
+    .map((value) => value.trim())
     .filter(Boolean);
-  return parsed.length > 0 ? parsed : fallback;
 }
 
 export function launchConfig(): LaunchConfig {
   return {
-    platform: envValue("APP_DEPLOY_PLATFORM") ?? resolveDeployPlatform(),
-    templateRepo: TEMPLATE_REPO,
-    createdRepoPrivate: CREATED_REPO_PRIVATE,
-    aomiTomlPaths: commaList(
-      envValue("APP_DEPLOY_AOMI_TOML_PATHS"),
-      DEFAULT_AOMI_TOML_PATHS,
-    ),
-    targetTags: commaList(envValue("APP_DEPLOY_TARGET_TAGS")),
+    platform: process.env.APP_DEPLOY_PLATFORM?.trim() || resolveDeployPlatform(),
+    templateRepo:
+      process.env.APP_DEPLOY_TEMPLATE_REPO?.trim() ||
+      envString("NEXT_PUBLIC_APP_DEPLOY_TEMPLATE_REPO", DEFAULT_TEMPLATE_REPO),
+    createdRepoPrivate: envBoolean("APP_DEPLOY_CREATED_REPO_PRIVATE", false),
+    targetTags: envList("APP_DEPLOY_TARGET_TAGS"),
   };
-}
-
-export function launchDeploySourceRef(): SourceRef {
-  const value =
-    process.env[SOURCE_REF_ENV]?.trim() ||
-    process.env[SOURCE_COMMIT_ENV]?.trim();
-  if (!value) {
-    throw new DeployError(
-      "INVALID_REQUEST",
-      `${SOURCE_REF_ENV} or ${SOURCE_COMMIT_ENV} must be set to an immutable source commit SHA`,
-    );
-  }
-  return value;
 }

--- a/apps/portal/src/server/bff/launch/routes.test.ts
+++ b/apps/portal/src/server/bff/launch/routes.test.ts
@@ -33,10 +33,6 @@ function writeReq(body: unknown) {
 }
 
 describe("launchDeployRoute", () => {
-  beforeEach(() => {
-    vi.stubEnv("APP_DEPLOY_SOURCE_REF", "abc1234def5678");
-  });
-
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
@@ -59,7 +55,10 @@ describe("launchDeployRoute", () => {
         origin: "http://localhost:3000",
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ appSourceId: 123 }),
+      body: JSON.stringify({
+        appSourceId: 123,
+        sourceRef: "abc1234def5678",
+      }),
     });
 
     const res = await POST(req);
@@ -80,6 +79,7 @@ describe("launchDeployRoute", () => {
             id: 123,
             installation_id: 555,
             repository_link: "alice/bot",
+            source_ref: "abc1234def5678",
           },
         }),
       )
@@ -123,7 +123,7 @@ describe("launchDeployRoute", () => {
       "http://127.0.0.1:8080/api/platforms/community/deploy",
       expect.objectContaining({
         method: "POST",
-        body: expect.stringContaining('"app_source_id":123'),
+        body: expect.stringContaining('"source_ref":"abc1234def5678"'),
       }),
     );
   });
@@ -172,6 +172,7 @@ describe("launchDeployRoute", () => {
       },
       body: JSON.stringify({
         appSourceId: 777,
+        sourceRef: "abc1234def5678",
         installationId: "555",
         repo: "alice/bot",
       }),
@@ -190,12 +191,12 @@ describe("launchDeployRoute", () => {
       "http://127.0.0.1:8080/api/platforms/community/deploy",
       expect.objectContaining({
         method: "POST",
-        body: expect.stringContaining('"app_source_id":777'),
+        body: expect.stringContaining('"source_ref":"abc1234def5678"'),
       }),
     );
   });
 
-  it("rejects deploy requests when no immutable source commit is configured", async () => {
+  it("rejects deploy requests when no source commit is supplied or resolved", async () => {
     vi.unstubAllEnvs();
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
@@ -214,7 +215,7 @@ describe("launchDeployRoute", () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain("APP_DEPLOY_SOURCE_REF");
+    expect(body.error).toContain("missing source commit");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -267,7 +268,10 @@ describe("launchDeployRoute", () => {
         origin: "http://localhost:3000",
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ appSourceId: 123 }),
+      body: JSON.stringify({
+        appSourceId: 123,
+        sourceRef: "abc1234def5678",
+      }),
     });
 
     const res = await POST(req);
@@ -371,10 +375,6 @@ describe("redeployLaunchRoute", () => {
 });
 
 describe("launchStatusRoute", () => {
-  beforeEach(() => {
-    vi.stubEnv("APP_DEPLOY_SOURCE_REF", "abc1234def5678");
-  });
-
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.restoreAllMocks();

--- a/apps/portal/src/server/bff/launch/routes.ts
+++ b/apps/portal/src/server/bff/launch/routes.ts
@@ -4,7 +4,7 @@ import { randomBytes } from "crypto";
 import { NextResponse } from "next/server";
 import { deploymentClient } from "@portal/server/bff/backend";
 import { BackendError, launchErrorResponse } from "./errors";
-import { launchConfig, launchDeploySourceRef } from "./config";
+import { launchConfig } from "./config";
 import { appNamesFromDeployment, releaseTagsFromDeployment } from "./mappers";
 import { checkRateLimit, getClientIp } from "@portal/lib/rate-limit";
 import { validateOrigin } from "@portal/lib/csrf";
@@ -46,6 +46,19 @@ function isValidAppSourceId(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
 }
 
+function sourceRef(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const clean = value.trim().toLowerCase();
+  return /^[0-9a-f]{7,40}$/.test(clean) ? clean : null;
+}
+
+function sourceRefFromSource(source: {
+  sourceRef?: string | null;
+  commitHash?: string | null;
+}): string | null {
+  return sourceRef(source.sourceRef) ?? sourceRef(source.commitHash);
+}
+
 export function launchDeployRoute(preflight: boolean) {
   return async function POST(req: Request): Promise<NextResponse> {
     const blocked = checkWrite(req);
@@ -72,12 +85,10 @@ export function launchDeployRoute(preflight: boolean) {
       const config = launchConfig();
       const client = await deploymentClient();
 
-      // A deploy always commits against a stable source row id. Resolving (or
-      // minting) that row from a repo is a separate concern: it happens here
-      // only for a preflight — the preview that materializes the row — or via the
-      // dedicated /sync-installed route. The committing deploy never silently
-      // creates or re-resolves a source by repo.
+      // Deploy uses a stable source row plus an immutable source commit. When
+      // the portal only has a repo, sync-installed resolves both from GitHub.
       let appSourceId: number;
+      let deploySourceRef = sourceRef(body.sourceRef);
       if (isValidAppSourceId(body.appSourceId)) {
         appSourceId = body.appSourceId;
       } else if (preflight && isValidRepo(body.repo)) {
@@ -89,6 +100,7 @@ export function launchDeployRoute(preflight: boolean) {
           throw new Error("backend did not return a valid app source id");
         }
         appSourceId = synced.id;
+        deploySourceRef = sourceRefFromSource(synced);
       } else {
         return NextResponse.json(
           {
@@ -100,14 +112,39 @@ export function launchDeployRoute(preflight: boolean) {
         );
       }
 
-      const { deployment } = await client.deploy({
+      if (!deploySourceRef && isValidRepo(body.repo)) {
+        const synced = await client.syncSource({
+          platform: config.platform,
+          repo: body.repo as string,
+        });
+        if (synced.id !== appSourceId) {
+          return NextResponse.json(
+            { error: "repo does not match `appSourceId`" },
+            { status: 409 },
+          );
+        }
+        deploySourceRef = sourceRefFromSource(synced);
+      }
+      if (!deploySourceRef) {
+        return NextResponse.json(
+          {
+            error:
+              "missing source commit for deploy; sync the source repo and retry",
+          },
+          { status: 400 },
+        );
+      }
+
+      const deployInput = {
         platform: config.platform,
         appSourceId,
-        sourceRef: launchDeploySourceRef(),
-        aomiTomlPaths: config.aomiTomlPaths,
-        preflight,
+        sourceRef: deploySourceRef,
+        aomiTomlPaths: [],
         actor: typeof body.actor === "string" ? body.actor : undefined,
-      });
+      };
+      const { deployment } = preflight
+        ? await client.preflight(deployInput)
+        : await client.deploy(deployInput);
       return NextResponse.json(
         {
           ok: true,
@@ -118,6 +155,7 @@ export function launchDeployRoute(preflight: boolean) {
             ? String(deployment.source.installationId)
             : undefined,
           appSourceId,
+          sourceRef: deploySourceRef,
           deployment,
           releaseTags: releaseTagsFromDeployment(deployment),
           apps: appNamesFromDeployment(deployment),
@@ -166,6 +204,7 @@ export async function createLaunchRepoRoute(req: Request) {
       repo: source.repositoryLink,
       installationId: String(source.installationId),
       appSourceId: source.id,
+      sourceRef: source.sourceRef ?? source.commitHash ?? undefined,
       source,
     });
   } catch (err) {
@@ -469,6 +508,7 @@ export async function syncInstalledLaunchRoute(req: Request) {
       repo: source.repositoryLink ?? repo,
       installationId: String(source.installationId),
       appSourceId: source.id,
+      sourceRef: source.sourceRef ?? source.commitHash ?? undefined,
       source,
     });
   } catch (err) {

--- a/packages/client/dist/cli.js
+++ b/packages/client/dist/cli.js
@@ -8564,7 +8564,7 @@ var deploy_exports = {};
 __export(deploy_exports, {
   deployCommand: () => deployCommand
 });
-import { execSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
 function str4(value) {
   return typeof value === "string" && value.trim() ? value.trim() : void 0;
 }
@@ -8584,6 +8584,22 @@ function currentBranch() {
     throw new DeployCliError(
       "NOT_A_GIT_REPO",
       "Run this from inside a git repository"
+    );
+  }
+}
+function resolveGitCommit(ref) {
+  try {
+    const commit = execFileSync("git", ["rev-parse", "--verify", `${ref}^{commit}`], {
+      encoding: "utf-8"
+    }).trim();
+    if (!/^[0-9a-f]{7,40}$/i.test(commit)) {
+      throw new Error(`unexpected git commit hash: ${commit}`);
+    }
+    return commit.toLowerCase();
+  } catch (e) {
+    throw new DeployCliError(
+      "VALIDATION_ERROR",
+      `Could not resolve \`${ref}\` to a git commit SHA.`
     );
   }
 }
@@ -8662,7 +8678,7 @@ async function deviceAuthFlow(backendUrl, platform) {
   );
 }
 async function deployCommand(args) {
-  var _a3, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n;
+  var _a3, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o;
   const backendUrl = ((_b = (_a3 = str4(args["backend-url"])) != null ? _a3 : process.env.AOMI_BACKEND_URL) != null ? _b : "https://api.aomi.dev").replace(/\/+$/, "");
   const platform = (_d = (_c = str4(args.platform)) != null ? _c : process.env.AOMI_DEPLOY_PLATFORM) != null ? _d : "community";
   const activationToken = (_f = (_e = str4(args["activation-token"])) != null ? _e : process.env.AOMI_DEPLOY_TOKEN) != null ? _f : (await deviceAuthFlow(backendUrl, platform)).token;
@@ -8684,20 +8700,20 @@ async function deployCommand(args) {
       "--commit and --branch are mutually exclusive. Provide one or neither."
     );
   }
-  const sourceRef = commit ? { kind: "commit", value: commit } : { kind: "branch", value: branch != null ? branch : currentBranch() };
+  const selectedRef = (_h = commit != null ? commit : branch) != null ? _h : currentBranch();
+  const sourceRef = resolveGitCommit(selectedRef);
   if (!commit && !branch) {
     checkGitRemote();
   }
-  const aomiTomlPaths = ((_h = str4(args["aomi-toml-paths"])) != null ? _h : "aomi.toml").split(",").map((p) => p.trim()).filter(Boolean);
+  const aomiTomlPaths = ((_i = str4(args["aomi-toml-paths"])) != null ? _i : "").split(",").map((p) => p.trim()).filter(Boolean);
   const preflight = args["preflight"] === true;
   console.log(` Deploying to ${backendUrl} (platform: ${platform})`);
   console.log(`   app source id: ${appSourceId}`);
-  if (sourceRef.kind === "commit") {
-    console.log(`   commit:        ${sourceRef.value}`);
-  } else {
-    console.log(`   branch:        ${sourceRef.value}`);
-  }
-  console.log(`   aomi.toml:     ${aomiTomlPaths.join(", ")}`);
+  if (branch) console.log(`   branch:        ${branch}`);
+  console.log(`   commit:        ${sourceRef}`);
+  console.log(
+    `   aomi.toml:     ${aomiTomlPaths.length ? aomiTomlPaths.join(", ") : "discover"}`
+  );
   if (preflight) console.log("   preflight:      yes");
   const url = `${backendUrl}/api/platforms/${encodeURIComponent(platform)}/deploy`;
   const body = {
@@ -8753,8 +8769,8 @@ async function deployCommand(args) {
     console.log(`   ${JSON.stringify(result, null, 2)}`);
     return;
   }
-  console.log(` Deployment created: ${(_i = deployment == null ? void 0 : deployment.id) != null ? _i : "unknown"}`);
-  console.log(`   status:  ${(_j = deployment == null ? void 0 : deployment.status) != null ? _j : "unknown"}`);
+  console.log(` Deployment created: ${(_j = deployment == null ? void 0 : deployment.id) != null ? _j : "unknown"}`);
+  console.log(`   status:  ${(_k = deployment == null ? void 0 : deployment.status) != null ? _k : "unknown"}`);
   if (sourceInfo == null ? void 0 : sourceInfo.repository_link) {
     console.log(`   source:  ${sourceInfo.repository_link}`);
   }
@@ -8769,8 +8785,8 @@ async function deployCommand(args) {
   if (platformInfo == null ? void 0 : platformInfo.apps) {
     const appsArr = platformInfo.apps;
     for (const app of appsArr) {
-      const name = String((_k = app.name) != null ? _k : "?");
-      const tag = String((_m = (_l = app.release_tag) != null ? _l : app.releaseTag) != null ? _m : "");
+      const name = String((_l = app.name) != null ? _l : "?");
+      const tag = String((_n = (_m = app.release_tag) != null ? _m : app.releaseTag) != null ? _n : "");
       apps.push(name);
       if (tag) releaseTags.push(tag);
       console.log(`   app:     ${name}${tag ? ` (${tag})` : ""}`);
@@ -8779,7 +8795,7 @@ async function deployCommand(args) {
   if (platformInfo == null ? void 0 : platformInfo.commit_hash) {
     console.log(`   commit:  ${platformInfo.commit_hash}`);
   }
-  const deploymentId = String((_n = deployment == null ? void 0 : deployment.id) != null ? _n : "");
+  const deploymentId = String((_o = deployment == null ? void 0 : deployment.id) != null ? _o : "");
   if (deploymentId) {
     await writeDeploymentState({
       deploymentId,
@@ -9674,7 +9690,7 @@ var deployDef = defineCommand13({
     },
     "aomi-toml-paths": {
       type: "string",
-      description: "Comma-separated paths to aomi.toml files (default: aomi.toml)"
+      description: "Comma-separated paths to aomi.toml files (default: discover)"
     },
     platform: {
       type: "string",

--- a/packages/client/src/cli/commands/defs/deploy.ts
+++ b/packages/client/src/cli/commands/defs/deploy.ts
@@ -38,7 +38,7 @@ export const deployDef = defineCommand({
     "aomi-toml-paths": {
       type: "string",
       description:
-        "Comma-separated paths to aomi.toml files (default: aomi.toml)",
+        "Comma-separated paths to aomi.toml files (default: discover)",
     },
     platform: {
       type: "string",

--- a/packages/client/src/cli/commands/deploy.ts
+++ b/packages/client/src/cli/commands/deploy.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
 import { DeployCliError } from "../errors";
 import { writeDeploymentState } from "../../lib/deployment-state";
 
@@ -25,6 +25,23 @@ function currentBranch(): string {
     throw new DeployCliError(
       "NOT_A_GIT_REPO",
       "Run this from inside a git repository",
+    );
+  }
+}
+
+function resolveGitCommit(ref: string): string {
+  try {
+    const commit = execFileSync("git", ["rev-parse", "--verify", `${ref}^{commit}`], {
+      encoding: "utf-8",
+    }).trim();
+    if (!/^[0-9a-f]{7,40}$/i.test(commit)) {
+      throw new Error(`unexpected git commit hash: ${commit}`);
+    }
+    return commit.toLowerCase();
+  } catch {
+    throw new DeployCliError(
+      "VALIDATION_ERROR",
+      `Could not resolve \`${ref}\` to a git commit SHA.`,
     );
   }
 }
@@ -173,17 +190,14 @@ export async function deployCommand(args: DeployArgs): Promise<void> {
     );
   }
 
-  const sourceRef = commit
-    ? { kind: "commit", value: commit }
-    : { kind: "branch", value: branch ?? currentBranch() };
+  const selectedRef = commit ?? branch ?? currentBranch();
+  const sourceRef = resolveGitCommit(selectedRef);
 
   if (!commit && !branch) {
     checkGitRemote();
   }
 
-  const aomiTomlPaths = (
-    str(args["aomi-toml-paths"]) ?? "aomi.toml"
-  )
+  const aomiTomlPaths = (str(args["aomi-toml-paths"]) ?? "")
     .split(",")
     .map((p) => p.trim())
     .filter(Boolean);
@@ -191,12 +205,11 @@ export async function deployCommand(args: DeployArgs): Promise<void> {
 
   console.log(` Deploying to ${backendUrl} (platform: ${platform})`);
   console.log(`   app source id: ${appSourceId}`);
-  if (sourceRef.kind === "commit") {
-    console.log(`   commit:        ${sourceRef.value}`);
-  } else {
-    console.log(`   branch:        ${sourceRef.value}`);
-  }
-  console.log(`   aomi.toml:     ${aomiTomlPaths.join(", ")}`);
+  if (branch) console.log(`   branch:        ${branch}`);
+  console.log(`   commit:        ${sourceRef}`);
+  console.log(
+    `   aomi.toml:     ${aomiTomlPaths.length ? aomiTomlPaths.join(", ") : "discover"}`,
+  );
   if (preflight) console.log("   preflight:      yes");
 
   const url = `${backendUrl}/api/platforms/${encodeURIComponent(platform)}/deploy`;

--- a/packages/client/test/client.unit.test.ts
+++ b/packages/client/test/client.unit.test.ts
@@ -10,7 +10,7 @@ describe("AomiClient route manifest", () => {
         `${endpoint.method} ${endpoint.path} [${endpoint.auth.join(", ")}]`,
     );
 
-    expect(routeKeys).toHaveLength(77);
+    expect(routeKeys).toHaveLength(78);
     expect(new Set(routeKeys).size).toBe(routeKeys.length);
     expect(routeKeys).toContain("GET /api/session/apps [session]");
     expect(routeKeys).toContain("POST /api/platforms/:name/deploy [activation]");

--- a/packages/client/test/fixtures/backend-openapi.json
+++ b/packages/client/test/fixtures/backend-openapi.json
@@ -1003,6 +1003,23 @@
         ]
       }
     },
+    "/api/integrations/github-app/user/sources/{id}/latest-deployment": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "serviceBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
     "/api/integrations/github-app/platforms/{name}/sources/create-from-template": {
       "post": {
         "responses": {

--- a/packages/client/test/generated/backend-routes.ts
+++ b/packages/client/test/generated/backend-routes.ts
@@ -135,6 +135,11 @@ export const AOMI_BACKEND_ENDPOINTS = [
   },
   {
     method: "GET",
+    path: "/api/integrations/github-app/user/sources/:id/latest-deployment",
+    auth: ["service"],
+  },
+  {
+    method: "GET",
     path: "/api/openapi.json",
     auth: [],
   },

--- a/packages/deploy/README.md
+++ b/packages/deploy/README.md
@@ -5,13 +5,24 @@ BFF / server use only** (holds the activation bearer token).
 
 ## API
 
+### `preflight()`
+
+Calls `POST /api/platforms/:platform/deploy` with `app_source_id`, `source_ref`,
+optional `aomi_toml_paths`, and `preflight: true`. Returns the deployment
+record without opening or updating the platform PR. Use this to render
+`deployment.json` before the user applies.
+
 ### `deploy()`
 
 Calls `POST /api/platforms/:platform/deploy` with `app_source_id`, `source_ref`,
-`aomi_toml_paths`, and optional `preflight`.
+and optional `aomi_toml_paths`. This is the apply step: it writes the platform
+deployment branch/PR when needed and starts the CI path.
 
 `sourceRef` must be the immutable git commit SHA to deploy. Resolve branches or
-tags before calling the client; the backend no longer accepts mutable refs.
+tags before calling the client; the backend does not accept mutable refs.
+
+`aomiTomlPaths` may be omitted to let the backend discover every `aomi.toml` in
+the source commit.
 
 ### `activate()`
 
@@ -129,9 +140,10 @@ interface DeployRequest {
   appSourceId: number;
   /** Immutable git commit SHA. Branch names are rejected by the backend. */
   sourceRef: string;
-  aomiTomlPaths: string[];
-  preflight?: boolean;
+  aomiTomlPaths?: string[];
 }
+
+type PreflightRequest = DeployRequest;
 
 interface ActivateRequest {
   platform: string;
@@ -181,12 +193,17 @@ const dc = new DeploymentClient({
   },
 });
 
+const preview = await dc.preflight({
+  platform: "community",
+  appSourceId: 42,
+  sourceRef: process.env.AOMI_SOURCE_REF!,
+});
+console.log(JSON.stringify(preview.deployment, null, 2));
+
 const { deployment } = await dc.deploy({
   platform: "community",
   appSourceId: 42,
   sourceRef: process.env.AOMI_SOURCE_REF!,
-  aomiTomlPaths: ["aomi.toml"],
-  preflight: true,
 });
 
 await dc.activate({

--- a/packages/deploy/scripts/e2e-deploy.ts
+++ b/packages/deploy/scripts/e2e-deploy.ts
@@ -21,7 +21,7 @@ const backendUrl = requiredEnv("AOMI_BACKEND_URL");
 const activationToken = requiredEnv("AOMI_APP_ACTIVATION_TOKEN");
 const platform = requiredEnv("AOMI_PLATFORM");
 const appSourceId = Number.parseInt(requiredEnv("AOMI_APP_SOURCE_ID"), 10);
-const aomiTomlPaths = (process.env.AOMI_TOML_PATHS ?? "aomi.toml")
+const aomiTomlPaths = (process.env.AOMI_TOML_PATHS ?? "")
   .split(",")
   .map((path) => path.trim())
   .filter(Boolean);
@@ -43,13 +43,17 @@ const dc = new DeploymentClient({
   onAudit: (event) => console.log("audit", JSON.stringify(event)),
 });
 
-const deploy = await dc.deploy({
+const deployInput = {
   platform,
   appSourceId,
   sourceRef,
   aomiTomlPaths,
-  preflight: process.env.AOMI_ACTIVATE !== "1",
-});
+};
+
+const deploy =
+  process.env.AOMI_ACTIVATE === "1"
+    ? await dc.deploy(deployInput)
+    : await dc.preflight(deployInput);
 
 console.log(JSON.stringify(deploy, null, 2));
 

--- a/packages/deploy/src/client.ts
+++ b/packages/deploy/src/client.ts
@@ -22,6 +22,7 @@ import type {
   MintTokenInput,
   MintedToken,
   PlatformApp,
+  PreflightInput,
   ProgressModel,
   RevokeTokenInput,
   ScaffoldInput,
@@ -30,9 +31,6 @@ import type {
   TokenRecord,
   WatchDeploymentOptions,
 } from "./types";
-
-/** Portal one-shot template repo; the default source for `scaffold()`. */
-const DEFAULT_TEMPLATE_REPO = "aomi-labs/playground-example";
 
 /**
  * Server-side client to the Aomi platform deploy backend. It is a typed HTTP
@@ -82,9 +80,35 @@ export class DeploymentClient {
     return found;
   }
 
+  async preflight(input: PreflightInput): Promise<DeployResult> {
+    const platform = cleanPlatform(input.platform);
+    const body = deployRequest(input, true);
+    const result = await this.post<DeployResult>(
+      `/api/platforms/${encodeURIComponent(platform)}/deploy`,
+      body,
+      "preflight",
+      this.resolveBearer(),
+    );
+    const cameled = camelDeployResult(result);
+    if (!cameled.ok) {
+      throw new DeployError(
+        "BACKEND",
+        `preflight rejected by backend (deployment ${cameled.deployment.id})`,
+      );
+    }
+    await this.audit({
+      action: "preflight",
+      platform,
+      appSourceId: input.appSourceId,
+      actor: input.actor,
+      ts: Date.now(),
+    });
+    return cameled;
+  }
+
   async deploy(input: DeployInput): Promise<DeployResult> {
     const platform = cleanPlatform(input.platform);
-    const body = deployRequest(input);
+    const body = deployRequest(input, false);
     const result = await this.post<DeployResult>(
       `/api/platforms/${encodeURIComponent(platform)}/deploy`,
       body,
@@ -391,7 +415,7 @@ export class DeploymentClient {
       );
     }
     const repoName = required(input.repoName, "repoName");
-    const templateRepo = input.templateRepo?.trim() || DEFAULT_TEMPLATE_REPO;
+    const templateRepo = required(input.templateRepo, "templateRepo");
     const bearer = this.resolveBearer(input.bearer);
     const raw = await this.post<{ ok?: boolean; source?: unknown }>(
       `/api/integrations/github-app/platforms/${encodeURIComponent(platform)}/sources/create-from-template`,
@@ -671,7 +695,10 @@ export function assertServerOnly(): void {
   }
 }
 
-function deployRequest(input: DeployInput): Record<string, unknown> {
+function deployRequest(
+  input: DeployInput | PreflightInput,
+  preflight: boolean,
+): Record<string, unknown> {
   const appSourceId = Number(input.appSourceId);
   if (!Number.isSafeInteger(appSourceId) || appSourceId <= 0) {
     throw new DeployError(
@@ -679,12 +706,16 @@ function deployRequest(input: DeployInput): Record<string, unknown> {
       "deploy requires a positive appSourceId",
     );
   }
-  const aomiTomlPaths = cleanStringList(input.aomiTomlPaths, "aomiTomlPaths");
+  const aomiTomlPaths = cleanStringList(
+    input.aomiTomlPaths ?? [],
+    "aomiTomlPaths",
+    true,
+  );
   return {
     app_source_id: appSourceId,
     source_ref: sourceRef(input.sourceRef),
     aomi_toml_paths: aomiTomlPaths,
-    ...(input.preflight ? { preflight: true } : {}),
+    ...(preflight ? { preflight: true } : {}),
   };
 }
 
@@ -910,6 +941,8 @@ function camelAppSource(raw: unknown): AppSource {
     installationId: Number(s.installation_id),
     repositoryId: s.repository_id ?? null,
     repositoryLink: s.repository_link ?? null,
+    sourceRef: s.source_ref ?? null,
+    commitHash: s.commit_hash ?? s.source_ref ?? null,
     githubAccount: s.github_account ?? null,
     githubUserId: s.github_user_id ?? null,
     boundPlatformId: s.bound_platform_id ?? null,

--- a/packages/deploy/src/index.ts
+++ b/packages/deploy/src/index.ts
@@ -25,6 +25,7 @@ export type {
   DeploymentClientOptions,
   SourceRef,
   DeployInput,
+  PreflightInput,
   DeployStatus,
   CiStatus,
   DeployResult,

--- a/packages/deploy/src/types.ts
+++ b/packages/deploy/src/types.ts
@@ -22,6 +22,7 @@ export interface AomiConfig {
 export interface AuditEvent {
   action:
     | "request"
+    | "preflight"
     | "deploy"
     | "activate"
     | "status"
@@ -63,11 +64,12 @@ export interface DeployInput {
   /** Connected GitHub App source row selected for this deploy. */
   appSourceId: number;
   sourceRef: SourceRef;
-  aomiTomlPaths: string[];
-  /** Preview the deployment plan; may materialize backend source metadata but opens no PR. */
-  preflight?: boolean;
+  /** Optional explicit manifests. Empty/omitted lets the backend discover every aomi.toml. */
+  aomiTomlPaths?: string[];
   actor?: string;
 }
+
+export interface PreflightInput extends DeployInput {}
 
 export type DeployStatus =
   | "preflight"
@@ -316,6 +318,8 @@ export interface AppSource {
   installationId: number;
   repositoryId: number | null;
   repositoryLink: string | null;
+  sourceRef: SourceRef | null;
+  commitHash: string | null;
   githubAccount: string | null;
   githubUserId: number | null;
   boundPlatformId: number | null;
@@ -336,8 +340,8 @@ export interface ScaffoldInput extends BearerOverride {
   installationId: number;
   /** New repo name created in the installation's account from the template. */
   repoName: string;
-  /** Template `owner/repo`. Defaults to the portal one-shot template. */
-  templateRepo?: string;
+  /** Template `owner/repo` to copy for the one-shot flow. */
+  templateRepo: string;
   /** Create the new repo private. Defaults to false. */
   private?: boolean;
 }

--- a/packages/deploy/test/bootstrap.test.ts
+++ b/packages/deploy/test/bootstrap.test.ts
@@ -162,6 +162,8 @@ describe("DeploymentClient bootstrap — sources", () => {
       installation_id: 555,
       repository_id: 111,
       repository_link: "https://github.com/alice/alice-bot",
+      source_ref: "abc1234def5678",
+      commit_hash: "abc1234def5678",
       github_account: "alice",
       github_user_id: 222,
       bound_platform_id: 3,
@@ -186,6 +188,8 @@ describe("DeploymentClient bootstrap — sources", () => {
       installationId: 555,
       repositoryId: 111,
       repositoryLink: "https://github.com/alice/alice-bot",
+      sourceRef: "abc1234def5678",
+      commitHash: "abc1234def5678",
       githubAccount: "alice",
       githubUserId: 222,
       boundPlatformId: 3,
@@ -196,12 +200,13 @@ describe("DeploymentClient bootstrap — sources", () => {
     });
   });
 
-  it("scaffolds from the default template and maps the source", async () => {
+  it("scaffolds from the caller-provided template and maps the source", async () => {
     jsonOnce(fetchMock, sourceBody);
     const src = await client({ activationToken: "plat-tok" }).scaffold({
       platform: "playground",
       installationId: 555,
       repoName: "my-bot",
+      templateRepo: "alice/template-bot",
     });
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe(
@@ -209,7 +214,7 @@ describe("DeploymentClient bootstrap — sources", () => {
     );
     expect(JSON.parse((init as RequestInit).body as string)).toEqual({
       installation_id: 555,
-      template_repo: "aomi-labs/playground-example",
+      template_repo: "alice/template-bot",
       repo_name: "my-bot",
       private: false,
     });

--- a/packages/deploy/test/client.test.ts
+++ b/packages/deploy/test/client.test.ts
@@ -19,7 +19,7 @@ function client(onAudit?: (event: AuditEvent) => void) {
   });
 }
 
-describe("DeploymentClient.deploy", () => {
+describe("DeploymentClient deploy/preflight", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
@@ -73,14 +73,13 @@ describe("DeploymentClient.deploy", () => {
 
   afterEach(() => vi.unstubAllGlobals());
 
-  it("POSTs the repo-scoped deploy request and maps the response to camelCase", async () => {
+  it("POSTs a preflight request and maps the deployment.json response to camelCase", async () => {
     const audits: AuditEvent[] = [];
-    const result = await client((event) => audits.push(event)).deploy({
+    const result = await client((event) => audits.push(event)).preflight({
       platform: "community",
       appSourceId: 42,
       sourceRef: "ABC1234DEF5678",
       aomiTomlPaths: ["aomi.toml"],
-      preflight: true,
       actor: "alice",
     });
 
@@ -110,12 +109,28 @@ describe("DeploymentClient.deploy", () => {
     });
     expect(audits).toEqual([
       expect.objectContaining({
-        action: "deploy",
+        action: "preflight",
         platform: "community",
         appSourceId: 42,
         actor: "alice",
       }),
     ]);
+  });
+
+  it("POSTs an apply deploy request without the preflight flag", async () => {
+    const result = await client().deploy({
+      platform: "community",
+      appSourceId: 42,
+      sourceRef: "abc1234def5678",
+    });
+
+    expect(result.deployment.id).toBe("dep_123_abc1234");
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      app_source_id: 42,
+      source_ref: "abc1234def5678",
+      aomi_toml_paths: [],
+    });
   });
 
   it("rejects invalid deploy input before calling the backend", async () => {


### PR DESCRIPTION
## Summary
- split deploy package preflight/apply calls while keeping the backend wire contract explicit
- remove portal hardcoded source-ref env handling; resolve source commit from synced app source state
- let deploy requests omit aomi.toml paths so backend discovery owns manifest selection
- keep launch UI flow/tests aligned with preflight, deploy, and restart modes

## Validation
- pnpm exec vitest run packages/deploy/test/client.test.ts packages/deploy/test/bootstrap.test.ts
- pnpm --filter @aomi-labs/deploy build
- pnpm --filter portal type-check
- (apps/portal) pnpm exec vitest run --config vitest.config.ts src/server/bff/launch/routes.test.ts
- (apps/portal) pnpm exec vitest run --config vitest.config.ts src/features/launch/dashboard-lifecycle.test.ts src/features/launch/url-context.test.ts src/features/launch/components/bootstrap-wizard.test.tsx src/features/launch/components/oneshot-wizard.test.tsx src/features/launch/components/deploy-step.test.tsx
- pnpm run lint
- rg stale source-ref contract scan over apps packages