### PR TITLE
feat(deploy): actionable SDK version-mismatch message instead of a raw 502

### DIFF
--- a/apps/portal/src/features/launch/components/deploy-step.tsx
+++ b/apps/portal/src/features/launch/components/deploy-step.tsx
@@ -68,6 +68,42 @@ function backoffDelay(failureCount: number): number {
   return Math.min(delay, MAX_BACKOFF_MS);
 }
 
+async function readSdkPin(url: string, init?: RequestInit): Promise<string | null> {
+  try {
+    const res = await fetch(url, init);
+    if (!res.ok) return null;
+    const text = await res.text();
+    const m = text.match(/aomi-sdk\s*=\s*"=?([0-9]+\.[0-9]+\.[0-9]+)"/);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+// A deploy/preflight that fails with a server error is most often an aomi-sdk pin the
+// platform no longer accepts, which otherwise surfaces as an opaque "(502)". Compare the
+// app's pinned SDK against the platform's current version (the playground template's pin
+// is the canonical version builders must match) and return an actionable message instead.
+// Fails open to the raw error for anything that isn't a clear version mismatch.
+async function enrichDeployError(
+  repo: string | undefined,
+  raw: string,
+): Promise<string> {
+  if (!repo || !/\((?:400|409|500|502)\)/.test(raw)) return raw;
+  const [appSdk, requiredSdk] = await Promise.all([
+    readSdkPin(`https://api.github.com/repos/${repo}/contents/Cargo.toml`, {
+      headers: { Accept: "application/vnd.github.raw" },
+    }),
+    readSdkPin(
+      "https://raw.githubusercontent.com/aomi-labs/playground-example/main/Cargo.toml",
+    ),
+  ]);
+  if (appSdk && requiredSdk && appSdk !== requiredSdk) {
+    return `Your app pins aomi-sdk ${appSdk}, but the platform requires ${requiredSdk}. Set aomi-sdk = "=${requiredSdk}" in your Cargo.toml, push, and redeploy.`;
+  }
+  return raw;
+}
+
 function buildProgressModel(
   state: string,
   lastCompleted: number,
@@ -195,7 +231,8 @@ export function DeployStep({
       applyDeployment(result);
       setPhase("preflight_ready");
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      const raw = e instanceof Error ? e.message : String(e);
+      setError(await enrichDeployError(repo, raw));
       setPhase("error");
     }
   }, [
@@ -258,7 +295,8 @@ export function DeployStep({
       onProgress(patch);
       setPhase("building");
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      const raw = e instanceof Error ? e.message : String(e);
+      setError(await enrichDeployError(repo, raw));
       setPhase("error");
     }
   }, [
@@ -418,10 +456,11 @@ export function DeployStep({
       }
       await verifyLive(apps, tags);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      const raw = e instanceof Error ? e.message : String(e);
+      setError(await enrichDeployError(repo, raw));
       setPhase("error");
     }
-  }, [actor, apps, tags, verifyLive]);
+  }, [actor, apps, repo, tags, verifyLive]);
 
   const reset = useCallback(() => {
     setError(null);


### PR DESCRIPTION
## Why

Cecilia: *'even for a versioning problem we need better visualization instead of 502.'* Hit this live deploying Goal Digger — the app pinned `aomi-sdk = 3.0.0` while the platform moved to `3.0.1`, and the deploy page just showed `launch deploy failed (502)` with no hint of the cause.

## What

In `deploy-step.tsx`, when preflight / deploy / activate fails with a 4xx/5xx, compare the app's pinned `aomi-sdk` (read from its `Cargo.toml`) against the platform's current version (the `playground-example` template pin, which is the canonical version builders must match). If they differ, replace the opaque error with:

> Your app pins aomi-sdk 3.0.0, but the platform requires 3.0.1. Set `aomi-sdk = "=3.0.1"` in your Cargo.toml, push, and redeploy.

- **Additive + fails open:** any error that isn't a clear version mismatch (or if the checks fail / repo is private) shows the original message unchanged. No happy-path change.
- Module-level helper, so no hook-deps churn (added `repo` to the `activate` deps array only).

## Testing

Couldn't run the portal locally (no deps installed here) — relies on CI typecheck/lint + the Vercel preview. The diagnosis and the version numbers are from the live deploy. A natural follow-up is to also surface this proactively in preflight (warn before the user deploys), and to source the required version from the backend instead of the template once that's exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)