### PR TITLE
ci(smither): active PRs only — skip merged/closed PRs

### DIFF
--- a/.github/workflows/smither.yaml
+++ b/.github/workflows/smither.yaml
@@ -23,6 +23,8 @@ concurrency:
 
 jobs:
   coordinate:
+    # Active PRs only: skip merged/closed PRs (labeling a merged PR still emits events).
+    if: github.event_name != 'pull_request' || github.event.pull_request.state == 'open'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout coordinator


### PR DESCRIPTION
Adds a job guard so the collision radar never runs for merged/closed PRs (labeling a merged PR still emits `pull_request` events). The analysis layer already only compares open PRs; this stops the wasted CI run + LLM call. One-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)