### PR TITLE
Tolerate stale deployment records

### DIFF
--- a/apps/aomi-build/src/features/launch/components/deployments/use-global-deployment-records.test.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/use-global-deployment-records.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+vi.mock("@build/features/launch/client", () => ({
+  deploymentSources: vi.fn(async () => ({
+    sources: [
+      {
+        id: 1,
+        repositoryLink: "ceciliaz030/my-aomi-bots",
+        apps: [{ name: "cecilia-test-2" }, { name: "geckoterminal" }],
+      },
+    ],
+  })),
+  deploymentSdkStatus: vi.fn(async () => null),
+  deploymentRecords: vi.fn(async ({ app }: { app: string }) => {
+    if (app === "cecilia-test-2") {
+      throw new Error("unknown app `cecilia-test-2`");
+    }
+    return {
+      app,
+      currentReleaseTag:
+        "apps-141779906-r229e1090c5-geckoterminal-cb7227310237",
+      records: [
+        {
+          deploymentId: "dep_gecko",
+          releaseTag: "apps-141779906-r229e1090c5-geckoterminal-cb7227310237",
+          actor: null,
+          createdAt: 1,
+          current: true,
+          sdkVersion: "3.0.1",
+        },
+      ],
+    };
+  }),
+}));
+
+vi.mock("@build/features/launch/dashboard", () => ({
+  fetchGitHubSession: vi.fn(async () => ({
+    signedIn: true,
+    githubLogin: "ceciliaz030",
+  })),
+}));
+
+import { deploymentRecords } from "@build/features/launch/client";
+import { useGlobalDeploymentRecords } from "./use-global-deployment-records";
+
+describe("useGlobalDeploymentRecords", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("ignores stale apps that no longer have deployment records", async () => {
+    const { result } = renderHook(() => useGlobalDeploymentRecords());
+
+    await waitFor(() =>
+      expect(result.current.recordsState.status).toBe("ready"),
+    );
+    expect(deploymentRecords).toHaveBeenCalledTimes(2);
+    expect(
+      result.current.recordsState.status === "ready"
+        ? result.current.recordsState.deployments
+        : [],
+    ).toMatchObject([
+      {
+        deploymentId: "dep_gecko",
+        sourceId: 1,
+        repositoryLink: "ceciliaz030/my-aomi-bots",
+      },
+    ]);
+  });
+});

--- a/apps/aomi-build/src/features/launch/components/deployments/use-global-deployment-records.ts
+++ b/apps/aomi-build/src/features/launch/components/deployments/use-global-deployment-records.ts
@@ -20,6 +20,12 @@ type RecordsState =
   | { status: "ready"; deployments: GlobalDeployment[] }
   | { status: "error"; error: string; deployments: GlobalDeployment[] };
 
+function isMissingAppRecords(err: unknown) {
+  return (
+    err instanceof Error && err.message.toLowerCase().includes("unknown app")
+  );
+}
+
 async function loadSourceDeployments(
   source: UserSource,
 ): Promise<GlobalDeployment[]> {
@@ -28,6 +34,11 @@ async function loadSourceDeployments(
       const result = await deploymentRecords({
         app: app.name,
         appSourceId: source.id,
+      }).catch((err: unknown) => {
+        if (isMissingAppRecords(err)) {
+          return { records: [] };
+        }
+        throw err;
       });
       return [app.name, result.records] as const;
     }),

--- a/apps/aomi-build/src/features/launch/hooks/use-project-detail.test.ts
+++ b/apps/aomi-build/src/features/launch/hooks/use-project-detail.test.ts
@@ -104,6 +104,20 @@ describe("useProjectDetail", () => {
     expect(result.current.recordsByApp).toEqual({});
   });
 
