### PR TITLE
[codex] Pass activated app id to one-click chat

### DIFF
--- a/apps/portal/src/features/launch/components/deploy-step.tsx
+++ b/apps/portal/src/features/launch/components/deploy-step.tsx
@@ -370,7 +370,13 @@ export function DeployStep({
             checks.length > 0 &&
             checks.every((check) => check.ok && check.state === "live")
           ) {
-            onProgress({ live: true });
+            const firstApplicationId = checks
+              .find((check) => check.app?.id)
+              ?.app?.id?.toString();
+            onProgress({
+              live: true,
+              applicationId: firstApplicationId,
+            });
             setPhase("live");
             return;
           }
@@ -414,12 +420,16 @@ export function DeployStep({
         const failed = activatedApps.find((app) => app.error);
         throw new Error(failed?.error ?? "Activation was not accepted.");
       }
+      const applicationId = activatedApps
+        .find((app) => app.applicationId)
+        ?.applicationId?.toString();
+      if (applicationId) onProgress({ applicationId });
       await verifyLive(apps, tags);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
       setPhase("error");
     }
-  }, [actor, apps, tags, verifyLive]);
+  }, [actor, apps, onProgress, tags, verifyLive]);
 
   const reset = useCallback(() => {
     setError(null);

--- a/apps/portal/src/features/launch/components/oneshot-wizard.test.tsx
+++ b/apps/portal/src/features/launch/components/oneshot-wizard.test.tsx
@@ -76,13 +76,18 @@ describe("OneshotWizard", () => {
     render(
       <OneshotWizard
         {...defaultProps}
-        progress={{ ...baseProgress(), live: true, apps: ["my-agent"] }}
+        progress={{
+          ...baseProgress(),
+          live: true,
+          apps: ["my-agent"],
+          applicationId: "42",
+        }}
       />,
     );
     expect(screen.getByText(/Your agent is live/)).toBeInTheDocument();
     expect(screen.getByTitle("Chat with your agent")).toHaveAttribute(
       "src",
-      "https://chat.aomi.dev?app=my-agent&lock_app=1",
+      "https://chat.aomi.dev?app=my-agent&application_id=42&lock_app=1",
     );
   });
 

--- a/apps/portal/src/features/launch/components/oneshot-wizard.tsx
+++ b/apps/portal/src/features/launch/components/oneshot-wizard.tsx
@@ -225,7 +225,10 @@ export function OneshotWizard({
           repo={progress.repo}
           chatUrl={
             progress.apps?.[0]
-              ? chatAppUrl(progress.apps[0], { locked: true })
+              ? chatAppUrl(progress.apps[0], {
+                  locked: true,
+                  applicationId: progress.applicationId,
+                })
               : undefined
           }
         />


### PR DESCRIPTION
## Summary
- Include the activated application id in one-click live chat links.
- Persist the activated app id from activation/runtime verification into launch progress.
- This makes the chat iframe/request scope match the hosted app row and avoids 403s when setting the model.

## Validation
- pnpm --filter portal exec tsc --noEmit --project tsconfig.json
- pnpm --filter portal lint (0 errors; existing warnings remain)
