### PR TITLE
Fix account session readiness gate

### DIFF
--- a/apps/portal/src/components/providers/aomi-session-bridge.tsx
+++ b/apps/portal/src/components/providers/aomi-session-bridge.tsx
@@ -3,6 +3,11 @@
 import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { useAomiAuthAdapter } from "@aomi-labs/widget-lib";
 
+const SESSION_RETRY_BUDGET_MS = 30_000;
+const SESSION_RETRY_BASE_DELAY_MS = 300;
+const SESSION_RETRY_MAX_DELAY_MS = 2_000;
+const SESSION_RETRY_BACKOFF_FACTOR = 1.7;
+
 export type AomiSessionStatus =
   | "anonymous"
   | "establishing"
@@ -19,44 +24,74 @@ export function useAomiSession(): {
 } {
   const adapter = useAomiAuthAdapter();
   const adapterStatus = adapter.identity.status;
+  const accountStatus = adapter.accountStatus;
+  const accountUserId = adapter.accountUser?.id;
   const [probeStatus, setProbeStatus] =
     useState<AomiSessionStatus>("establishing");
   const [probeAttempt, setProbeAttempt] = useState(0);
 
   useEffect(() => {
-    if (adapterStatus === "connected") {
-      setProbeStatus("ready");
-      return;
-    }
-    if (adapterStatus === "booting") {
+    if (
+      adapterStatus === "booting" ||
+      (adapterStatus === "connected" && accountStatus === "loading")
+    ) {
       setProbeStatus("establishing");
       return;
     }
 
     let cancelled = false;
     setProbeStatus("establishing");
-    void fetch("/api/account", {
-      cache: "no-store",
-      headers: { "X-Thread-Id": "settings-session-probe" },
-    })
-      .then((response) => {
-        if (cancelled) return;
-        if (response.ok) {
-          setProbeStatus("ready");
-        } else if (response.status === 401) {
-          setProbeStatus("anonymous");
-        } else {
+
+    const run = async () => {
+      let nextDelay = SESSION_RETRY_BASE_DELAY_MS;
+      let waitedMs = 0;
+
+      for (;;) {
+        try {
+          const response = await fetch("/api/account", {
+            cache: "no-store",
+            headers: { "X-Thread-Id": "settings-session-probe" },
+          });
+          if (cancelled) return;
+          if (response.ok) {
+            setProbeStatus("ready");
+            return;
+          }
+          if (
+            adapterStatus === "connected" &&
+            response.status === 401 &&
+            waitedMs < SESSION_RETRY_BUDGET_MS
+          ) {
+            setProbeStatus("establishing");
+          } else if (response.status === 401) {
+            setProbeStatus("anonymous");
+            return;
+          } else {
+            setProbeStatus("error");
+            return;
+          }
+        } catch {
+          if (cancelled) return;
           setProbeStatus("error");
+          return;
         }
-      })
-      .catch(() => {
-        if (!cancelled) setProbeStatus("error");
-      });
+
+        await new Promise((resolve) => globalThis.setTimeout(resolve, nextDelay));
+        waitedMs += nextDelay;
+        nextDelay = Math.min(
+          Math.round(nextDelay * SESSION_RETRY_BACKOFF_FACTOR),
+          SESSION_RETRY_MAX_DELAY_MS,
+        );
+        if (cancelled) return;
+      }
+    };
+
+    void run();
 
     return () => {
       cancelled = true;
     };
-  }, [adapterStatus, probeAttempt]);
+  }, [adapterStatus, accountStatus, accountUserId, probeAttempt]);
 
   const retry = useCallback(() => {
     setProbeAttempt((attempt) => attempt + 1);


### PR DESCRIPTION
## Summary

Fixes the account/usage page showing `{"error":"Authentication required"}` under a connected wallet, and the thread sidebar hanging. Root cause: **no Better Auth session is ever established**, so every account-scoped call 401s. Two independent causes:

### 1. Account session readiness gate (`aomi-session-bridge.tsx`)
- require a successful `/api/account` probe before marking the portal session ready
- keep connected wallet sessions in `establishing` while Better Auth/account state is still loading
- retry transient connected 401s for a bounded window so settings does not render account calls before auth cookies settle

### 2. Smart-account SIWE verification hang (`packages/account/src/better-auth/siwe.ts`)
SIWE `/verify` for a **smart-account** wallet (Coinbase/Base/Privy/Para AA — most Aomi users) does a deployless EIP-1271 `eth_call`. With no per-chain `*_RPC_URL` configured it fell back to a keyless public RPC that **hangs (>40s observed on prod)**, so smart-account logins never mint a session. EOA wallets (MetaMask/Rabby) were unaffected (fast ecrecover, no RPC).

Fix: resolve the RPC from the **existing** `ALCHEMY_API_KEY` (same key the wallet/AA stack already uses; falls back to the shared default when unset) + a local Alchemy slug map. **No new env var.** Verify now resolves in ~400ms instead of hanging.

## Validation
- `pnpm --filter portal exec tsc --noEmit`
- `pnpm --filter @aomi-labs/account exec tsc --noEmit`
- Local e2e: full SIWE flow (nonce → sign → verify) — smart-account path went from >40s hang to ~415ms; verify 200 + `better-auth.session_token` cookie → `/api/aomi/account` 200 → `/api/account` 200.