### PR TITLE
[codex] Include platform apps in picker

### DIFF
--- a/apps/portal/src/app/api/[...slug]/route.test.ts
+++ b/apps/portal/src/app/api/[...slug]/route.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment node
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GET } from "./route";
+
+const listApps = vi.fn();
+
+vi.mock("@aomi-labs/account", () => ({
+  mintAccountBearer: vi.fn(),
+}));
+
+vi.mock("@portal/server/cookies/session", () => ({
+  getSessionedCanonicalId: vi.fn(async () => null),
+}));
+
+vi.mock("@portal/server/backend-url", () => ({
+  configuredBackendUrl: () => "https://api-staging.aomi.dev",
+}));
+
+vi.mock("@portal/server/bff/backend", () => ({
+  deploymentClient: vi.fn(async () => ({ listApps })),
+}));
+
+vi.mock("@portal/server/bff/launch/config", () => ({
+  launchConfig: () => ({ platform: "somm.finance" }),
+}));
+
+function sessionAppsRequest() {
+  return [
+    new NextRequest("https://chat-staging.aomi.dev/api/session/apps"),
+    { params: Promise.resolve({ slug: ["session", "apps"] }) },
+  ] as const;
+}
+
+describe("portal API proxy", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    listApps.mockReset();
+  });
+
+  it("adds public active loaded platform apps to the session app catalog", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json([{ name: "default" }, { name: "limitless" }]),
+      ),
+    );
+    listApps.mockResolvedValueOnce([
+      {
+        id: 1,
+        name: "somm-agent",
+        isPublic: true,
+        isActive: true,
+        loaded: true,
+      },
+      {
+        id: 2,
+        name: "private-agent",
+        isPublic: false,
+        isActive: true,
+        loaded: true,
+      },
+      {
+        id: 3,
+        name: "not-loaded-agent",
+        isPublic: true,
+        isActive: true,
+        loaded: false,
+      },
+    ]);
+
+    const res = await GET(...sessionAppsRequest());
+    const body = await res.json();
+
+    expect(body).toEqual([
+      { name: "default" },
+      { name: "limitless" },
+      { name: "somm-agent" },
+    ]);
+    expect(listApps).toHaveBeenCalledWith({ platform: "somm.finance" });
+  });
+
+  it("preserves the runtime app catalog when the platform app list fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json([{ name: "default" }])),
+    );
+    listApps.mockRejectedValueOnce(new Error("platform unavailable"));
+
+    const res = await GET(...sessionAppsRequest());
+    const body = await res.json();
+
+    expect(body).toEqual([{ name: "default" }]);
+  });
+});

--- a/apps/portal/src/app/api/[...slug]/route.ts
+++ b/apps/portal/src/app/api/[...slug]/route.ts
@@ -1,8 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { mintAccountBearer } from "@aomi-labs/account";
+import type { AomiAppDescriptor } from "@aomi-labs/client";
 import { getSessionedCanonicalId } from "@portal/server/cookies/session";
 import { configuredBackendUrl } from "@portal/server/backend-url";
+import { deploymentClient } from "@portal/server/bff/backend";
+import { launchConfig } from "@portal/server/bff/launch/config";
 
 /**
  * Same-origin proxy that fronts the Rust backend and **injects the
@@ -155,9 +158,12 @@ async function injectBearer(req: NextRequest, headers: Headers): Promise<void> {
     const { accessToken: accountBearer } = await mintAccountBearer(canonicalId);
     headers.set("authorization", `Bearer ${accountBearer}`);
   } catch (error) {
-    console.warn("Aomi proxy: could not mint AccountBearer; forwarding anonymous", {
-      message: error instanceof Error ? error.message : String(error),
-    });
+    console.warn(
+      "Aomi proxy: could not mint AccountBearer; forwarding anonymous",
+      {
+        message: error instanceof Error ? error.message : String(error),
+      },
+    );
   }
 }
 
@@ -174,6 +180,56 @@ function copyResponseHeaders(upstream: Response): Headers {
   return headers;
 }
 
+function normalizeAppDescriptors(data: unknown): AomiAppDescriptor[] {
+  if (!Array.isArray(data)) return [];
+  return data
+    .map((item) => {
+      if (typeof item === "string" && item.trim().length > 0) {
+        return { name: item.trim() };
+      }
+      if (item && typeof item === "object" && "name" in item) {
+        const descriptor = item as AomiAppDescriptor;
+        if (descriptor.name?.trim()) {
+          return { ...descriptor, name: descriptor.name.trim() };
+        }
+      }
+      return null;
+    })
+    .filter((item): item is AomiAppDescriptor => item !== null);
+}
+
+async function mergePlatformApps(
+  descriptors: AomiAppDescriptor[],
+): Promise<AomiAppDescriptor[]> {
+  try {
+    const config = launchConfig();
+    const client = await deploymentClient();
+    const platformApps = await client.listApps({ platform: config.platform });
+    const merged = new Map(
+      descriptors.map((descriptor) => [descriptor.name, descriptor]),
+    );
+
+    for (const app of platformApps) {
+      if (!app.name || !app.isPublic || !app.isActive || !app.loaded) {
+        continue;
+      }
+      if (!merged.has(app.name)) {
+        merged.set(app.name, { name: app.name });
+      }
+    }
+
+    return Array.from(merged.values());
+  } catch (error) {
+    console.warn(
+      "Aomi proxy: could not merge platform apps into session apps",
+      {
+        message: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return descriptors;
+  }
+}
+
 async function handle(
   req: NextRequest,
   context: { params: Promise<{ slug?: string[] }> },
@@ -182,7 +238,10 @@ async function handle(
   const upstreamUrl = buildUpstreamUrl(req, slug);
 
   if (!isAllowedProxyRequest(upstreamUrl.pathname, req.method)) {
-    return NextResponse.json({ error: "Unsupported API route" }, { status: 404 });
+    return NextResponse.json(
+      { error: "Unsupported API route" },
+      { status: 404 },
+    );
   }
 
   const headers = copyRequestHeaders(req);
@@ -198,6 +257,18 @@ async function handle(
           : await req.text(),
       redirect: "manual",
     });
+    if (
+      req.method === "GET" &&
+      upstream.ok &&
+      upstreamUrl.pathname === "/api/session/apps"
+    ) {
+      const descriptors = normalizeAppDescriptors(await upstream.json());
+      const merged = await mergePlatformApps(descriptors);
+      return NextResponse.json(merged, {
+        status: upstream.status,
+        headers: copyResponseHeaders(upstream),
+      });
+    }
     return new NextResponse(upstream.body, {
       status: upstream.status,
       statusText: upstream.statusText,
@@ -207,7 +278,10 @@ async function handle(
     console.error("Aomi upstream request failed", {
       message: error instanceof Error ? error.message : String(error),
     });
-    return NextResponse.json({ error: "Upstream request failed" }, { status: 502 });
+    return NextResponse.json(
+      { error: "Upstream request failed" },
+      { status: 502 },
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

- merge active, public, loaded platform deployments into the portal `/api/session/apps` response
- preserve the existing runtime app catalog when the platform app list is unavailable
- add focused route coverage for hosted platform apps such as `somm-agent`

## Root cause

The app picker reads the runtime `getApps()` catalog through `/api/session/apps`, while hosted platform deployments are visible through the platform app endpoint. Public loaded hosted apps therefore could be live but absent from the picker.

## Validation

- `pnpm --filter portal exec vitest run 'src/app/api/[...slug]/route.test.ts'`\n- `pnpm run lint`\n- `pnpm --filter portal type-check`\n- `pnpm run build:lib`\n