### PR TITLE
Decouple portal app catalog platform filters

### DIFF
--- a/apps/portal/src/app/api/[...slug]/route.test.ts
+++ b/apps/portal/src/app/api/[...slug]/route.test.ts
@@ -5,6 +5,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { GET } from "./route";
 
 const listApps = vi.fn();
+const launchConfigMock = vi.hoisted(() => ({
+  catalogPlatforms: [] as string[],
+}));
 
 vi.mock("@aomi-labs/account", () => ({
   mintAccountBearer: vi.fn(),
@@ -26,6 +29,7 @@ vi.mock("@portal/server/bff/launch/config", () => ({
   launchConfig: () => ({
     platform: "somm.finance",
     platforms: ["somm.finance", "community"],
+    catalogPlatforms: launchConfigMock.catalogPlatforms,
   }),
 }));
 
@@ -40,10 +44,11 @@ describe("portal API proxy", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+    launchConfigMock.catalogPlatforms = [];
     listApps.mockReset();
   });
 
-  it("forwards the backend session app catalog with the launch platforms", async () => {
+  it("forwards the backend session app catalog without a default platform filter", async () => {
     const fetchMock = vi.fn(async () =>
       Response.json([
         { name: "default" },
@@ -59,6 +64,23 @@ describe("portal API proxy", () => {
       { name: "default" },
       { name: "somm-agent", application_id: 1, platform: "somm.finance" },
     ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: "/api/session/apps",
+        search: "",
+      }),
+      expect.any(Object),
+    );
+    expect(listApps).not.toHaveBeenCalled();
+  });
+
+  it("adds explicit catalog platform filters to session app catalog calls", async () => {
+    launchConfigMock.catalogPlatforms = ["somm.finance", "community"];
+    const fetchMock = vi.fn(async () => Response.json([{ name: "default" }]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await GET(...sessionAppsRequest());
+
     expect(fetchMock).toHaveBeenCalledWith(
       expect.objectContaining({
         pathname: "/api/session/apps",

--- a/apps/portal/src/app/api/[...slug]/route.ts
+++ b/apps/portal/src/app/api/[...slug]/route.ts
@@ -128,7 +128,7 @@ function applyPortalDefaults(upstreamUrl: URL): void {
     upstreamUrl.pathname === "/api/session/apps" &&
     !upstreamUrl.searchParams.get("platform")
   ) {
-    for (const platform of launchConfig().platforms) {
+    for (const platform of launchConfig().catalogPlatforms) {
       upstreamUrl.searchParams.append("platform", platform);
     }
   }

--- a/apps/portal/src/features/launch/components/deploy-step.tsx
+++ b/apps/portal/src/features/launch/components/deploy-step.tsx
@@ -269,7 +269,7 @@ export function DeployStep({
     progress.appSourceId,
     progress.sourceRef,
     repo,
-    deployment?.source?.ref,
+    deployment,
   ]);
 
   useEffect(() => {

--- a/apps/portal/src/server/bff/launch/config.test.ts
+++ b/apps/portal/src/server/bff/launch/config.test.ts
@@ -11,6 +11,7 @@ describe("launchConfig", () => {
     const config = launchConfig();
     expect(config.platform).toBe("community");
     expect(config.platforms).toEqual(["community"]);
+    expect(config.catalogPlatforms).toEqual([]);
     expect(config.templateRepo).toBe("aomi-labs/playground-example");
     expect(config.createdRepoPrivate).toBe(false);
     expect(config.targetTags).toEqual([]);
@@ -25,6 +26,7 @@ describe("launchConfig", () => {
     const config = launchConfig();
     expect(config.platform).toBe("partners");
     expect(config.platforms).toEqual(["partners", "somm.finance"]);
+    expect(config.catalogPlatforms).toEqual([]);
     expect(config.templateRepo).toBe("acme/template");
     expect(config.createdRepoPrivate).toBe(true);
     expect(config.targetTags).toEqual(["staging", "launch"]);
@@ -36,6 +38,7 @@ describe("launchConfig", () => {
     const config = launchConfig();
     expect(config.platform).toBe("somm.finance");
     expect(config.platforms).toEqual(["somm.finance", "community"]);
+    expect(config.catalogPlatforms).toEqual([]);
   });
 
   it("falls back to public platform envs during deployment bootstrap", () => {
@@ -47,6 +50,7 @@ describe("launchConfig", () => {
     const config = launchConfig();
     expect(config.platform).toBe("somm.finance");
     expect(config.platforms).toEqual(["somm.finance", "community"]);
+    expect(config.catalogPlatforms).toEqual([]);
   });
 
   it("accepts a single platform env as a one-item platform list", () => {
@@ -55,5 +59,25 @@ describe("launchConfig", () => {
     const config = launchConfig();
     expect(config.platform).toBe("somm.finance");
     expect(config.platforms).toEqual(["somm.finance"]);
+    expect(config.catalogPlatforms).toEqual([]);
+  });
+
+  it("uses explicit catalog platforms without changing deploy platforms", () => {
+    vi.stubEnv("APP_DEPLOY_PLATFORMS", "community,somm.finance");
+    vi.stubEnv("APP_CATALOG_PLATFORMS", "official, somm.finance, official");
+
+    const config = launchConfig();
+    expect(config.platform).toBe("community");
+    expect(config.platforms).toEqual(["community", "somm.finance"]);
+    expect(config.catalogPlatforms).toEqual(["official", "somm.finance"]);
+  });
+
+  it("falls back to public catalog platform envs", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_CATALOG_PLATFORMS", '["somm.finance"]');
+
+    const config = launchConfig();
+    expect(config.platform).toBe("community");
+    expect(config.platforms).toEqual(["community"]);
+    expect(config.catalogPlatforms).toEqual(["somm.finance"]);
   });
 });

--- a/apps/portal/src/server/bff/launch/config.ts
+++ b/apps/portal/src/server/bff/launch/config.ts
@@ -7,6 +7,7 @@ const DEFAULT_TEMPLATE_REPO = "aomi-labs/playground-example";
 export type LaunchConfig = {
   platform: string;
   platforms: string[];
+  catalogPlatforms: string[];
   templateRepo: string;
   createdRepoPrivate: boolean;
   targetTags: string[];
@@ -72,12 +73,25 @@ function deployPlatforms(): string[] {
   return [DEFAULT_DEPLOY_PLATFORM];
 }
 
+function catalogPlatforms(): string[] {
+  for (const name of [
+    "APP_CATALOG_PLATFORMS",
+    "NEXT_PUBLIC_APP_CATALOG_PLATFORMS",
+  ]) {
+    const platforms = envJsonOrCommaList(name);
+    if (platforms.length > 0) return platforms;
+  }
+
+  return [];
+}
+
 export function launchConfig(): LaunchConfig {
   const resolvedPlatforms = deployPlatforms();
 
   return {
     platform: resolvedPlatforms[0],
     platforms: resolvedPlatforms,
+    catalogPlatforms: catalogPlatforms(),
     templateRepo:
       process.env.APP_DEPLOY_TEMPLATE_REPO?.trim() ||
       envString("NEXT_PUBLIC_APP_DEPLOY_TEMPLATE_REPO", DEFAULT_TEMPLATE_REPO),


### PR DESCRIPTION
## Summary
- stop using deploy platform config as the default /api/session/apps catalog filter
- add explicit APP_CATALOG_PLATFORMS / NEXT_PUBLIC_APP_CATALOG_PLATFORMS for partner surfaces that intentionally want catalog filtering
- fix the portal deploy-step hook dependency that currently breaks portal lint

## Verification
- pnpm --filter portal exec vitest run src/server/bff/launch/config.test.ts 'src/app/api/[...slug]/route.test.ts'
- pnpm --filter portal exec tsc --noEmit --incremental false
- pnpm --filter portal lint
- pnpm --filter portal build