### PR TITLE
Fix MCP OAuth connect flow

### DIFF
--- a/apps/portal/src/app/api/auth/[...all]/route.ts
+++ b/apps/portal/src/app/api/auth/[...all]/route.ts
@@ -1,7 +1,15 @@
 import { auth } from "@aomi-labs/account/better-auth";
-import { toNextJsHandler } from "better-auth/next-js";
+import { withRegisteredMcpRedirectUri } from "@portal/server/mcp/oauth-redirect";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export const { GET, POST, PUT, PATCH, DELETE } = toNextJsHandler(auth);
+async function handleAuth(request: Request) {
+  return auth.handler(await withRegisteredMcpRedirectUri(request));
+}
+
+export const GET = handleAuth;
+export const POST = handleAuth;
+export const PUT = handleAuth;
+export const PATCH = handleAuth;
+export const DELETE = handleAuth;

--- a/apps/portal/src/app/mcp/connect/mcp-connect-client.tsx
+++ b/apps/portal/src/app/mcp/connect/mcp-connect-client.tsx
@@ -21,6 +21,9 @@ const providerLabels = { privy: "Privy", para: "Para" } as const;
 
 const STASH_KEY = "aomi.mcp.authorize.query";
 
+/** How long to wait for the provider modal before letting the user retry. */
+const PROVIDER_SIGN_IN_TIMEOUT_MS = 120_000;
+
 const SCOPE_DESCRIPTIONS: Record<string, string> = {
   openid: "Confirm your Aomi identity",
   profile: "Read your basic profile",
@@ -220,6 +223,22 @@ function ProviderSignIn({
     providerRequested,
     walletKit.getAccountCredential,
   ]);
+
+  // The provider modal can be dismissed without completing sign-in, in which
+  // case `getAccountCredential` never materializes and the effect above never
+  // fires. Without a deadline the page would sit disabled on "Complete
+  // sign-in..." forever; reset instead so the user can retry.
+  useEffect(() => {
+    if (!providerRequested || exchangeRequested || complete || !pending) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      setStatus(`${providerLabels[provider]} sign-in timed out. Try again.`);
+      setProviderRequested(false);
+      setPending(false);
+    }, PROVIDER_SIGN_IN_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [complete, exchangeRequested, pending, provider, providerRequested]);
 
   useEffect(() => {
     if (!exchangeRequested || complete || !pending) return;

--- a/apps/portal/src/app/mcp/connect/mcp-connect-client.tsx
+++ b/apps/portal/src/app/mcp/connect/mcp-connect-client.tsx
@@ -182,6 +182,7 @@ function ProviderSignIn({
   );
   const [pending, setPending] = useState(false);
   const [complete, setComplete] = useState(false);
+  const [providerRequested, setProviderRequested] = useState(false);
   const [exchangeRequested, setExchangeRequested] = useState(false);
 
   const start = useCallback(async () => {
@@ -189,15 +190,36 @@ function ProviderSignIn({
     setStatus(`Opening ${providerLabels[provider]}...`);
     try {
       await walletKit.connectSocial?.("google");
-      setStatus("Waiting for provider credential...");
-      setExchangeRequested(true);
+      setProviderRequested(true);
+      setStatus(`Complete sign-in in ${providerLabels[provider]}...`);
     } catch (error) {
       setStatus(
         error instanceof Error ? error.message : "Authentication failed",
       );
+      setProviderRequested(false);
       setPending(false);
     }
   }, [provider, walletKit]);
+
+  useEffect(() => {
+    if (
+      !providerRequested ||
+      exchangeRequested ||
+      complete ||
+      !pending ||
+      !walletKit.getAccountCredential
+    ) {
+      return;
+    }
+    setStatus("Waiting for provider credential...");
+    setExchangeRequested(true);
+  }, [
+    complete,
+    exchangeRequested,
+    pending,
+    providerRequested,
+    walletKit.getAccountCredential,
+  ]);
 
   useEffect(() => {
     if (!exchangeRequested || complete || !pending) return;
@@ -229,6 +251,7 @@ function ProviderSignIn({
         setStatus(
           error instanceof Error ? error.message : "Authentication failed",
         );
+        setExchangeRequested(false);
         setPending(false);
       }
     };

--- a/apps/portal/src/server/mcp/oauth-redirect.test.ts
+++ b/apps/portal/src/server/mcp/oauth-redirect.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  selectRegisteredRedirectUri,
+  withRegisteredMcpRedirectUri,
+} from "./oauth-redirect";
+
+describe("MCP OAuth redirect URI preservation", () => {
+  it("restores the registered loopback host when the auth stack normalizes redirect_uri", async () => {
+    const request = new Request(
+      "https://chat-staging.aomi.dev/api/auth/mcp/authorize?client_id=codex&redirect_uri=http%3A%2F%2Flocalhost%3A55633%2Fcallback%2FpZo_LEkWXZua&foo=http%3A%2F%2F127.0.0.1%3A1234%2Fx",
+    );
+
+    const corrected = await withRegisteredMcpRedirectUri(request, async () => [
+      "http://127.0.0.1:55633/callback/pZo_LEkWXZua",
+    ]);
+    const url = new URL(corrected.url);
+
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "http://127.0.0.1:55633/callback/pZo_LEkWXZua",
+    );
+    expect(url.searchParams.get("foo")).toBe("http://127.0.0.1:1234/x");
+  });
+
+  it("keeps an exact registered redirect URI unchanged", () => {
+    expect(
+      selectRegisteredRedirectUri("http://127.0.0.1:55633/callback/id", [
+        "http://127.0.0.1:55633/callback/id",
+      ]),
+    ).toBe("http://127.0.0.1:55633/callback/id");
+  });
+
+  it("does not substitute a redirect URI with a different callback path", () => {
+    expect(
+      selectRegisteredRedirectUri("http://localhost:55633/callback/id", [
+        "http://127.0.0.1:55633/callback/other",
+      ]),
+    ).toBeNull();
+  });
+});

--- a/apps/portal/src/server/mcp/oauth-redirect.ts
+++ b/apps/portal/src/server/mcp/oauth-redirect.ts
@@ -1,0 +1,78 @@
+import { getPool } from "@aomi-labs/account";
+
+const MCP_AUTHORIZE_PATH = "/api/auth/mcp/authorize";
+
+export async function withRegisteredMcpRedirectUri(
+  request: Request,
+  lookupRedirectUrls = registeredRedirectUrls,
+): Promise<Request> {
+  if (request.method !== "GET") return request;
+  const url = new URL(request.url);
+  if (url.pathname !== MCP_AUTHORIZE_PATH) return request;
+
+  const clientId = url.searchParams.get("client_id");
+  const redirectUri = url.searchParams.get("redirect_uri");
+  if (!clientId || !redirectUri) return request;
+
+  const registered = await lookupRedirectUrls(clientId).catch(() => []);
+  const exactRedirectUri = selectRegisteredRedirectUri(redirectUri, registered);
+  if (!exactRedirectUri || exactRedirectUri === redirectUri) return request;
+
+  url.searchParams.set("redirect_uri", exactRedirectUri);
+  return new Request(url.toString(), {
+    headers: request.headers,
+    method: request.method,
+  });
+}
+
+export function selectRegisteredRedirectUri(
+  redirectUri: string,
+  registeredRedirectUrls: readonly string[],
+): string | null {
+  if (registeredRedirectUrls.includes(redirectUri)) return redirectUri;
+  const requested = parseUrl(redirectUri);
+  if (!requested || !isLoopback(requested)) return null;
+
+  return (
+    registeredRedirectUrls.find((candidate) => {
+      const registered = parseUrl(candidate);
+      return (
+        registered &&
+        isLoopback(registered) &&
+        registered.protocol === requested.protocol &&
+        registered.port === requested.port &&
+        registered.pathname === requested.pathname &&
+        registered.search === requested.search
+      );
+    }) ?? null
+  );
+}
+
+async function registeredRedirectUrls(clientId: string): Promise<string[]> {
+  const result = await getPool().query<{ redirect_urls?: string }>(
+    "select redirect_urls from ba_oauth_applications where client_id = $1 limit 1",
+    [clientId],
+  );
+  const value = result.rows[0]?.redirect_urls;
+  return typeof value === "string"
+    ? value
+        .split(",")
+        .map((url) => url.trim())
+        .filter(Boolean)
+    : [];
+}
+
+function parseUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+function isLoopback(url: URL): boolean {
+  return (
+    url.protocol === "http:" &&
+    (url.hostname === "localhost" || url.hostname === "127.0.0.1")
+  );
+}

--- a/apps/portal/src/server/mcp/oauth-redirect.ts
+++ b/apps/portal/src/server/mcp/oauth-redirect.ts
@@ -2,6 +2,14 @@ import { getPool } from "@aomi-labs/account";
 
 const MCP_AUTHORIZE_PATH = "/api/auth/mcp/authorize";
 
+/**
+ * Something upstream of this route handler rewrites loopback `redirect_uri`
+ * hosts on the deployed stack (`127.0.0.1` -> `localhost`) — param-specific,
+ * so it is OAuth-aware, but it is NOT better-auth (1.6.19 does exact-match
+ * validation and no loopback rewriting; verified against its source) and not
+ * portal code. Rather than chase the platform layer, snap the param back to
+ * the client's registered URI, which holds regardless of which layer mutates.
+ */
 export async function withRegisteredMcpRedirectUri(
   request: Request,
   lookupRedirectUrls = registeredRedirectUrls,
@@ -14,7 +22,17 @@ export async function withRegisteredMcpRedirectUri(
   const redirectUri = url.searchParams.get("redirect_uri");
   if (!clientId || !redirectUri) return request;
 
-  const registered = await lookupRedirectUrls(clientId).catch(() => []);
+  const registered = await lookupRedirectUrls(clientId).catch(
+    (error: unknown) => {
+      // A silent [] here quietly disables the fix and resurfaces as an
+      // undebuggable "Invalid OAuth callback" at the client. Say something.
+      console.warn(
+        "mcp authorize: registered redirect_uri lookup failed; passing request through",
+        error,
+      );
+      return [];
+    },
+  );
   const exactRedirectUri = selectRegisteredRedirectUri(redirectUri, registered);
   if (!exactRedirectUri || exactRedirectUri === redirectUri) return request;
 


### PR DESCRIPTION
## Summary
- Preserve the exact registered MCP OAuth redirect URI before Better Auth handles /api/auth/mcp/authorize, so loopback 127.0.0.1 callbacks are not normalized to localhost.
- Wait for Para to expose the account credential before starting the MCP credential exchange. connectSocial only opens the modal; it does not mean the provider credential is ready.
- Reset the exchange state on failure so the connect page can retry cleanly.

## Root Cause
- The staging auth flow normalized the OAuth redirect_uri host from 127.0.0.1 to localhost while keeping the rest of the URL intact. Codex registered the 127.0.0.1 callback, so the exact redirect URI check failed later and the local callback saw "Invalid OAuth callback".
- The MCP connect UI treated walletKit.connectSocial("google") as a completed provider login, but the Para adapter only opens the modal. The page started polling getAccountCredential immediately, before that method was available after Para auth.

## Tests
- PASS: pnpm exec vitest run --config vitest.config.ts src/server/mcp/oauth-redirect.test.ts (from apps/portal)
- PASS: pnpm --filter portal type-check
- PASS: pnpm --filter portal exec eslint 'src/app/api/auth/[...all]/route.ts' src/app/mcp/connect/mcp-connect-client.tsx src/server/mcp/oauth-redirect.ts src/server/mcp/oauth-redirect.test.ts
- Known unrelated existing failure: full apps/portal vitest run fails in src/features/launch/components/deploy-step.test.tsx because the tests query duplicate visible text for Preflight / Deploy / Activate.