### PR TITLE
fix(siwe): resolve smart-account SIWE via shared Alchemy key

### DIFF
--- a/packages/account/src/better-auth/siwe.ts
+++ b/packages/account/src/better-auth/siwe.ts
@@ -80,13 +80,14 @@ const VERIFY_CHAINS: readonly Chain[] = [
 
 const publicClients = new Map<number, PublicClient>();
 
-// Per-chain RPC override read from env. Smart-account (EIP-1271 / ERC-6492)
-// verification does a heavy *deployless* `eth_call` (it counterfactually deploys
-// the wallet, then calls `isValidSignature`). Keyless public RPCs — notably
-// viem's mainnet default `eth.merkle.io` — frequently time out on this call,
-// which makes Coinbase Smart Wallet / Base Account SIWE logins appear to hang
-// (the EOA path short-circuits, so MetaMask/Rabby are unaffected). Point these
-// at a real RPC (Alchemy/Infura/etc.) so the on-chain check resolves.
+// Per-chain RPC for the smart-account (EIP-1271 / ERC-6492) check, which does a
+// heavy *deployless* `eth_call` (it counterfactually deploys the wallet, then
+// calls `isValidSignature`). Keyless public RPCs — notably viem's mainnet
+// default `eth.merkle.io` — frequently time out on this call, which makes
+// Coinbase Smart Wallet / Base Account SIWE logins hang (the EOA path
+// short-circuits, so MetaMask/Rabby are unaffected). Resolution order per chain:
+// an explicit `*_RPC_URL` override, then the shared `ALCHEMY_API_KEY` the
+// wallet/AA stack already uses (no new env var), then the public default.
 const RPC_ENV_BY_CHAIN: Record<number, readonly string[]> = {
   [mainnet.id]: ["MAINNET_RPC_URL", "ETH_RPC_URL"],
   [base.id]: ["BASE_RPC_URL"],
@@ -99,12 +100,40 @@ const RPC_ENV_BY_CHAIN: Record<number, readonly string[]> = {
   [lineaSepolia.id]: ["LINEA_SEPOLIA_RPC_URL"],
 };
 
+// Alchemy network slugs, mirroring ALCHEMY_CHAIN_SLUGS in `@aomi-labs/client`
+// (kept local to avoid a client dependency in this auth package).
+const ALCHEMY_SLUG_BY_CHAIN: Record<number, string> = {
+  [mainnet.id]: "eth-mainnet",
+  [sepolia.id]: "eth-sepolia",
+  [arbitrum.id]: "arb-mainnet",
+  [optimism.id]: "opt-mainnet",
+  [base.id]: "base-mainnet",
+  [baseSepolia.id]: "base-sepolia",
+  [polygon.id]: "polygon-mainnet",
+  [linea.id]: "linea-mainnet",
+  [lineaSepolia.id]: "linea-sepolia",
+};
+
+// Shared public default, mirrors DEFAULT_ALCHEMY_API_KEY in `@aomi-labs/client`
+// so the on-chain check still resolves when neither Alchemy env var is set.
+const DEFAULT_ALCHEMY_API_KEY = "72eIUle_3rfixX00QJVwk";
+
+function alchemyApiKey(): string {
+  return (
+    process.env.ALCHEMY_API_KEY?.trim() ||
+    process.env.NEXT_PUBLIC_ALCHEMY_API_KEY?.trim() ||
+    DEFAULT_ALCHEMY_API_KEY
+  );
+}
+
 function rpcUrlForChain(chain: Chain): string | undefined {
   for (const name of RPC_ENV_BY_CHAIN[chain.id] ?? []) {
     const value = process.env[name]?.trim();
     if (value) return value;
   }
-  // Fall back to the chain's default public RPC.
+  const slug = ALCHEMY_SLUG_BY_CHAIN[chain.id];
+  if (slug) return `https://${slug}.g.alchemy.com/v2/${alchemyApiKey()}`;
+  // Last resort: the chain's default public RPC.
   return chain.rpcUrls.default.http[0];
 }
 


### PR DESCRIPTION
## Why

Split out of #296 (which merged with only the session-gate commit; this fix was left out).

Fixes the account/usage page showing `{"error":"Authentication required"}` under a connected wallet, and the thread sidebar hanging — for **smart-account wallets** (Coinbase/Base/Privy/Para AA, i.e. most Aomi users).

## Root cause

SIWE `/verify` for a non-EOA wallet does a deployless EIP-1271 `eth_call`. With no per-chain `*_RPC_URL` configured, `rpcUrlForChain` fell back to a keyless public RPC that **hangs (>40s observed on prod `chat.aomi.dev`)**, so the smart-account signature check never resolves → no Better Auth session is minted → every account-scoped call 401s. EOA wallets (MetaMask/Rabby) were unaffected (fast ecrecover, no RPC).

## Fix — no new env var

Resolve the RPC from the **existing** `ALCHEMY_API_KEY` / `NEXT_PUBLIC_ALCHEMY_API_KEY` (the same key the wallet/AA stack already uses; falls back to the shared default `72eIUle_…` when unset, mirroring `@aomi-labs/client`'s `resolveAlchemyApiKey`) plus a local Alchemy slug map mirroring `ALCHEMY_CHAIN_SLUGS`. Pre-existing `*_RPC_URL` overrides are kept as-is.

## Validation

- `pnpm --filter @aomi-labs/account exec tsc --noEmit` — clean
- Local e2e full SIWE flow (nonce → sign → verify): smart-account verify path **>40s hang → ~415ms**, even with `ALCHEMY_API_KEY` empty (default-key path); verify 200 + `better-auth.session_token` cookie → `/api/aomi/account` 200 → `/api/account` 200.
- Confirmed the default Alchemy key resolves `eth_blockNumber` on eth-mainnet and base-mainnet.

Recommend a smoke on a branch deploy with a real smart-account wallet before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)