+  it("treats unknown app deployment records as an empty timeline", async () => {
+    vi.mocked(deploymentRecords).mockRejectedValueOnce(
+      new Error("unknown app `my-bot`"),
+    );
+    const { result } = renderHook(() => useProjectDetail(7));
+    await waitFor(() => expect(result.current.source?.id).toBe(7));
+
+    act(() => result.current.loadRecords());
+    await waitFor(() =>
+      expect(result.current.recordsByApp?.["my-bot"]).toEqual([]),
+    );
+    expect(result.current.recordsError).toBeNull();
+  });
+
   it("surfaces history load failures and allows retry", async () => {
     vi.mocked(deploymentHistory)
       .mockRejectedValueOnce(new Error("history failed (401)"))

--- a/apps/aomi-build/src/features/launch/hooks/use-project-detail.ts
+++ b/apps/aomi-build/src/features/launch/hooks/use-project-detail.ts
@@ -35,6 +35,12 @@ export type DeployFlowState =
 const DEPLOY_POLL_MS = 4000;
 const DEPLOY_TIMEOUT_MS = 8 * 60 * 1000;
 
+function isMissingAppRecords(err: unknown) {
+  return (
+    err instanceof Error && err.message.toLowerCase().includes("unknown app")
+  );
+}
+
 export function useProjectDetail(sourceId: number) {
   const [source, setSource] = useState<UserSource | null>(null);
   const [sdk, setSdk] = useState<LaunchSdkStatus | null>(null);
@@ -162,6 +168,11 @@ export function useProjectDetail(sourceId: number) {
           const result = await deploymentRecords({
             app: app.name,
             appSourceId: src.id,
+          }).catch((err: unknown) => {
+            if (isMissingAppRecords(err)) {
+              return { records: [] };
+            }
+            throw err;
           });
           return [app.name, result.records] as const;
         }),

--- a/packages/client/test/client.unit.test.ts
+++ b/packages/client/test/client.unit.test.ts
@@ -11,8 +11,9 @@ describe("AomiClient route manifest", () => {
         `${endpoint.method} ${endpoint.path} [${endpoint.auth.join(", ")}]`,
     );
 
-    expect(routeKeys).toHaveLength(95);
+    expect(routeKeys).toHaveLength(96);
     expect(new Set(routeKeys).size).toBe(routeKeys.length);
+    expect(routeKeys).toContain("POST /api/aa/v1/:chain_slug [thread]");
     expect(routeKeys).toContain("GET /api/thread/apps [thread]");
     expect(routeKeys).toContain("GET /api/_internal/secrets [service]");
     expect(routeKeys).toContain("DELETE /api/_internal/secrets [service]");

--- a/packages/client/test/fixtures/backend-openapi.json
+++ b/packages/client/test/fixtures/backend-openapi.json
@@ -114,6 +114,23 @@
         ]
       }
     },
+    "/api/aa/v1/{chain_slug}": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "threadId": []
+          }
+        ],
+        "x-aomi-auth": [
+          "thread"
+        ]
+      }
+    },
     "/api/_internal/secrets": {
       "post": {
         "responses": {

--- a/packages/client/test/generated/backend-routes.ts
+++ b/packages/client/test/generated/backend-routes.ts
@@ -305,6 +305,11 @@ export const AOMI_BACKEND_ENDPOINTS = [
   },
   {
     method: "POST",
+    path: "/api/aa/v1/:chain_slug",
+    auth: ["thread"],
+  },
+  {
+    method: "POST",
     path: "/api/account/app-keys",
     auth: ["account"],
   },


### PR DESCRIPTION
## Summary

- Treat source-keyed deployment record lookups that return `unknown app` as an empty timeline.
- Keep other deployment record errors surfaced normally.
- Add focused coverage for the global deployments fanout and project detail records tab.

## Root cause

The Deployments page fans out record requests for every app returned by the source list. A stale DB app such as `cecilia-test-2` can still be listed while the records endpoint returns `unknown app`, causing `Promise.all` to fail the entire page and render the red error.

## Validation

- `pnpm --filter aomi-build exec vitest run src/features/launch/hooks/use-project-detail.test.ts src/features/launch/components/deployments/use-global-deployment-records.test.tsx`