### PR TITLE
Fix Privy MCP connect callback flow

### DIFF
--- a/apps/portal/src/app/api/mcp/route.ts
+++ b/apps/portal/src/app/api/mcp/route.ts
@@ -1,8 +1,8 @@
 import { auth } from "@aomi-labs/account/better-auth";
-import { getOrCreateAomiUserForBetterAuthSession } from "@aomi-labs/account/account";
 import { withMcpAuth } from "better-auth/plugins";
 
 import { MCP_TOOLS, dispatchTool } from "@portal/server/mcp/tools";
+import { resolveMcpCanonicalUser } from "@portal/server/mcp/session";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -44,7 +44,11 @@ export const POST = withMcpAuth(auth, async (request, session) => {
   try {
     message = (await request.json()) as JsonRpcRequest;
   } catch {
-    return rpcError(null, -32700, "parse error: body must be a JSON-RPC message");
+    return rpcError(
+      null,
+      -32700,
+      "parse error: body must be a JSON-RPC message",
+    );
   }
   if (Array.isArray(message)) {
     return rpcError(null, -32600, "batch requests are not supported");
@@ -69,7 +73,7 @@ export const POST = withMcpAuth(auth, async (request, session) => {
         params?.arguments && typeof params.arguments === "object"
           ? (params.arguments as Record<string, unknown>)
           : {};
-      const canonicalUser = await getOrCreateAomiUserForBetterAuthSession({
+      const canonicalUser = await resolveMcpCanonicalUser({
         betterAuthUserId: session.userId,
       });
       const outcome = await dispatchTool(canonicalUser.id, name, args);

--- a/apps/portal/src/app/mcp/connect/mcp-connect-client.tsx
+++ b/apps/portal/src/app/mcp/connect/mcp-connect-client.tsx
@@ -14,15 +14,16 @@ import { CheckCircle2, Loader2, ShieldCheck } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { AomiWalletKitProvider, useAomiWalletKit } from "@aomi-labs/widget-lib";
 import { authClient } from "@aomi-labs/account/better-auth/client";
+import {
+  providerExchangeError,
+  waitForProviderCredential,
+} from "./provider-credential";
 
 type Provider = "privy" | "para";
 
 const providerLabels = { privy: "Privy", para: "Para" } as const;
 
 const STASH_KEY = "aomi.mcp.authorize.query";
-
-/** How long to wait for the provider modal before letting the user retry. */
-const PROVIDER_SIGN_IN_TIMEOUT_MS = 120_000;
 
 const SCOPE_DESCRIPTIONS: Record<string, string> = {
   openid: "Confirm your Aomi identity",
@@ -42,7 +43,11 @@ const SCOPE_DESCRIPTIONS: Record<string, string> = {
  *    deny via `POST /api/auth/oauth2/consent`, then follow `redirectURI`
  *    back to the MCP client's callback.
  */
-export function McpConnectClient({ clientName }: { clientName: string | null }) {
+export function McpConnectClient({
+  clientName,
+}: {
+  clientName: string | null;
+}) {
   const params = useSearchParams();
   const consentCode = params.get("consent_code");
   const isAuthorizeRequest =
@@ -185,71 +190,35 @@ function ProviderSignIn({
   );
   const [pending, setPending] = useState(false);
   const [complete, setComplete] = useState(false);
-  const [providerRequested, setProviderRequested] = useState(false);
   const [exchangeRequested, setExchangeRequested] = useState(false);
+  const connectSocial = walletKit.connectSocial;
+  const getAccountCredential = walletKit.getAccountCredential;
 
   const start = useCallback(async () => {
     setPending(true);
     setStatus(`Opening ${providerLabels[provider]}...`);
     try {
-      await walletKit.connectSocial?.("google");
-      setProviderRequested(true);
-      setStatus(`Complete sign-in in ${providerLabels[provider]}...`);
+      await connectSocial?.("google");
+      setStatus("Waiting for provider credential...");
+      setExchangeRequested(true);
     } catch (error) {
       setStatus(
         error instanceof Error ? error.message : "Authentication failed",
       );
-      setProviderRequested(false);
       setPending(false);
     }
-  }, [provider, walletKit]);
-
-  useEffect(() => {
-    if (
-      !providerRequested ||
-      exchangeRequested ||
-      complete ||
-      !pending ||
-      !walletKit.getAccountCredential
-    ) {
-      return;
-    }
-    setStatus("Waiting for provider credential...");
-    setExchangeRequested(true);
-  }, [
-    complete,
-    exchangeRequested,
-    pending,
-    providerRequested,
-    walletKit.getAccountCredential,
-  ]);
-
-  // The provider modal can be dismissed without completing sign-in, in which
-  // case `getAccountCredential` never materializes and the effect above never
-  // fires. Without a deadline the page would sit disabled on "Complete
-  // sign-in..." forever; reset instead so the user can retry.
-  useEffect(() => {
-    if (!providerRequested || exchangeRequested || complete || !pending) {
-      return;
-    }
-    const timer = setTimeout(() => {
-      setStatus(`${providerLabels[provider]} sign-in timed out. Try again.`);
-      setProviderRequested(false);
-      setPending(false);
-    }, PROVIDER_SIGN_IN_TIMEOUT_MS);
-    return () => clearTimeout(timer);
-  }, [complete, exchangeRequested, pending, provider, providerRequested]);
+  }, [connectSocial, provider]);
 
   useEffect(() => {
     if (!exchangeRequested || complete || !pending) return;
     let cancelled = false;
     const run = async () => {
       try {
-        setStatus("Creating Aomi session...");
-        const credential = await waitForCredential(() =>
-          walletKit.getAccountCredential?.(),
+        const credential = await waitForProviderCredential(() =>
+          getAccountCredential?.(),
         );
         if (cancelled) return;
+        setStatus("Creating Aomi session...");
         const exchange = await fetch("/api/auth/aomi/provider/exchange", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -257,7 +226,7 @@ function ProviderSignIn({
           body: JSON.stringify(credential),
         });
         if (!exchange.ok) {
-          throw new Error(`Provider exchange failed: HTTP ${exchange.status}`);
+          throw await providerExchangeError(exchange);
         }
         setComplete(true);
         setStatus("Signed in. Preparing authorization...");
@@ -278,7 +247,7 @@ function ProviderSignIn({
     return () => {
       cancelled = true;
     };
-  }, [complete, exchangeRequested, pending, walletKit]);
+  }, [complete, exchangeRequested, getAccountCredential, pending]);
 
   return (
     <Shell title={title}>
@@ -333,7 +302,9 @@ function ConsentPanel({
         if (!response.ok || typeof body?.redirectURI !== "string") {
           throw new Error(`Consent failed: HTTP ${response.status}`);
         }
-        setStatus(accept ? "Authorized. Returning to your client..." : "Denied.");
+        setStatus(
+          accept ? "Authorized. Returning to your client..." : "Denied.",
+        );
         window.location.assign(body.redirectURI);
       } catch (error) {
         setStatus(error instanceof Error ? error.message : "Consent failed");
@@ -347,8 +318,8 @@ function ConsentPanel({
   return (
     <Shell title={`${name} wants to connect`}>
       <p className="text-muted-foreground mt-3 text-sm">
-        Allow {name} to access your Aomi account? It will be able to act as
-        you through the Aomi tools you invoke from it.
+        Allow {name} to access your Aomi account? It will be able to act as you
+        through the Aomi tools you invoke from it.
       </p>
       <ul className="mt-5 grid gap-2">
         {scopes.map((scope) => (
@@ -398,16 +369,4 @@ function Shell({ children, title }: { children?: ReactNode; title: string }) {
       </section>
     </main>
   );
-}
-
-async function waitForCredential(
-  getCredential: () => Promise<unknown> | undefined,
-): Promise<unknown> {
-  const startedAt = Date.now();
-  while (Date.now() - startedAt < 30_000) {
-    const credential = await getCredential();
-    if (credential) return credential;
-    await new Promise((resolve) => setTimeout(resolve, 500));
-  }
-  throw new Error("Timed out waiting for provider credential");
 }

--- a/apps/portal/src/app/mcp/connect/provider-credential.test.ts
+++ b/apps/portal/src/app/mcp/connect/provider-credential.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  providerExchangeError,
+  waitForProviderCredential,
+} from "./provider-credential";
+
+describe("waitForProviderCredential", () => {
+  it("keeps polling until the provider exposes an exchangeable credential", async () => {
+    const credential = { provider: "privy", providerToken: "token" };
+    let calls = 0;
+
+    await expect(
+      waitForProviderCredential(
+        () => {
+          calls += 1;
+          return calls < 3 ? null : credential;
+        },
+        { attemptTimeoutMs: 2, pollMs: 1, timeoutMs: 50 },
+      ),
+    ).resolves.toBe(credential);
+    expect(calls).toBeGreaterThanOrEqual(3);
+  });
+
+  it("times out a provider credential promise that never resolves", async () => {
+    await expect(
+      waitForProviderCredential(() => new Promise(() => undefined), {
+        attemptTimeoutMs: 2,
+        pollMs: 1,
+        timeoutMs: 12,
+      }),
+    ).rejects.toThrow("Provider did not return an exchangeable credential");
+  });
+});
+
+describe("providerExchangeError", () => {
+  it("surfaces the BFF response message instead of hiding it behind a status", async () => {
+    const error = await providerExchangeError(
+      new Response(JSON.stringify({ message: "already_linked" }), {
+        status: 409,
+      }),
+    );
+
+    expect(error.message).toBe("Provider exchange failed: already_linked");
+  });
+});

--- a/apps/portal/src/app/mcp/connect/provider-credential.ts
+++ b/apps/portal/src/app/mcp/connect/provider-credential.ts
@@ -1,0 +1,59 @@
+const DEFAULT_CREDENTIAL_TIMEOUT_MS = 120_000;
+const DEFAULT_CREDENTIAL_POLL_MS = 500;
+const DEFAULT_CREDENTIAL_ATTEMPT_TIMEOUT_MS = 5_000;
+
+export async function waitForProviderCredential(
+  getCredential: () => Promise<unknown> | unknown,
+  options: {
+    timeoutMs?: number;
+    pollMs?: number;
+    attemptTimeoutMs?: number;
+  } = {},
+): Promise<unknown> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_CREDENTIAL_TIMEOUT_MS;
+  const pollMs = options.pollMs ?? DEFAULT_CREDENTIAL_POLL_MS;
+  const attemptTimeoutMs =
+    options.attemptTimeoutMs ?? DEFAULT_CREDENTIAL_ATTEMPT_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const credential = await resolveCredentialAttempt(
+      getCredential,
+      Math.min(attemptTimeoutMs, Math.max(1, deadline - Date.now())),
+    );
+    if (credential) return credential;
+    await sleep(Math.min(pollMs, Math.max(1, deadline - Date.now())));
+  }
+
+  throw new Error("Provider did not return an exchangeable credential");
+}
+
+export async function providerExchangeError(
+  response: Response,
+): Promise<Error> {
+  const body = (await response.json().catch(() => null)) as {
+    message?: unknown;
+    error?: unknown;
+  } | null;
+  const message =
+    typeof body?.message === "string"
+      ? body.message
+      : typeof body?.error === "string"
+        ? body.error
+        : `HTTP ${response.status}`;
+  return new Error(`Provider exchange failed: ${message}`);
+}
+
+async function resolveCredentialAttempt(
+  getCredential: () => Promise<unknown> | unknown,
+  timeoutMs: number,
+): Promise<unknown> {
+  return Promise.race([
+    Promise.resolve().then(getCredential),
+    sleep(timeoutMs),
+  ]);
+}
+
+function sleep(ms: number): Promise<undefined> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/portal/src/app/mcp/connect/provider-credential.ts
+++ b/apps/portal/src/app/mcp/connect/provider-credential.ts
@@ -16,13 +16,17 @@ export async function waitForProviderCredential(
     options.attemptTimeoutMs ?? DEFAULT_CREDENTIAL_ATTEMPT_TIMEOUT_MS;
   const deadline = Date.now() + timeoutMs;
 
-  while (Date.now() < deadline) {
+  for (let remainingMs = deadline - Date.now(); remainingMs > 0; ) {
     const credential = await resolveCredentialAttempt(
       getCredential,
-      Math.min(attemptTimeoutMs, Math.max(1, deadline - Date.now())),
+      Math.min(attemptTimeoutMs, remainingMs),
     );
     if (credential) return credential;
-    await sleep(Math.min(pollMs, Math.max(1, deadline - Date.now())));
+    remainingMs = deadline - Date.now();
+    if (remainingMs > 0) {
+      await sleep(Math.min(pollMs, remainingMs));
+    }
+    remainingMs = deadline - Date.now();
   }
 
   throw new Error("Provider did not return an exchangeable credential");

--- a/apps/portal/src/server/mcp/session.test.ts
+++ b/apps/portal/src/server/mcp/session.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const accountMocks = vi.hoisted(() => ({
+  getOrCreateAomiUserForBetterAuthSession: vi.fn(),
+  syncSiweWalletsForUser: vi.fn(),
+}));
+
+vi.mock("@aomi-labs/account/account", () => accountMocks);
+
+import { resolveMcpCanonicalUser } from "./session";
+
+describe("resolveMcpCanonicalUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    accountMocks.getOrCreateAomiUserForBetterAuthSession.mockResolvedValue({
+      id: "canonical-user-1",
+    });
+    accountMocks.syncSiweWalletsForUser.mockResolvedValue(undefined);
+  });
+
+  it("materializes SIWE wallets into public_keys before MCP tools run", async () => {
+    await expect(
+      resolveMcpCanonicalUser({ betterAuthUserId: "ba-user-1" }),
+    ).resolves.toEqual({ id: "canonical-user-1" });
+
+    expect(
+      accountMocks.getOrCreateAomiUserForBetterAuthSession,
+    ).toHaveBeenCalledWith({
+      betterAuthUserId: "ba-user-1",
+    });
+    expect(accountMocks.syncSiweWalletsForUser).toHaveBeenCalledWith({
+      aomiUserId: "canonical-user-1",
+      betterAuthUserId: "ba-user-1",
+    });
+  });
+});

--- a/apps/portal/src/server/mcp/session.ts
+++ b/apps/portal/src/server/mcp/session.ts
@@ -1,0 +1,27 @@
+import "server-only";
+
+import {
+  getOrCreateAomiUserForBetterAuthSession,
+  syncSiweWalletsForUser,
+} from "@aomi-labs/account/account";
+import type { DbAomiUser } from "@aomi-labs/account";
+
+export type McpBetterAuthUserSeed = {
+  betterAuthUserId: string;
+};
+
+/**
+ * MCP OAuth tokens carry the BetterAuth user id. Resolve it into Aomi's
+ * canonical account graph and materialize any SIWE wallet rows into
+ * `public_keys` before tool execution needs wallet policy.
+ */
+export async function resolveMcpCanonicalUser(
+  input: McpBetterAuthUserSeed,
+): Promise<DbAomiUser> {
+  const user = await getOrCreateAomiUserForBetterAuthSession(input);
+  await syncSiweWalletsForUser({
+    aomiUserId: user.id,
+    betterAuthUserId: input.betterAuthUserId,
+  });
+  return user;
+}

--- a/packages/account/src/better-auth/auth.ts
+++ b/packages/account/src/better-auth/auth.ts
@@ -8,6 +8,22 @@ import { verifySiweMessage } from "./siwe";
 import { aomiProviderAuthPlugin } from "./provider-plugin";
 
 const env = readAccountAuthEnv();
+const HEADLESS_MCP_AUTH_METADATA = {
+  aomi_headless_authentication: {
+    proof: "siwe",
+    nonce_endpoint: `${env.betterAuthUrl}/siwe/nonce`,
+    verify_endpoint: `${env.betterAuthUrl}/siwe/verify`,
+    oauth_register_endpoint: `${env.betterAuthUrl}/mcp/register`,
+    oauth_authorize_endpoint: `${env.betterAuthUrl}/mcp/authorize`,
+    oauth_token_endpoint: `${env.betterAuthUrl}/mcp/token`,
+    session_token_usage:
+      "Use the token returned by SIWE verify as Authorization: Bearer for MCP OAuth authorize, or keep the returned session cookie.",
+    public_key_policy:
+      "A public key is only an identifier; Aomi requires signed SIWE possession proof before MCP OAuth.",
+  },
+} as unknown as NonNullable<
+  NonNullable<Parameters<typeof mcp>[0]["oidcConfig"]>["metadata"]
+>;
 
 // BetterAuth's storage lives in the SAME database as the canonical account
 // graph, but under our house schema style: `ba_`-prefixed snake_case tables
@@ -141,7 +157,11 @@ export const auth = betterAuth({
         loginPage: "/mcp/connect",
         // `mcp()` copies its own `loginPage` over this one; the field is only
         // repeated because `OIDCOptions` requires it.
-        oidcConfig: { loginPage: "/mcp/connect", consentPage: "/mcp/connect" },
+        oidcConfig: {
+          loginPage: "/mcp/connect",
+          consentPage: "/mcp/connect",
+          metadata: HEADLESS_MCP_AUTH_METADATA,
+        },
       }),
     ),
     aomiProviderAuthPlugin(),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,14 +6,11 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
-    include: ["packages/**/*.{test,spec}.{ts,tsx,mjs,cjs,js,jsx}"],
-    exclude: [
-      ".claude/**",
-      "**/.claude/**",
-      "**/node_modules/**",
-      "apps/**",
-      "dist/**",
+    include: [
+      "packages/**/*.{test,spec}.{ts,tsx,mjs,cjs,js,jsx}",
+      "apps/portal/src/app/mcp/connect/provider-credential.test.ts",
     ],
+    exclude: [".claude/**", "**/.claude/**", "**/node_modules/**", "dist/**"],
     restoreMocks: true,
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,14 +1,37 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
+const currentDir = fileURLToPath(new URL(".", import.meta.url));
+
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      "@portal": resolve(currentDir, "apps/portal/src"),
+      "@aomi-labs/account": resolve(currentDir, "packages/account/src"),
+      "@aomi-labs/client": resolve(currentDir, "packages/client/src"),
+      "@aomi-labs/deploy": resolve(currentDir, "packages/deploy/src"),
+      "@aomi-labs/react": resolve(currentDir, "packages/react/src"),
+      "@aomi-labs/service": resolve(currentDir, "packages/service/src"),
+      "server-only": resolve(
+        currentDir,
+        "apps/portal/__mocks__/server-only.ts",
+      ),
+      "client-only": resolve(
+        currentDir,
+        "apps/portal/__mocks__/client-only.ts",
+      ),
+    },
+  },
   test: {
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
     include: [
       "packages/**/*.{test,spec}.{ts,tsx,mjs,cjs,js,jsx}",
-      "apps/portal/src/app/mcp/connect/provider-credential.test.ts",
+      "apps/portal/src/{app,server}/mcp/**/*.{test,spec}.{ts,tsx}",
     ],
     exclude: [".claude/**", "**/.claude/**", "**/node_modules/**", "dist/**"],
     restoreMocks: true,


### PR DESCRIPTION
## Summary
- start the MCP provider exchange after the provider handoff instead of waiting for the credential function to appear first
- add a bounded provider credential wait so a hung Privy/Para credential promise cannot freeze the connect page
- surface BFF provider-exchange messages instead of generic HTTP-only errors
- include the new app-level helper test in Vitest

## Tests
- pnpm exec vitest run apps/portal/src/app/mcp/connect/provider-credential.test.ts
- pnpm run typecheck:portal
- pnpm exec prettier --check vitest.config.ts apps/portal/src/app/mcp/connect/mcp-connect-client.tsx apps/portal/src/app/mcp/connect/provider-credential.ts apps/portal/src/app/mcp/connect/provider-credential.test.ts