### PR TITLE
fix(auth): let explicit BETTER_AUTH_URL win on Vercel preview (unblocks chat-staging login)

### DIFF
--- a/packages/account/src/better-auth/env.ts
+++ b/packages/account/src/better-auth/env.ts
@@ -93,19 +93,23 @@ function requiredDatabaseUrl(env: AccountAuthEnvInput): string {
 }
 
 function resolveBetterAuthUrl(env: AccountAuthEnvInput): string {
-  const vercelDeploymentUrl = firstUrl(env.VERCEL_BRANCH_URL, env.VERCEL_URL);
+  // An explicit override always wins, including on Vercel `preview`. Stable
+  // custom-alias deployments (e.g. chat-staging.aomi.dev fronting a `preview`
+  // build) are served on a host that is NOT the auto-detected *.vercel.app URL;
+  // deriving the SIWE domain / trusted origins from that URL breaks every login
+  // on the alias (domain/origin mismatch). Ephemeral PR previews leave this
+  // unset and keep the *.vercel.app fallback below.
+  const explicit = firstUrl(env.BETTER_AUTH_URL, env.AOMI_PORTAL_BASE_URL);
+  if (explicit) return explicit;
 
+  const vercelDeploymentUrl = firstUrl(env.VERCEL_BRANCH_URL, env.VERCEL_URL);
   if (env.VERCEL_ENV === "preview" && vercelDeploymentUrl) {
     return vercelDeploymentUrl;
   }
 
   return (
-    firstUrl(
-      env.BETTER_AUTH_URL,
-      env.AOMI_PORTAL_BASE_URL,
-      env.VERCEL_PROJECT_PRODUCTION_URL,
-      env.VERCEL_URL,
-    ) ?? "http://localhost:3001"
+    firstUrl(env.VERCEL_PROJECT_PRODUCTION_URL, env.VERCEL_URL) ??
+    "http://localhost:3001"
   );
 }
 

--- a/packages/account/test/env.test.ts
+++ b/packages/account/test/env.test.ts
@@ -56,10 +56,12 @@ describe("readAccountAuthEnv", () => {
     );
   });
 
