### PR TITLE
fix(deploy): wait for runtime and skip unaffected apps

### DIFF
--- a/apps/aomi-build/src/features/launch/hooks/use-project-detail.ts
+++ b/apps/aomi-build/src/features/launch/hooks/use-project-detail.ts
@@ -16,6 +16,7 @@ import {
   launchDeploy,
   launchStatus,
   launchActivate,
+  launchAppStatus,
 } from "@build/features/launch/client";
 import type {
   LaunchSdkStatus,
@@ -34,6 +35,8 @@ export type DeployFlowState =
 
 const DEPLOY_POLL_MS = 4000;
 const DEPLOY_TIMEOUT_MS = 8 * 60 * 1000;
+const RUNTIME_POLL_MS = 3000;
+const RUNTIME_POLL_ATTEMPTS = 30;
 
 function isMissingAppRecords(err: unknown) {
   return (
@@ -274,12 +277,48 @@ export function useProjectDetail(sourceId: number) {
         releaseTags,
         apps,
       });
-      const unloaded = activated.activation.apps.filter((app) => !app.loaded);
+      const activatedApps = activated.activation.apps;
+      for (let attempt = 0; attempt < RUNTIME_POLL_ATTEMPTS; attempt += 1) {
+        const checks = await Promise.all(
+          activatedApps.map((app) =>
+            launchAppStatus({
+              name: app.name,
+              releaseTag: app.releaseTag ?? undefined,
+            }),
+          ),
+        );
+        if (
+          checks.length > 0 &&
+          checks.every((check) => check.ok && check.state === "live")
+        ) {
+          setDeployFlow({ phase: "done", message: "New version is live." });
+          await reload();
+          refreshRecords();
+          return;
+        }
+        const terminal = checks.find(
+          (check) =>
+            check.app?.is_active === false && check.app?.loaded === false,
+        );
+        if (terminal) {
+          setDeployFlow({
+            phase: "error",
+            message: terminal.app?.name
+              ? `Runtime check failed for ${terminal.app.name}.`
+              : "Runtime reported a terminal error during activation.",
+          });
+          return;
+        }
+        setDeployFlow({
+          phase: "activating",
+          message: `Waiting for runtime… (${attempt + 1}/${RUNTIME_POLL_ATTEMPTS})`,
+        });
+        await new Promise((resolve) => setTimeout(resolve, RUNTIME_POLL_MS));
+      }
       setDeployFlow({
-        phase: unloaded.length ? "error" : "done",
-        message: unloaded.length
-          ? `Release selected, but ${unloaded.map((app) => app.name).join(", ")} is not loaded in this runtime.`
-          : "New version is live.",
+        phase: "error",
+        message:
+          "Activation was accepted, but the app artifact did not become ready.",
       });
       await reload();
       refreshRecords();

--- a/apps/portal/src/features/launch/hooks/use-project-detail.ts
+++ b/apps/portal/src/features/launch/hooks/use-project-detail.ts
@@ -16,6 +16,7 @@ import {
   launchDeploy,
   launchStatus,
   launchActivate,
+  launchAppStatus,
 } from "@portal/features/launch/client";
 import type {
   LaunchSdkStatus,
@@ -34,6 +35,8 @@ export type DeployFlowState =
 
 const DEPLOY_POLL_MS = 4000;
 const DEPLOY_TIMEOUT_MS = 8 * 60 * 1000;
+const RUNTIME_POLL_MS = 3000;
+const RUNTIME_POLL_ATTEMPTS = 30;
 
 export function useProjectDetail(sourceId: number) {
   const [source, setSource] = useState<UserSource | null>(null);
@@ -263,12 +266,48 @@ export function useProjectDetail(sourceId: number) {
         releaseTags,
         apps,
       });
-      const unloaded = activated.activation.apps.filter((app) => !app.loaded);
+      const activatedApps = activated.activation.apps;
+      for (let attempt = 0; attempt < RUNTIME_POLL_ATTEMPTS; attempt += 1) {
+        const checks = await Promise.all(
+          activatedApps.map((app) =>
+            launchAppStatus({
+              name: app.name,
+              releaseTag: app.releaseTag ?? undefined,
+            }),
+          ),
+        );
+        if (
+          checks.length > 0 &&
+          checks.every((check) => check.ok && check.state === "live")
+        ) {
+          setDeployFlow({ phase: "done", message: "New version is live." });
+          await reload();
+          refreshRecords();
+          return;
+        }
+        const terminal = checks.find(
+          (check) =>
+            check.app?.is_active === false && check.app?.loaded === false,
+        );
+        if (terminal) {
+          setDeployFlow({
+            phase: "error",
+            message: terminal.app?.name
+              ? `Runtime check failed for ${terminal.app.name}.`
+              : "Runtime reported a terminal error during activation.",
+          });
+          return;
+        }
+        setDeployFlow({
+          phase: "activating",
+          message: `Waiting for runtime… (${attempt + 1}/${RUNTIME_POLL_ATTEMPTS})`,
+        });
+        await new Promise((resolve) => setTimeout(resolve, RUNTIME_POLL_MS));
+      }
       setDeployFlow({
-        phase: unloaded.length ? "error" : "done",
-        message: unloaded.length
-          ? `Release selected, but ${unloaded.map((app) => app.name).join(", ")} is not loaded in this runtime.`
-          : "New version is live.",
+        phase: "error",
+        message:
+          "Activation was accepted, but the app artifact did not become ready.",
       });
       await reload();
       refreshRecords();

--- a/scripts/vercel-should-build.mjs
+++ b/scripts/vercel-should-build.mjs
@@ -1,0 +1,75 @@
+import { spawnSync } from "node:child_process";
+
+const project = process.argv[2];
+const projectPaths = {
+  "aomi-build": [
+    "apps/aomi-build",
+    "packages/account",
+    "packages/client",
+    "packages/deploy",
+    "packages/react",
+    "packages/widget-lib",
+  ],
+  base: [
+    "apps/base",
+    "packages/account",
+    "packages/client",
+    "packages/react",
+    "packages/widget-lib",
+  ],
+  landing: [
+    "apps/landing",
+    "apps/shadcn-registry",
+    "packages/account",
+    "packages/react",
+    "packages/widget-lib",
+  ],
+  portal: [
+    "apps/portal",
+    "packages/account",
+    "packages/client",
+    "packages/deploy",
+    "packages/react",
+    "packages/widget-lib",
+  ],
+  telegram: ["apps/telegram", "packages/client"],
+};
+const globalPaths = [
+  "package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "tsconfig.json",
+  "tsconfig.lib.json",
+  "next.config.ts",
+  "postcss.config.mjs",
+];
+
+if (!projectPaths[project]) {
+  console.error(`Unknown Vercel project: ${project}`);
+  process.exit(1);
+}
+
+const previous = process.env.VERCEL_GIT_PREVIOUS_SHA;
+const current = process.env.VERCEL_GIT_COMMIT_SHA ?? "HEAD";
+if (!previous) {
+  console.log("No previous Vercel commit; building.");
+  process.exit(1);
+}
+
+const result = spawnSync(
+  "git",
+  ["diff", "--quiet", previous, current, "--", ...globalPaths, ...projectPaths[project]],
+  { stdio: "inherit" },
+);
+
+if (result.error || result.status === null) {
+  console.error("Could not compare Vercel Git commits; building.");
+  process.exit(1);
+}
+
+if (result.status === 0) {
+  console.log(`No ${project} inputs changed; skipping build.`);
+  process.exit(0);
+}
+
+process.exit(1);


### PR DESCRIPTION
## What changed

- Deployment-console flows now poll the app-status endpoint after activation and mark a deployment live only once the runtime reports it ready.
- Added Vercel ignored-build filtering for Portal, Aomi Build, Base, Landing, and Telegram. Each project now skips previews when neither its app nor its workspace dependencies changed.

## Why

Activation starts artifact reconciliation asynchronously. The previous UI read the initial `loaded: false` response as a failure even when staging downloaded and validated the release moments later.

Every push also previously scheduled all Vercel projects, even for app-local changes. Shared workspace packages and root build inputs remain included so dependent apps still deploy safely.

## Validation

- `pnpm --filter aomi-build exec tsc --noEmit --project tsconfig.json`
- `pnpm --filter portal exec tsc --noEmit --project tsconfig.json`
- `node --check scripts/vercel-should-build.mjs`
- Verified this PR's diff: Portal and Aomi Build build; Base, Landing, and Telegram skip.
- `git diff --check`

Portal lint still has unrelated existing errors.