### PR TITLE
Migrate client SDK and portal to the threads backend API

### DIFF
--- a/apps/portal/src/app/api/[...slug]/route.ts
+++ b/apps/portal/src/app/api/[...slug]/route.ts
@@ -25,12 +25,23 @@ const ALLOWED_ROUTES: AllowedRoute[] = [
   { pattern: /^\/api\/secrets$/, methods: new Set(["GET", "POST", "DELETE"]) },
   { pattern: /^\/api\/secrets\/[^/]+$/, methods: new Set(["DELETE"]) },
   { pattern: /^\/api\/updates$/, methods: new Set(["GET"]) },
+  // Threads-era backend routes plus their pre-rename `session` twins: the
+  // old patterns stay allowlisted (they just 404 upstream on a new backend)
+  // so portal deploys don't have to be lockstep with the backend cutover.
+  { pattern: /^\/api\/threads$/, methods: new Set(["GET", "POST"]) },
+  {
+    pattern: /^\/api\/threads\/[^/]+$/,
+    methods: new Set(["GET", "PATCH", "DELETE"]),
+  },
   { pattern: /^\/api\/sessions$/, methods: new Set(["GET", "POST"]) },
   {
     pattern: /^\/api\/sessions\/[^/]+$/,
     methods: new Set(["GET", "PATCH", "DELETE"]),
   },
   { pattern: /^\/api\/events$/, methods: new Set(["GET"]) },
+  { pattern: /^\/api\/thread\/apps$/, methods: new Set(["GET"]) },
+  { pattern: /^\/api\/thread\/models$/, methods: new Set(["GET"]) },
+  { pattern: /^\/api\/thread\/model$/, methods: new Set(["POST"]) },
   { pattern: /^\/api\/session\/apps$/, methods: new Set(["GET"]) },
   { pattern: /^\/api\/session\/models$/, methods: new Set(["GET"]) },
   { pattern: /^\/api\/session\/model$/, methods: new Set(["POST"]) },
@@ -68,7 +79,8 @@ const ALLOWED_ROUTES: AllowedRoute[] = [
 
 function applyPortalDefaults(upstreamUrl: URL): void {
   if (
-    upstreamUrl.pathname === "/api/session/apps" &&
+    (upstreamUrl.pathname === "/api/thread/apps" ||
+      upstreamUrl.pathname === "/api/session/apps") &&
     !upstreamUrl.searchParams.get("platform")
   ) {
     for (const platform of launchConfig().catalogPlatforms) {

--- a/apps/portal/src/components/shell/portal-aomi-frame.tsx
+++ b/apps/portal/src/components/shell/portal-aomi-frame.tsx
@@ -190,7 +190,12 @@ function usePortalClientOptions(
       const url = parseUrl(input);
       if (
         !url ||
-        !["/api/chat", "/api/system", "/api/session/model"].includes(
+        ![
+          "/api/chat",
+          "/api/system",
+          "/api/thread/model",
+          "/api/session/model",
+        ].includes(
           url.pathname,
         )
       ) {

--- a/apps/portal/src/lib/settings-api.ts
+++ b/apps/portal/src/lib/settings-api.ts
@@ -63,6 +63,7 @@ export async function sessionScopedFetch<T>(
   const url = `${getBackendUrl()}${path}`;
   const headers = new Headers(requestInit.headers ?? {});
   headers.set("X-Session-Id", getSettingsSessionId());
+  headers.set("X-Thread-Id", getSettingsSessionId());
   const resolvedSecret =
     secret === undefined ? getSettingsSecret() : secret?.trim() || null;
   if (resolvedSecret) {

--- a/apps/shadcn-registry/package.json
+++ b/apps/shadcn-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/widget-lib",
-  "version": "1.2.21",
+  "version": "1.3.0",
   "description": "Shadcn registry for the Aomi widget.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/account/src/proxy.ts
+++ b/packages/account/src/proxy.ts
@@ -34,6 +34,7 @@ const ALLOWED_REQUEST_HEADERS = new Set([
   "content-type",
   "aomi-app-key",
   "x-session-id",
+  "x-thread-id",
 ]);
 
 export type AllowedRoute = {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/client",
-  "version": "0.1.42",
+  "version": "0.2.0",
   "description": "Platform-agnostic TypeScript client for the Aomi backend API",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -39,6 +39,11 @@ import { normalizeAppDescriptor } from "./app-descriptor";
 // =============================================================================
 
 const SESSION_ID_HEADER = "X-Session-Id";
+// The threads-era backend reads `X-Thread-Id`; older backends read
+// `X-Session-Id`. Both are sent during the migration so routes whose paths
+// didn't change (`/api/chat`, `/api/state`, `/api/updates`) work against
+// either backend.
+const THREAD_ID_HEADER = "X-Thread-Id";
 const APP_KEY_HEADER = "Aomi-App-Key";
 
 function previewText(value: string, max = 80): string {
@@ -182,9 +187,25 @@ function encodeJsonBody(body: unknown): BodyInit | undefined {
   return body === undefined ? undefined : JSON.stringify(body);
 }
 
+// The threads-era backend returns `thread_id`; older backends returned
+// `session_id`. The SDK's public types keep `session_id` as the id field, so
+// normalize at the wire boundary.
+type ThreadWire = {
+  thread_id?: string;
+  session_id?: string;
+  title?: string | null;
+  is_archived?: boolean;
+};
+
+function normalizeThreadWire(wire: ThreadWire): AomiThread {
+  const { thread_id, session_id, ...rest } = wire;
+  return { ...rest, session_id: session_id ?? thread_id ?? "" } as AomiThread;
+}
+
 function withSessionHeader(sessionId: string, init?: HeadersInit): HeadersInit {
   const headers = new Headers(init);
   headers.set(SESSION_ID_HEADER, sessionId);
+  headers.set(THREAD_ID_HEADER, sessionId);
   return headers;
 }
 
@@ -370,6 +391,7 @@ export class AomiClient {
     const headers = new Headers(options?.headers);
     if (options?.sessionId) {
       headers.set(SESSION_ID_HEADER, options.sessionId);
+      headers.set(THREAD_ID_HEADER, options.sessionId);
     }
     const apiKey = options?.apiKey ?? this.apiKey;
     if (apiKey) {
@@ -758,7 +780,7 @@ export class AomiClient {
    * List all threads for the authenticated account.
    */
   async listThreads(sessionId: string): Promise<AomiThread[]> {
-    const url = buildApiUrl(this.baseUrl, "/api/sessions");
+    const url = buildApiUrl(this.baseUrl, "/api/threads");
     const response = await this.fetchImpl(url, {
       headers: withSessionHeader(sessionId),
     });
@@ -767,7 +789,8 @@ export class AomiClient {
       throw new Error(`Failed to fetch threads: HTTP ${response.status}`);
     }
 
-    return (await response.json()) as AomiThread[];
+    const threads = (await response.json()) as ThreadWire[];
+    return threads.map(normalizeThreadWire);
   }
 
   /**
@@ -776,7 +799,7 @@ export class AomiClient {
   async getThread(sessionId: string): Promise<AomiThread> {
     const url = buildApiUrl(
       this.baseUrl,
-      `/api/sessions/${encodeURIComponent(sessionId)}`,
+      `/api/threads/${encodeURIComponent(sessionId)}`,
     );
     const response = await this.fetchImpl(url, {
       headers: withSessionHeader(sessionId),
@@ -786,14 +809,14 @@ export class AomiClient {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
 
-    return (await response.json()) as AomiThread;
+    return normalizeThreadWire((await response.json()) as ThreadWire);
   }
 
   /**
    * Create a new thread. The client generates the session ID.
    */
   async createThread(threadId: string): Promise<AomiCreateThreadResponse> {
-    const url = buildApiUrl(this.baseUrl, "/api/sessions");
+    const url = buildApiUrl(this.baseUrl, "/api/threads");
     const response = await this.fetchImpl(url, {
       method: "POST",
       headers: withSessionHeader(threadId),
@@ -803,7 +826,7 @@ export class AomiClient {
       throw new Error(`Failed to create thread: HTTP ${response.status}`);
     }
 
-    return (await response.json()) as AomiCreateThreadResponse;
+    return normalizeThreadWire((await response.json()) as ThreadWire);
   }
 
   /**
@@ -812,7 +835,7 @@ export class AomiClient {
   async deleteThread(sessionId: string): Promise<void> {
     const url = buildApiUrl(
       this.baseUrl,
-      `/api/sessions/${encodeURIComponent(sessionId)}`,
+      `/api/threads/${encodeURIComponent(sessionId)}`,
     );
     const response = await this.fetchImpl(url, {
       method: "DELETE",
@@ -830,7 +853,7 @@ export class AomiClient {
   async renameThread(sessionId: string, newTitle: string): Promise<void> {
     const url = buildApiUrl(
       this.baseUrl,
-      `/api/sessions/${encodeURIComponent(sessionId)}`,
+      `/api/threads/${encodeURIComponent(sessionId)}`,
     );
     const response = await this.fetchImpl(url, {
       method: "PATCH",
@@ -850,7 +873,7 @@ export class AomiClient {
    */
   async archiveThread(sessionId: string): Promise<void> {
     throw new Error(
-      "Failed to archive thread: current backend does not expose /api/sessions/:id/archive",
+      "Failed to archive thread: current backend does not expose /api/threads/:id/archive",
     );
   }
 
@@ -859,7 +882,7 @@ export class AomiClient {
    */
   async unarchiveThread(sessionId: string): Promise<void> {
     throw new Error(
-      "Failed to unarchive thread: current backend does not expose /api/sessions/:id/unarchive",
+      "Failed to unarchive thread: current backend does not expose /api/threads/:id/unarchive",
     );
   }
 
@@ -903,7 +926,7 @@ export class AomiClient {
     options?: { apiKey?: string; platforms?: AomiPlatformFilter },
   ): Promise<AomiAppDescriptor[]> {
     const platforms = normalizePlatformFilter(options?.platforms);
-    const url = buildApiUrl(this.baseUrl, "/api/session/apps", {
+    const url = buildApiUrl(this.baseUrl, "/api/thread/apps", {
       platform: platforms.length > 0 ? platforms : undefined,
     });
 
@@ -1000,7 +1023,7 @@ export class AomiClient {
     sessionId: string,
     options?: { apiKey?: string },
   ): Promise<string[]> {
-    const url = buildApiUrl(this.baseUrl, "/api/session/models");
+    const url = buildApiUrl(this.baseUrl, "/api/thread/models");
     const apiKey = options?.apiKey ?? this.apiKey;
     const headers = new Headers(withSessionHeader(sessionId));
     if (apiKey) {
@@ -1038,7 +1061,7 @@ export class AomiClient {
   }> {
     const apiKey = options?.apiKey ?? this.apiKey;
     const applicationId = options?.applicationId?.toString().trim();
-    const url = buildApiUrl(this.baseUrl, "/api/session/model", {
+    const url = buildApiUrl(this.baseUrl, "/api/thread/model", {
       rig,
       app: options?.app,
       application_id: applicationId || undefined,

--- a/packages/client/src/user-state/normalize.ts
+++ b/packages/client/src/user-state/normalize.ts
@@ -9,6 +9,14 @@ function asObject(value: unknown): UnknownRecord | undefined {
   return value as UnknownRecord;
 }
 
+// The threads-era backend serializes `evm` as an array of per-chain wallets
+// whose first entry is the primary operating wallet; older backends sent a
+// single object. Collapse to the primary object at the boundary so the rest
+// of the pipeline keeps a single shape.
+function asEvmObject(value: unknown): UnknownRecord | undefined {
+  return Array.isArray(value) ? asObject(value[0]) : asObject(value);
+}
+
 function pick(record: UnknownRecord | undefined, ...keys: string[]): unknown {
   if (!record) {
     return undefined;
@@ -260,7 +268,7 @@ function parseChainId(value: unknown): number | undefined {
 }
 
 function address(state: UserState | undefined): string | undefined {
-  const value = asObject(state?.evm)?.address;
+  const value = asEvmObject(state?.evm)?.address;
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
@@ -270,7 +278,7 @@ function svmAddress(state: UserState | undefined): string | undefined {
 }
 
 function chainId(state: UserState | undefined): number | undefined {
-  return parseChainId(asObject(state?.evm)?.chain_id);
+  return parseChainId(asEvmObject(state?.evm)?.chain_id);
 }
 
 function isConnected(state: UserState | undefined): boolean | undefined {
@@ -295,7 +303,7 @@ export function normalizeUserState(
   const out: UserState = {};
   const connection = buildConnection(asObject(pick(src, "connection")), src);
   if (connection) out.connection = connection;
-  const evm = buildEvm(asObject(pick(src, "evm")), src);
+  const evm = buildEvm(asEvmObject(pick(src, "evm")), src);
   if (evm) out.evm = evm;
   const svm = buildSvm(asObject(pick(src, "svm", "solana")), src);
   if (svm) out.svm = svm;

--- a/packages/client/test/backend-openapi.contract.test.ts
+++ b/packages/client/test/backend-openapi.contract.test.ts
@@ -102,7 +102,7 @@ function isAomiAuthList(value: unknown): value is readonly AomiAuthClass[] {
 
 function isAomiAuthClass(value: unknown): value is AomiAuthClass {
   return (
-    value === "session" ||
+    value === "thread" ||
     value === "account" ||
     value === "app_gate" ||
     value === "service" ||

--- a/packages/client/test/client.unit.test.ts
+++ b/packages/client/test/client.unit.test.ts
@@ -10,9 +10,9 @@ describe("AomiClient route manifest", () => {
         `${endpoint.method} ${endpoint.path} [${endpoint.auth.join(", ")}]`,
     );
 
-    expect(routeKeys).toHaveLength(78);
+    expect(routeKeys).toHaveLength(85);
     expect(new Set(routeKeys).size).toBe(routeKeys.length);
-    expect(routeKeys).toContain("GET /api/session/apps [session]");
+    expect(routeKeys).toContain("GET /api/thread/apps [thread]");
     expect(routeKeys).toContain(
       "POST /api/platforms/:name/deploy [activation]",
     );

--- a/packages/client/test/client.unit.test.ts
+++ b/packages/client/test/client.unit.test.ts
@@ -324,7 +324,7 @@ describe("AomiClient account profile", () => {
 
       const [url, init] = nativeFetch.mock.calls[0] ?? [];
       expect(String(url)).toBe(
-        "http://unit.test/api/session/model?rig=gpt-5&app=default&client_id=client-1",
+        "http://unit.test/api/thread/model?rig=gpt-5&app=default&client_id=client-1",
       );
       expect((init as RequestInit | undefined)?.body).toBeUndefined();
       expect(
@@ -367,7 +367,7 @@ describe("AomiClient app catalog", () => {
       });
 
       expect(String(nativeFetch.mock.calls[0]?.[0])).toBe(
-        "http://unit.test/api/session/apps?platform=somm.finance&platform=community",
+        "http://unit.test/api/thread/apps?platform=somm.finance&platform=community",
       );
       expect(apps).toEqual([
         {

--- a/packages/client/test/fixtures/backend-openapi.json
+++ b/packages/client/test/fixtures/backend-openapi.json
@@ -53,12 +53,12 @@
         },
         "security": [
           {
-            "sessionId": [],
+            "threadId": [],
             "appKey": []
           }
         ],
         "x-aomi-auth": [
-          "session",
+          "thread",
           "app_gate"
         ]
       }
@@ -72,11 +72,11 @@
         },
         "security": [
           {
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
-          "session"
+          "thread"
         ]
       }
     },
@@ -89,11 +89,11 @@
         },
         "security": [
           {
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
-          "session"
+          "thread"
         ]
       }
     },
@@ -106,11 +106,11 @@
         },
         "security": [
           {
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
-          "session"
+          "thread"
         ]
       }
     },
@@ -140,15 +140,43 @@
         },
         "security": [
           {
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
-          "session"
+          "thread"
         ]
       }
     },
     "/api/auth/privy/callback": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": []
+      }
+    },
+    "/api/auth/para/begin": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "threadId": []
+          }
+        ],
+        "x-aomi-auth": [
+          "thread"
+        ]
+      }
+    },
+    "/api/auth/para/callback": {
       "post": {
         "responses": {
           "200": {
@@ -169,12 +197,12 @@
         "security": [
           {
             "accountBearer": [],
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
           "account",
-          "session"
+          "thread"
         ]
       },
       "get": {
@@ -186,12 +214,12 @@
         "security": [
           {
             "accountBearer": [],
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
           "account",
-          "session"
+          "thread"
         ]
       },
       "post": {
@@ -203,12 +231,12 @@
         "security": [
           {
             "accountBearer": [],
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
           "account",
-          "session"
+          "thread"
         ]
       }
     },
@@ -222,16 +250,16 @@
         "security": [
           {
             "accountBearer": [],
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
           "account",
-          "session"
+          "thread"
         ]
       }
     },
-    "/api/sessions": {
+    "/api/threads": {
       "get": {
         "responses": {
           "200": {
@@ -241,12 +269,12 @@
         "security": [
           {
             "accountBearer": [],
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
           "account",
-          "session"
+          "thread"
         ]
       },
       "post": {
@@ -257,15 +285,15 @@
         },
         "security": [
           {
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
-          "session"
+          "thread"
         ]
       }
     },
-    "/api/sessions/{session_id}": {
+    "/api/threads/{thread_id}": {
       "delete": {
         "responses": {
           "200": {
@@ -275,12 +303,12 @@
         "security": [
           {
             "accountBearer": [],
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
           "account",
-          "session"
+          "thread"
         ]
       },
       "get": {
@@ -292,12 +320,12 @@
         "security": [
           {
             "accountBearer": [],
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
           "account",
-          "session"
+          "thread"
         ]
       },
       "patch": {
@@ -309,12 +337,12 @@
         "security": [
           {
             "accountBearer": [],
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
           "account",
-          "session"
+          "thread"
         ]
       }
     },
@@ -354,6 +382,140 @@
     },
     "/api/account/usage": {
       "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "accountBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "account"
+        ]
+      }
+    },
+    "/api/account/status": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "accountBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "account"
+        ]
+      }
+    },
+    "/api/account/wallets": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "accountBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "account"
+        ]
+      }
+    },
+    "/api/account/authorization/challenge": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "accountBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "account"
+        ]
+      }
+    },
+    "/api/account/authorization/commit": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "accountBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "account"
+        ]
+      }
+    },
+    "/api/account/providers/{provider}/grant": {
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "accountBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "account"
+        ]
+      }
+    },
+    "/api/account/scheduled-intents": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "accountBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "account"
+        ]
+      }
+    },
+    "/api/account/scheduled-intents/{id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "accountBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "account"
+        ]
+      },
+      "delete": {
         "responses": {
           "200": {
             "description": "OK"
@@ -467,55 +629,6 @@
         ]
       }
     },
-    "/api/account/approvals": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        },
-        "security": [
-          {
-            "accountBearer": []
-          }
-        ],
-        "x-aomi-auth": [
-          "account"
-        ]
-      },
-      "post": {
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        },
-        "security": [
-          {
-            "accountBearer": []
-          }
-        ],
-        "x-aomi-auth": [
-          "account"
-        ]
-      }
-    },
-    "/api/account/approvals/{id}": {
-      "delete": {
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        },
-        "security": [
-          {
-            "accountBearer": []
-          }
-        ],
-        "x-aomi-auth": [
-          "account"
-        ]
-      }
-    },
     "/api/account/payment": {
       "get": {
         "responses": {
@@ -599,7 +712,7 @@
         ]
       }
     },
-    "/api/session/apps": {
+    "/api/thread/apps": {
       "get": {
         "responses": {
           "200": {
@@ -608,15 +721,15 @@
         },
         "security": [
           {
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
-          "session"
+          "thread"
         ]
       }
     },
-    "/api/session/runtime/models": {
+    "/api/thread/runtime/models": {
       "get": {
         "responses": {
           "200": {
@@ -625,15 +738,15 @@
         },
         "security": [
           {
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
-          "session"
+          "thread"
         ]
       }
     },
-    "/api/session/runtime/model": {
+    "/api/thread/runtime/model": {
       "post": {
         "responses": {
           "200": {
@@ -642,15 +755,15 @@
         },
         "security": [
           {
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
-          "session"
+          "thread"
         ]
       }
     },
-    "/api/session/models": {
+    "/api/thread/models": {
       "get": {
         "responses": {
           "200": {
@@ -659,15 +772,15 @@
         },
         "security": [
           {
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
-          "session"
+          "thread"
         ]
       }
     },
-    "/api/session/model": {
+    "/api/thread/model": {
       "post": {
         "responses": {
           "200": {
@@ -676,11 +789,11 @@
         },
         "security": [
           {
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
-          "session"
+          "thread"
         ]
       }
     },
@@ -1206,11 +1319,11 @@
         },
         "security": [
           {
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
-          "session"
+          "thread"
         ]
       }
     },
@@ -1223,11 +1336,11 @@
         },
         "security": [
           {
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
-          "session"
+          "thread"
         ]
       }
     },
@@ -1252,22 +1365,22 @@
         "security": [
           {
             "accountBearer": [],
-            "sessionId": []
+            "threadId": []
           }
         ],
         "x-aomi-auth": [
           "account",
-          "session"
+          "thread"
         ]
       }
     }
   },
   "components": {
     "securitySchemes": {
-      "sessionId": {
+      "threadId": {
         "type": "apiKey",
         "in": "header",
-        "name": "X-Session-Id"
+        "name": "X-Thread-Id"
       },
       "accountBearer": {
         "type": "http",

--- a/packages/client/test/generated/backend-routes.ts
+++ b/packages/client/test/generated/backend-routes.ts
@@ -10,11 +10,6 @@ export const AOMI_BACKEND_ENDPOINTS = [
   },
   {
     method: "DELETE",
-    path: "/api/account/approvals/:id",
-    auth: ["account"],
-  },
-  {
-    method: "DELETE",
     path: "/api/account/bots/:id",
     auth: ["account"],
   },
@@ -30,23 +25,33 @@ export const AOMI_BACKEND_ENDPOINTS = [
   },
   {
     method: "DELETE",
+    path: "/api/account/providers/:provider/grant",
+    auth: ["account"],
+  },
+  {
+    method: "DELETE",
+    path: "/api/account/scheduled-intents/:id",
+    auth: ["account"],
+  },
+  {
+    method: "DELETE",
     path: "/api/platforms/:name/tokens/:id",
     auth: ["activation"],
   },
   {
     method: "DELETE",
     path: "/api/secrets",
-    auth: ["account","session"],
+    auth: ["account","thread"],
   },
   {
     method: "DELETE",
     path: "/api/secrets/:name",
-    auth: ["account","session"],
+    auth: ["account","thread"],
   },
   {
     method: "DELETE",
-    path: "/api/sessions/:session_id",
-    auth: ["account","session"],
+    path: "/api/threads/:thread_id",
+    auth: ["account","thread"],
   },
   {
     method: "GET",
@@ -56,11 +61,6 @@ export const AOMI_BACKEND_ENDPOINTS = [
   {
     method: "GET",
     path: "/api/account/app-keys",
-    auth: ["account"],
-  },
-  {
-    method: "GET",
-    path: "/api/account/approvals",
     auth: ["account"],
   },
   {
@@ -80,7 +80,27 @@ export const AOMI_BACKEND_ENDPOINTS = [
   },
   {
     method: "GET",
+    path: "/api/account/scheduled-intents",
+    auth: ["account"],
+  },
+  {
+    method: "GET",
+    path: "/api/account/scheduled-intents/:id",
+    auth: ["account"],
+  },
+  {
+    method: "GET",
+    path: "/api/account/status",
+    auth: ["account"],
+  },
+  {
+    method: "GET",
     path: "/api/account/usage",
+    auth: ["account"],
+  },
+  {
+    method: "GET",
+    path: "/api/account/wallets",
     auth: ["account"],
   },
   {
@@ -106,7 +126,7 @@ export const AOMI_BACKEND_ENDPOINTS = [
   {
     method: "GET",
     path: "/api/events",
-    auth: ["session"],
+    auth: ["thread"],
   },
   {
     method: "GET",
@@ -176,32 +196,7 @@ export const AOMI_BACKEND_ENDPOINTS = [
   {
     method: "GET",
     path: "/api/secrets",
-    auth: ["account","session"],
-  },
-  {
-    method: "GET",
-    path: "/api/session/apps",
-    auth: ["session"],
-  },
-  {
-    method: "GET",
-    path: "/api/session/models",
-    auth: ["session"],
-  },
-  {
-    method: "GET",
-    path: "/api/session/runtime/models",
-    auth: ["session"],
-  },
-  {
-    method: "GET",
-    path: "/api/sessions",
-    auth: ["account","session"],
-  },
-  {
-    method: "GET",
-    path: "/api/sessions/:session_id",
-    auth: ["account","session"],
+    auth: ["account","thread"],
   },
   {
     method: "GET",
@@ -211,12 +206,37 @@ export const AOMI_BACKEND_ENDPOINTS = [
   {
     method: "GET",
     path: "/api/state",
-    auth: ["session"],
+    auth: ["thread"],
+  },
+  {
+    method: "GET",
+    path: "/api/thread/apps",
+    auth: ["thread"],
+  },
+  {
+    method: "GET",
+    path: "/api/thread/models",
+    auth: ["thread"],
+  },
+  {
+    method: "GET",
+    path: "/api/thread/runtime/models",
+    auth: ["thread"],
+  },
+  {
+    method: "GET",
+    path: "/api/threads",
+    auth: ["account","thread"],
+  },
+  {
+    method: "GET",
+    path: "/api/threads/:thread_id",
+    auth: ["account","thread"],
   },
   {
     method: "GET",
     path: "/api/updates",
-    auth: ["session"],
+    auth: ["thread"],
   },
   {
     method: "GET",
@@ -230,8 +250,8 @@ export const AOMI_BACKEND_ENDPOINTS = [
   },
   {
     method: "PATCH",
-    path: "/api/sessions/:session_id",
-    auth: ["account","session"],
+    path: "/api/threads/:thread_id",
+    auth: ["account","thread"],
   },
   {
     method: "POST",
@@ -245,7 +265,12 @@ export const AOMI_BACKEND_ENDPOINTS = [
   },
   {
     method: "POST",
-    path: "/api/account/approvals",
+    path: "/api/account/authorization/challenge",
+    auth: ["account"],
+  },
+  {
+    method: "POST",
+    path: "/api/account/authorization/commit",
     auth: ["account"],
   },
   {
@@ -280,8 +305,18 @@ export const AOMI_BACKEND_ENDPOINTS = [
   },
   {
     method: "POST",
+    path: "/api/auth/para/begin",
+    auth: ["thread"],
+  },
+  {
+    method: "POST",
+    path: "/api/auth/para/callback",
+    auth: [],
+  },
+  {
+    method: "POST",
     path: "/api/auth/privy/begin",
-    auth: ["session"],
+    auth: ["thread"],
   },
   {
     method: "POST",
@@ -296,7 +331,7 @@ export const AOMI_BACKEND_ENDPOINTS = [
   {
     method: "POST",
     path: "/api/chat",
-    auth: ["session","app_gate"],
+    auth: ["thread","app_gate"],
   },
   {
     method: "POST",
@@ -311,7 +346,7 @@ export const AOMI_BACKEND_ENDPOINTS = [
   {
     method: "POST",
     path: "/api/interrupt",
-    auth: ["session"],
+    auth: ["thread"],
   },
   {
     method: "POST",
@@ -356,32 +391,32 @@ export const AOMI_BACKEND_ENDPOINTS = [
   {
     method: "POST",
     path: "/api/secrets",
-    auth: ["account","session"],
-  },
-  {
-    method: "POST",
-    path: "/api/session/model",
-    auth: ["session"],
-  },
-  {
-    method: "POST",
-    path: "/api/session/runtime/model",
-    auth: ["session"],
-  },
-  {
-    method: "POST",
-    path: "/api/sessions",
-    auth: ["session"],
+    auth: ["account","thread"],
   },
   {
     method: "POST",
     path: "/api/simulate",
-    auth: ["session"],
+    auth: ["thread"],
   },
   {
     method: "POST",
     path: "/api/system",
-    auth: ["account","session"],
+    auth: ["account","thread"],
+  },
+  {
+    method: "POST",
+    path: "/api/thread/model",
+    auth: ["thread"],
+  },
+  {
+    method: "POST",
+    path: "/api/thread/runtime/model",
+    auth: ["thread"],
+  },
+  {
+    method: "POST",
+    path: "/api/threads",
+    auth: ["thread"],
   },
   {
     method: "PUT",

--- a/packages/client/test/routes.ts
+++ b/packages/client/test/routes.ts
@@ -1,7 +1,7 @@
 export type AomiHttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 
 export type AomiAuthClass =
-  | "session"
+  | "thread"
   | "account"
   | "app_gate"
   | "service"

--- a/packages/client/test/user-state-normalize.unit.test.ts
+++ b/packages/client/test/user-state-normalize.unit.test.ts
@@ -89,3 +89,36 @@ describe("normalizeUserState null pruning", () => {
     expect(normalized?.ext).toEqual({ client_type: "web_ui", custom: null });
   });
 });
+
+describe("normalizeUserState evm wire shapes", () => {
+  // The threads-era backend serializes `evm` as an array of per-chain
+  // wallets (primary = first entry); older backends sent a single object.
+  // Normalization must read both so the portal keeps its wallet context
+  // across the backend cutover.
+  it("collapses the array shape to the primary wallet", () => {
+    const normalized = UserState.normalize({
+      connection: { is_connected: true },
+      evm: [
+        { address: "0xC764D92E312195114595cB645f31C38Fad9c14eE", chain_id: 1 },
+        { address: "0xC764D92E312195114595cB645f31C38Fad9c14eE", chain_id: 8453 },
+      ],
+    } as unknown as Parameters<typeof UserState.normalize>[0]);
+
+    expect(UserState.address(normalized)).toBe(
+      "0xC764D92E312195114595cB645f31C38Fad9c14eE",
+    );
+    expect(UserState.chainId(normalized)).toBe(1);
+  });
+
+  it("still reads the legacy object shape", () => {
+    const normalized = UserState.normalize({
+      connection: { is_connected: true },
+      evm: { address: "0xC764D92E312195114595cB645f31C38Fad9c14eE", chain_id: 1 },
+    });
+
+    expect(UserState.address(normalized)).toBe(
+      "0xC764D92E312195114595cB645f31C38Fad9c14eE",
+    );
+    expect(UserState.chainId(normalized)).toBe(1);
+  });
+});

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/deploy",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Server-side TypeScript client for the Aomi platform deploy API. Node-only; never bundle into a browser.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/react",
-  "version": "0.3.23",
+  "version": "0.4.0",
   "description": "Runtime, state, and utilities for the Aomi widget.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
The backend renamed the session surface to threads and the widget never caught up — every session route the SDK/portal calls 404s against a threads-era backend (this is why staging portal chat is broken, and what the somm.finance partner will hit after their SDK upgrade unless this ships).

## Wire changes covered

| Old | New |
|---|---|
| `GET/POST /api/sessions`, `/api/sessions/:id` | `/api/threads`, `/api/threads/:id` |
| `/api/session/apps` / `models` / `model` | `/api/thread/apps` / `models` / `model` |
| `X-Session-Id` header | `X-Thread-Id` |
| `session_id` in thread responses | `thread_id` |
| `user_state.evm` single object | array of per-chain wallets (primary = first entry) |

## Approach

- **SDK public surface unchanged** — `AomiThread.session_id`, method names, and options are as before; `thread_id` is normalized to `session_id` at the wire boundary. The partner's upgrade is drop-in.
- **Dual headers during the transition** — the client sends both `X-Session-Id` and `X-Thread-Id`, so routes whose paths didn't change (`/api/chat`, `/api/state`, `/api/updates`, `/api/events`) work against either backend generation. Path-renamed routes are inherently version-bound: this build requires a threads-era backend for thread CRUD and model bind.
- **evm shape** — `normalizeUserState` collapses the new array shape to the primary wallet (first entry, matching the backend's `EvmWalletState::primary()`); the legacy object shape still parses. Fixes the known portal wallet-context loss on the new wire.
- **Portal proxy** — thread routes allowlisted next to their session twins (the old patterns just 404 upstream on a new backend, so portal deploys don't need to be lockstep); `x-thread-id` forwarded; `/api/thread/apps` gets the same platform-default injection as `/api/session/apps`.

## Deploy ordering

Merge only when the backend it fronts speaks threads: staging BE already does; prod BE flips at the prod-v3 cutover (product-mono#762 + the main→prod-v3 sync). Sequencing details in the incident thread.

## Testing

- `pnpm exec vitest run packages/client/test/`: 28 files pass (241 tests), including new regression tests for the evm array/object shapes; stale URL expectations updated.
- `pnpm run typecheck` and `pnpm run build:portal` clean.
- Full-workspace vitest: same single pre-existing failure as unmodified main (`auth-runtime-user-sync.test.tsx`, unresolved `@aomi-labs/react` dist entry — unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)