-  it("derives preview auth URLs from arbitrary Vercel branch URLs", () => {
+  it("derives preview auth URLs from arbitrary Vercel branch URLs when no explicit override is set", () => {
+    // Ephemeral PR previews get a unique *.vercel.app URL and no BETTER_AUTH_URL,
+    // so auth derives from the branch URL (and AOMI_AUTH_DOMAIN is ignored on
+    // preview in favour of that derived host).
     const env = readAccountAuthEnv({
       BETTER_AUTH_SECRET: "preview-secret",
-      BETTER_AUTH_URL: "https://chat-staging.aomi.dev",
       DATABASE_URL: "postgresql://preview.example/aomi",
       NODE_ENV: "production",
       VERCEL_ENV: "preview",
@@ -84,6 +86,30 @@ describe("readAccountAuthEnv", () => {
       "https://chat-portal-git-codex-merge-bff-betterauth-aomi-labs.vercel.app",
       "https://chat-portal-random-deployment-id-aomi-labs.vercel.app",
       "https://chat.aomi.dev",
+    ]);
+  });
+
+  it("lets an explicit BETTER_AUTH_URL win on preview (stable custom-alias deploys)", () => {
+    // chat-staging.aomi.dev is a stable alias over a `preview` build; the browser
+    // is served on the alias, not the *.vercel.app URL, so auth must key off the
+    // explicit host or SIWE domain/origin checks reject every login.
+    const env = readAccountAuthEnv({
+      BETTER_AUTH_SECRET: "preview-secret",
+      BETTER_AUTH_URL: "https://chat-staging.aomi.dev",
+      DATABASE_URL: "postgresql://preview.example/aomi",
+      NODE_ENV: "production",
+      VERCEL_ENV: "preview",
+      VERCEL_BRANCH_URL: "chat-portal-git-main-aomi-labs.vercel.app",
+      VERCEL_URL: "chat-portal-random-deployment-id-aomi-labs.vercel.app",
+    });
+
+    expect(env.betterAuthUrl).toBe("https://chat-staging.aomi.dev");
+    expect(env.siweDomain).toBe("chat-staging.aomi.dev");
+    // still trusts the auto-detected preview URLs so the deploy's own hostname works
+    expect(env.trustedOrigins).toEqual([
+      "https://chat-staging.aomi.dev",
+      "https://chat-portal-git-main-aomi-labs.vercel.app",
+      "https://chat-portal-random-deployment-id-aomi-labs.vercel.app",
     ]);
   });
 

--- a/packages/client/test/client.unit.test.ts
+++ b/packages/client/test/client.unit.test.ts
@@ -11,13 +11,16 @@ describe("AomiClient route manifest", () => {
         `${endpoint.method} ${endpoint.path} [${endpoint.auth.join(", ")}]`,
     );
 
-    expect(routeKeys).toHaveLength(90);
+    expect(routeKeys).toHaveLength(95);
     expect(new Set(routeKeys).size).toBe(routeKeys.length);
     expect(routeKeys).toContain("GET /api/thread/apps [thread]");
     expect(routeKeys).toContain("GET /api/_internal/secrets [service]");
     expect(routeKeys).toContain("DELETE /api/_internal/secrets [service]");
     expect(routeKeys).toContain(
       "GET /api/integrations/github-app/user/sources/:id/deployments [service]",
+    );
+    expect(routeKeys).toContain(
+      "GET /api/integrations/github-app/user/sources/:id/observability [service]",
     );
     expect(routeKeys).toContain(
       "GET /api/platforms/:name/apps/:app/records [activation]",

--- a/packages/client/test/fixtures/backend-openapi.json
+++ b/packages/client/test/fixtures/backend-openapi.json
@@ -1214,6 +1214,91 @@
         ]
       }
     },
+    "/api/integrations/github-app/user/sources/{id}/agents": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "serviceBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/sources/{id}/transactions": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "serviceBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/sources/{id}/usage": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "serviceBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/sources/{id}/logs": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "serviceBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/sources/{id}/observability": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "serviceBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
     "/api/integrations/github-app/platforms/{name}/sources/create-from-template": {
       "post": {
         "responses": {

--- a/packages/client/test/generated/backend-routes.ts
+++ b/packages/client/test/generated/backend-routes.ts
@@ -165,12 +165,37 @@ export const AOMI_BACKEND_ENDPOINTS = [
   },
   {
     method: "GET",
+    path: "/api/integrations/github-app/user/sources/:id/agents",
+    auth: ["service"],
+  },
+  {
+    method: "GET",
     path: "/api/integrations/github-app/user/sources/:id/deployments",
     auth: ["service"],
   },
   {
     method: "GET",
     path: "/api/integrations/github-app/user/sources/:id/latest-deployment",
+    auth: ["service"],
+  },
+  {
+    method: "GET",
+    path: "/api/integrations/github-app/user/sources/:id/logs",
+    auth: ["service"],
+  },
+  {
+    method: "GET",
+    path: "/api/integrations/github-app/user/sources/:id/observability",
+    auth: ["service"],
+  },
+  {
+    method: "GET",
+    path: "/api/integrations/github-app/user/sources/:id/transactions",
+    auth: ["service"],
+  },
+  {
+    method: "GET",
+    path: "/api/integrations/github-app/user/sources/:id/usage",
     auth: ["service"],
   },
   {


### PR DESCRIPTION
## Why

`chat-staging.aomi.dev` login is broken: the settings page spins **"Connecting your account…"** forever and the account/usage page 401s, for every wallet.

## Root cause (confirmed on the live deploy via `vercel curl`)

`chat-staging.aomi.dev` is a **stable custom alias over a Vercel `preview`** (git-main) deployment. On `VERCEL_ENV=preview`, `resolveBetterAuthUrl` forces `betterAuthUrl` to the auto-detected `*.vercel.app` URL, and `siweDomain`/`trustedOrigins` derive from it. But the browser is on `chat-staging.aomi.dev`, so it signs the SIWE message with `domain: chat-staging.aomi.dev` → better-auth expects `chat-portal-git-main-…vercel.app` → **domain mismatch → SIWE `/verify` fast-rejects (`UNAUTHORIZED_SIWE_MESSAGE_MISMATCH`)** → no session → the settings gate retries for 30s ("Connecting your account…").

Proof (same valid EOA signature, only the message `domain` changed):
- `domain=chat-portal-git-main-…vercel.app` → **200**, session minted
- `domain=chat-staging.aomi.dev` (real browser) → **401** mismatch

This is distinct from the SIWE RPC hang (#298) — that's already deployed on staging and unrelated to this.

## Fix

Make an explicit `BETTER_AUTH_URL` / `AOMI_PORTAL_BASE_URL` take precedence **even on `preview`**. Ephemeral PR previews leave it unset and keep the `*.vercel.app` fallback, so they're unaffected. `betterAuthUrl` cascades to `siweDomain` (via `fallbackHost`) and `trustedOrigins`, so one override fixes domain + origin.

## Activate

Set `BETTER_AUTH_URL=https://chat-staging.aomi.dev` on the **chat-portal Preview env, scoped to the `main` branch** (so PR previews are untouched), then redeploy `chat-staging`.

## Validation
- `pnpm --filter @aomi-labs/account exec tsc --noEmit` — clean
- Local repro of the staging condition (`VERCEL_ENV=preview` + `VERCEL_URL=…vercel.app` + explicit `BETTER_AUTH_URL`): SIWE verify went **401 mismatch → 200 + session**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)