### PR TITLE
feat(aomi-build): builders experience — Projects IA, Secrets picker, thin Environment

### DIFF
--- a/apps/aomi-build/BUILDERS-EXPERIENCE.md
+++ b/apps/aomi-build/BUILDERS-EXPERIENCE.md
@@ -1,0 +1,294 @@
+# Aomi Build — Builders' Experience Plan
+
+> **Status:** Not started  
+> **App:** `aomi/apps/aomi-build` → [build.aomi.dev](https://build.aomi.dev)  
+> **Owner:** Gordian (`0xgordian`)  
+> **Last updated:** 2026-07-12
+
+Execution plan for improving the **builders' experience** on Han's live Build app.  
+Not a redesign. Not a backend task. Not a rebuild of the mock portal.
+
+**Team visibility:** This file is the local source of truth for the work. Pair it with a Scrum Board issue (and optional `aomi-scrum` handoff) so Cecilia/Han can see status. Do not treat this markdown alone as team sync.
+
+---
+
+## Scope
+
+Work only in `aomi/apps/aomi-build`. Improve builders' experience on what Han already shipped.
+
+**Not** a redesign. **Not** a backend task. **Not** a rebuild of the mock.
+
+```mermaid
+flowchart TD
+  Must[Must_ship] --> P1[Phase1_Trust_IA]
+  P1 --> Gate1[Stop_and_review]
+  Gate1 --> P2[Phase2_Secrets_picker]
+  P2 --> Gate2[Stop_and_review]
+  Gate2 --> P3[Phase3_Thin_Environment]
+  P3 --> Gate3[Show_Cecilia_Han]
+  Gate3 --> Later[Polish_later]
+  Later --> P4[Phase4_Theme_tokens]
+  P4 --> P5[Phase5_Transactions]
+```
+
+---
+
+## Rules (so we don't spoil Han's work)
+
+1. **Clarify, don't invent** — every change must answer: *Where am I? What is this? What do I do next?*
+2. **Reuse his wiring** — `useProjects`, `useProjectDetail`, secrets BFF, operate APIs. No parallel data layer.
+3. **Smallest fix that works** — prefer a string/label change over a component rewrite.
+4. **Keep his behavior** — deploy promote/deactivate, write-only vault, GitHub session, existing routes.
+5. **One phase → pause → click-through** before the next. No "while we're here."
+6. **If unsure it was intentional** — leave it; note it. Don't guess-improve.
+
+---
+
+## Product principles
+
+- Builders own applications.
+- Builders configure environments.
+- Builders manage secrets.
+- End users should never think about API keys.
+- Every page should clearly answer: Where am I? What am I looking at? What should I do next?
+- Avoid dead ends. Prefer guidance over documentation. The UI should teach the product.
+- Direction: closer to **Vercel** than a traditional dashboard — without cloning Vercel feature-for-feature.
+
+---
+
+## Hard constraint
+
+Backend returns **secret names only**. Values are write-only.
+
+**Reveal is impossible** without a new API → **out of scope**.  
+UI may show masked `••••` as a *status affordance*, never as a real reveal control.
+
+---
+
+## Must-ship vs polish later
+
+| Tier | Phases | Why |
+|---|---|---|
+| **Must-ship** | 1 → 2 → thin 3 | Trust + Cecilia's builder-secrets rule |
+| **Polish later** | 4 → 5 | Only after 1–3 feel solid; don't block the product story |
+
+---
+
+## Phase 1 — Trust & IA (must-ship)
+
+**Goal:** Fix "where am I?" without visual redesign.
+
+| Change | File | Action |
+|---|---|---|
+| Projects title | `src/features/launch/components/deployments/project-index.tsx` | h1 `Deployments` → **Projects**; project-first subtitle |
+| Tab rename | `src/features/launch/components/deployments/project-page.tsx` | Label `Settings` → **Details**; keep `id: "settings"` |
+| Global copy | `src/features/launch/components/deployments/global-deployments-list.tsx` | "Deployment history across all projects." |
+| Project copy | `src/features/launch/components/deployments/tabs/deployments-tab.tsx` | "Deployment history for this project." |
+| Empty states (**thin**) | Projects, global Deployments, project Deployments, Environment, Transactions only | Why empty + one next action |
+
+**Do not** empty-state every panel in the app in this phase.
+
+```mermaid
+flowchart LR
+  SidebarProjects[Sidebar_Projects] --> PageProjects[Page_title_Projects]
+  SidebarDeployments[Sidebar_Deployments] --> GlobalHistory[All_projects_history]
+  ProjectTab[Project_Deployments_tab] --> OneProjectHistory[This_project_history]
+  ProjectDetails[Details_tab] --> Metadata[Repo_SDK_not_account]
+```
+
+**Done when:** Projects isn't mislabeled; Details ≠ Account Settings; global vs project Deployments are verbally distinct; worst empties aren't dead ends.
+
+**Stop gate:** Click Projects → open project → Global Deployments. Does it make sense?
+
+---
+
+## Phase 2 — Account → Secrets = project picker (must-ship)
+
+**Goal:** `/settings/secrets` teaches "secrets live on projects." Never a fake vault.
+
+```mermaid
+flowchart LR
+  Secrets["/settings/secrets"] --> N{project_count}
+  N -->|0| Empty["Explain + New app CTA"]
+  N -->|1| Auto["Replace to /projects/id?tab=environment"]
+  N -->|2plus| List["List projects → Environment"]
+```
+
+| Piece | Action |
+|---|---|
+| `src/app/(control-plane)/settings/[section]/page.tsx` | Keep server page; render client island when `slug === "secrets"` |
+| New `SettingsSecretsPanel` (client) | Uses `useProjects`; lists / routes only |
+| `src/app/(control-plane)/settings/settings-data.ts` | Remove broken `actionHref` to `/operate/deployments?tab=environment` |
+| Links | Only `/projects/{id}?tab=environment` |
+
+**Do not** add a secret editor on this page.
+
+**Done when:** No dead button; 0 / 1 / 2+ behaviors work; builders land in Environment.
+
+**Stop gate:** Open `/settings/secrets` signed in. Does it feel like guidance, not a broken settings page?
+
+---
+
+## Phase 3 — Thin Environment (must-ship, highest product value)
+
+**Goal:** Honest builder vault — **not** a Vercel clone.
+
+Primary: `src/features/launch/components/deployments/tabs/environment-tab.tsx`  
+APIs unchanged: `loadSecrets` / `setEnvVars` / `deleteEnvVar`
+
+```mermaid
+flowchart TD
+  EnvTab[Environment_tab] --> Story[One_vault_story]
+  Story --> Add[Add_key_value]
+  Story --> List[Configured_keys]
+  List --> Row["name + Builder_secret + Runtime + dots"]
+  Row --> Actions[Copy_key / Overwrite / Delete]
+  List --> NoReveal[No_Reveal]
+```
+
+**Do:**
+- One vault story (stop implying Env vs Secret are different backends)
+- Configured rows: name, badges, `••••`, Copy key / overwrite / Delete
+- Empty copy: builders set keys here; chat users never paste them
+- Keep multi-app scope tabs when needed
+
+**Don't:**
+- Provider grouping (OpenAI / Anthropic / …)
+- Reveal
+- New APIs
+- Full tab chrome redesign
+
+**Done when:** Cecilia's rule is obvious in the UI.
+
+**Stop gate:** Show Cecilia/Han. Ready for chat work only after this feels clear — Phase 4–5 are optional polish.
+
+---
+
+## Phase 4 — Theme consistency (polish later)
+
+**Goal:** Same dark shell language. Token swap only — no redesign.
+
+Restyle zinc/`bg-white` on project/deploy surfaces:
+`project-page`, `project-index`, `project-header`, `project-row`, `global-deployments-list`, tabs, shared `deployments/ui/*`
+
+Leave Overview / Operate / New app alone (already dark).
+
+**Diff should look like class renames**, not a new design system.
+
+**Only start after Phase 3 stop gate passes.**
+
+---
+
+## Phase 5 — Transactions (polish later)
+
+**Goal:** Slightly denser operate table from fields already on the wire.
+
+`src/features/operate/operate-view.tsx`: keep Time / App / Status / Chain / To / Hash; add `fromAddress`, `value`, `description`; better empty state; truncate addresses.
+
+No new filters product.
+
+---
+
+## Onboarding (threaded, not a new system)
+
+No separate onboarding product. Guide via Phase 1 empties + existing New app / Onboarding wizard:
+
+| Moment | Next action |
+|---|---|
+| Not signed in | Continue with GitHub |
+| No projects | New app |
+| No deploys | Deploy CTA on project |
+| No env vars | Environment empty + builder copy |
+| Account Secrets | Phase 2 picker |
+
+---
+
+## Mental model (what the UI must teach)
+
+```mermaid
+flowchart TD
+  Account[Account] --> GitHub[GitHub_sign_in]
+  Account --> AccSettings["/settings mostly future"]
+  Account --> SecretsSignpost["/settings/secrets = picker only"]
+  Project[Project] --> DepTab[Deployments_this_project]
+  Project --> EnvTab[Environment_real_secrets]
+  Project --> ChatTab[Chat]
+  Project --> DetailsTab[Details_metadata]
+  Operate[Operate] --> GlobalDep[All_deployments]
+  Operate --> Txs[Transactions]
+```
+
+**Account** = sidebar group (Settings + GitHub session), not a separate page.  
+**Two Settings:** Account `/settings` vs project **Details** tab (renamed from Settings) — do not conflate them.
+
+**Cecilia rule:** builders set secrets on **Project → Environment**. Chat users never paste API keys.
+
+---
+
+## Out of scope
+
+- Sidebar / nav redesign  
+- Backend, APIs, auth, deploy architecture  
+- Chat / Smithers Build page  
+- Reveal / value read-back  
+- Global account secret store  
+- Provider-grouped env UI  
+- New onboarding system  
+
+---
+
+## Commit order
+
+**Must-ship**
+1. Projects title + Details tab  
+2. Deployment scope copy + thin empty states  
+3. Settings secrets → project picker  
+4. Thin Environment vault UX  
+
+**Then pause for review**
+
+**Polish later**
+5. Dark tokens on project/deploy pages  
+6. Transactions density  
+
+---
+
+## Click-through checklist (every phase)
+
+1. Sign out → sign in  
+2. Projects → open a project  
+3. Global Deployments vs project Deployments tab  
+4. Account Settings → Secrets  
+5. Project → Environment  
+
+If anything feels worse than before → revert that piece.
+
+---
+
+## Done enough (before chat work)
+
+- Projects isn't mislabeled  
+- Secrets path isn't a dead end  
+- Environment clearly owns builder secrets  
+- Theme/txs either done or consciously deferred  
+
+---
+
+## Team sync (how others know)
+
+| Channel | Use |
+|---|---|
+| This file | Local execution plan + stop gates |
+| Scrum Board issue | Team-visible "what Gordian is working on" |
+| PR on `aomi` | Reviewable code + file touch list |
+| `aomi-scrum` handoff | Only when packaging context for a teammate |
+
+Skills in `product-mono/.agents/skills` (`track-work-on-kanban`, `handoff-bridge`) are **how** agents publish to the board / `aomi-scrum` — they do not replace a board card or PR.
+
+---
+
+## One sentence
+
+**Ship Phases 1 → 2 → thin 3 with stop gates, reuse Han's wiring, and only then polish theme and transactions — that's the builders' experience plan.**
+
+Say **start Phase 1** when ready to implement.

--- a/apps/aomi-build/BUILDERS-EXPERIENCE.md
+++ b/apps/aomi-build/BUILDERS-EXPERIENCE.md
@@ -1,8 +1,9 @@
 # Aomi Build — Builders' Experience Plan
 
-> **Status:** Not started  
+> **Status:** Phase 1 in progress (trust & IA)  
 > **App:** `aomi/apps/aomi-build` → [build.aomi.dev](https://build.aomi.dev)  
 > **Owner:** Gordian (`0xgordian`)  
+> **Branch:** `feat/builders-experience-phase-1`  
 > **Last updated:** 2026-07-12
 
 Execution plan for improving the **builders' experience** on Han's live Build app.  

--- a/apps/aomi-build/BUILDERS-EXPERIENCE.md
+++ b/apps/aomi-build/BUILDERS-EXPERIENCE.md
@@ -1,6 +1,6 @@
 # Aomi Build — Builders' Experience Plan
 
-> **Status:** Phase 1 in progress (trust & IA)  
+> **Status:** Phase two in progress (secrets project picker)  
 > **App:** `aomi/apps/aomi-build` → [build.aomi.dev](https://build.aomi.dev)  
 > **Owner:** Gordian (`0xgordian`)  
 > **Branch:** `feat/builders-experience-phase-1`  

--- a/apps/aomi-build/BUILDERS-EXPERIENCE.md
+++ b/apps/aomi-build/BUILDERS-EXPERIENCE.md
@@ -1,6 +1,6 @@
 # Aomi Build — Builders' Experience Plan
 
-> **Status:** Phase two in progress (secrets project picker)  
+> **Status:** Phase three done — stop for Cecilia/Han review  
 > **App:** `aomi/apps/aomi-build` → [build.aomi.dev](https://build.aomi.dev)  
 > **Owner:** Gordian (`0xgordian`)  
 > **Branch:** `feat/builders-experience-phase-1`  

--- a/apps/aomi-build/src/app/(control-plane)/settings/[section]/page.tsx
+++ b/apps/aomi-build/src/app/(control-plane)/settings/[section]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { getSettingsSection, settingsSections } from "../settings-data";
+import { SettingsSecretsPanel } from "../settings-secrets-panel";
 
 export function generateStaticParams() {
   return settingsSections.map((section) => ({ section: section.slug }));
@@ -37,20 +38,24 @@ export default async function SettingsSectionPage({
         <p className="max-w-2xl text-sm text-subtle">{section.description}</p>
       </div>
 
-      <section className="rounded-lg border border-border bg-surface-1 p-4">
-        <div className="text-sm font-medium text-foreground">
-          {section.enabled ? "Current state" : "Not available yet"}
-        </div>
-        <p className="mt-2 text-[13px] text-dim">{section.detail}</p>
-        {section.actionHref ? (
-          <Link
-            href={section.actionHref}
-            className="mt-4 inline-flex h-8 items-center rounded-md bg-primary px-3 text-[12px] font-medium text-primary-foreground transition hover:bg-brand-hover"
-          >
-            {section.actionLabel}
-          </Link>
-        ) : null}
-      </section>
+      {slug === "secrets" ? (
+        <SettingsSecretsPanel />
+      ) : (
+        <section className="rounded-lg border border-border bg-surface-1 p-4">
+          <div className="text-sm font-medium text-foreground">
+            {section.enabled ? "Current state" : "Not available yet"}
+          </div>
+          <p className="mt-2 text-[13px] text-dim">{section.detail}</p>
+          {section.actionHref ? (
+            <Link
+              href={section.actionHref}
+              className="mt-4 inline-flex h-8 items-center rounded-md bg-primary px-3 text-[12px] font-medium text-primary-foreground transition hover:bg-brand-hover"
+            >
+              {section.actionLabel}
+            </Link>
+          ) : null}
+        </section>
+      )}
     </div>
   );
 }

--- a/apps/aomi-build/src/app/(control-plane)/settings/settings-data.ts
+++ b/apps/aomi-build/src/app/(control-plane)/settings/settings-data.ts
@@ -38,14 +38,13 @@ export const settingsSections: SettingsSection[] = [
   {
     slug: "secrets",
     title: "Secrets",
-    description: "Deployment and runtime environment values.",
+    description:
+      "Per-project environment values. Pick a project to manage its secrets.",
     icon: KeyRound,
     enabled: true,
     status: "project-scoped",
     detail:
-      "Secrets are already implemented per project in the deployment Environment tab. There is no global secret store in this app yet.",
-    actionHref: "/operate/deployments?tab=environment",
-    actionLabel: "Open project environment",
+      "Secrets live on each project Environment tab. There is no account-wide secret store — choose a project below.",
   },
   {
     slug: "notifications",

--- a/apps/aomi-build/src/app/(control-plane)/settings/settings-secrets-panel.test.tsx
+++ b/apps/aomi-build/src/app/(control-plane)/settings/settings-secrets-panel.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+const replace = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+}));
+
+vi.mock("@build/features/launch/hooks/use-projects", () => ({
+  useProjects: vi.fn(),
+}));
+
+import { useProjects } from "@build/features/launch/hooks/use-projects";
+import { SettingsSecretsPanel } from "./settings-secrets-panel";
+
+const useProjectsMock = vi.mocked(useProjects);
+
+describe("SettingsSecretsPanel", () => {
+  beforeEach(() => {
+    replace.mockReset();
+    useProjectsMock.mockReset();
+  });
+
+  it("shows New app when there are no projects", () => {
+    useProjectsMock.mockReturnValue({
+      state: {
+        status: "ready",
+        sources: [],
+        sdk: null,
+        github: { signedIn: true, githubLogin: "alice", githubUserId: "1" },
+      },
+      reload: vi.fn(),
+    });
+
+    render(<SettingsSecretsPanel />);
+    expect(screen.getByText(/No projects yet/i)).toBeTruthy();
+    expect(screen.getByRole("link", { name: /New app/i })).toHaveAttribute(
+      "href",
+      "/operate/deployments/new",
+    );
+  });
+
+  it("auto-routes a single project to its Environment tab", async () => {
+    useProjectsMock.mockReturnValue({
+      state: {
+        status: "ready",
+        sources: [
+          {
+            id: 7,
+            installationId: 1,
+            repositoryLink: "alice/only-bot",
+            apps: [],
+            latestDeployment: null,
+          },
+        ],
+        sdk: null,
+        github: { signedIn: true, githubLogin: "alice", githubUserId: "1" },
+      },
+      reload: vi.fn(),
+    });
+
+    render(<SettingsSecretsPanel />);
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith("/projects/7?tab=environment"),
+    );
+  });
+
+  it("lists projects that deep-link to Environment", () => {
+    useProjectsMock.mockReturnValue({
+      state: {
+        status: "ready",
+        sources: [
+          {
+            id: 3,
+            installationId: 1,
+            repositoryLink: "alice/bot",
+            apps: [],
+            latestDeployment: null,
+          },
+          {
+            id: 4,
+            installationId: 1,
+            repositoryLink: "alice/other",
+            apps: [],
+            latestDeployment: null,
+          },
+        ],
+        sdk: null,
+        github: { signedIn: true, githubLogin: "alice", githubUserId: "1" },
+      },
+      reload: vi.fn(),
+    });
+
+    render(<SettingsSecretsPanel />);
+    expect(screen.getByRole("link", { name: /alice\/bot/i })).toHaveAttribute(
+      "href",
+      "/projects/3?tab=environment",
+    );
+    expect(screen.getByRole("link", { name: /alice\/other/i })).toHaveAttribute(
+      "href",
+      "/projects/4?tab=environment",
+    );
+    expect(replace).not.toHaveBeenCalled();
+  });
+});

--- a/apps/aomi-build/src/app/(control-plane)/settings/settings-secrets-panel.tsx
+++ b/apps/aomi-build/src/app/(control-plane)/settings/settings-secrets-panel.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowRight } from "lucide-react";
+
+import { useProjects } from "@build/features/launch/hooks/use-projects";
+import {
+  ErrorPanel,
+  GitHubSignInPanel,
+  LoadingPanel,
+} from "@build/features/launch/components/deployments/ui/state-panels";
+
+function environmentHref(sourceId: number) {
+  return `/projects/${sourceId}?tab=environment`;
+}
+
+function projectLabel(source: {
+  id: number;
+  repositoryLink?: string | null;
+}) {
+  return source.repositoryLink?.trim() || `Project ${source.id}`;
+}
+
+export function SettingsSecretsPanel() {
+  const router = useRouter();
+  const { state } = useProjects();
+
+  useEffect(() => {
+    if (state.status !== "ready") return;
+    if (state.sources.length !== 1) return;
+    const only = state.sources[0];
+    if (!only) return;
+    router.replace(environmentHref(only.id));
+  }, [router, state]);
+
+  if (state.status === "loading") {
+    return <LoadingPanel label="Loading projects…" />;
+  }
+
+  if (state.status === "signed_out") {
+    return <GitHubSignInPanel error={null} />;
+  }
+
+  if (state.status === "error") {
+    return <ErrorPanel message={state.error} />;
+  }
+
+  if (state.sources.length === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-surface-1 p-4">
+        <div className="text-sm font-medium text-foreground">
+          No projects yet
+        </div>
+        <p className="mt-2 text-[13px] text-dim">
+          Secrets are managed per project. Import a GitHub repository first,
+          then set environment values on that project&apos;s Environment tab.
+        </p>
+        <Link
+          href="/operate/deployments/new"
+          className="mt-4 inline-flex h-8 items-center rounded-md bg-primary px-3 text-[12px] font-medium text-primary-foreground transition hover:bg-brand-hover"
+        >
+          New app
+        </Link>
+      </div>
+    );
+  }
+
+  if (state.sources.length === 1) {
+    return <LoadingPanel label="Opening project environment…" />;
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-lg border border-border bg-surface-1 p-4">
+        <div className="text-sm font-medium text-foreground">
+          Secrets are managed per project
+        </div>
+        <p className="mt-2 text-[13px] text-dim">
+          Choose a project to manage its environment variables and secrets.
+          There is no account-wide secret store.
+        </p>
+      </div>
+
+      <ul className="divide-border overflow-hidden rounded-lg border border-border bg-surface-1 divide-y">
+        {state.sources.map((source) => (
+          <li key={source.id}>
+            <Link
+              href={environmentHref(source.id)}
+              className="hover:bg-accent-hover flex items-center justify-between gap-3 px-4 py-3 transition"
+            >
+              <div className="min-w-0">
+                <div className="text-foreground truncate text-sm font-medium">
+                  {projectLabel(source)}
+                </div>
+                <div className="text-dim mt-0.5 text-xs">
+                  Environment →
+                </div>
+              </div>
+              <ArrowRight className="text-dim size-4 shrink-0" aria-hidden />
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/aomi-build/src/features/launch/components/deployments/global-deployments-list.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/global-deployments-list.tsx
@@ -95,8 +95,7 @@ export function GlobalDeploymentsList() {
               Deployments
             </h1>
             <p className="mt-1 text-sm text-zinc-500">
-              All project deployments. Use the project filter without leaving
-              this deployments view.
+              Deployment history across all projects.
             </p>
           </div>
           <div className="flex shrink-0 items-center gap-2">
@@ -207,7 +206,27 @@ export function GlobalDeploymentsList() {
           ) : recordsState.status === "error" ? (
             <ErrorPanel message={recordsState.error} />
           ) : filtered.length === 0 ? (
-            <EmptyPanel>No deployments match the current filters.</EmptyPanel>
+            <EmptyPanel>
+              {deployments.length === 0 ? (
+                <div className="flex flex-col items-center gap-3">
+                  <p>
+                    No deployments yet. Deploy an app from a connected project
+                    to see history here.
+                  </p>
+                  <Link
+                    href="/operate/deployments/new"
+                    className="inline-flex h-8 items-center justify-center rounded-md bg-zinc-900 px-3 text-sm font-medium text-white hover:bg-zinc-800"
+                  >
+                    New app
+                  </Link>
+                </div>
+              ) : (
+                <p>
+                  No deployments match the current filters. Clear filters or
+                  pick another project.
+                </p>
+              )}
+            </EmptyPanel>
           ) : (
             <div className="divide-y divide-zinc-100">
               {filtered.map((deployment) => (

--- a/apps/aomi-build/src/features/launch/components/deployments/project-index.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/project-index.tsx
@@ -27,10 +27,10 @@ export function ProjectIndex() {
         <div className="flex items-center justify-between gap-4">
           <div className="min-w-0">
             <h1 className="text-2xl font-semibold tracking-normal">
-              Deployments
+              Projects
             </h1>
             <p className="mt-1 text-sm text-zinc-500">
-              Your connected projects and their latest deployments.
+              GitHub repositories connected as Aomi apps.
             </p>
           </div>
           <div className="flex shrink-0 items-center gap-2">
@@ -72,7 +72,20 @@ export function ProjectIndex() {
             <GitHubSignInPanel error={githubError} />
           )}
           {state.status === "ready" && state.sources.length === 0 && (
-            <EmptyPanel>No projects yet.</EmptyPanel>
+            <EmptyPanel>
+              <div className="flex flex-col items-center gap-3">
+                <p>
+                  No projects yet. Import a GitHub repository to deploy your
+                  first app.
+                </p>
+                <a
+                  href="/operate/deployments/new"
+                  className="inline-flex h-8 items-center justify-center rounded-md bg-zinc-900 px-3 text-sm font-medium text-white hover:bg-zinc-800"
+                >
+                  New app
+                </a>
+              </div>
+            </EmptyPanel>
           )}
           {state.status === "ready" &&
             state.sources.map((source) => (

--- a/apps/aomi-build/src/features/launch/components/deployments/project-page.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/project-page.tsx
@@ -13,7 +13,7 @@ const TABS = [
   { id: "deployments", label: "Deployments" },
   { id: "chat", label: "Chat" },
   { id: "environment", label: "Environment" },
-  { id: "settings", label: "Settings" },
+  { id: "settings", label: "Details" },
 ] as const;
 type TabId = (typeof TABS)[number]["id"];
 

--- a/apps/aomi-build/src/features/launch/components/deployments/tabs/deployments-tab.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/tabs/deployments-tab.tsx
@@ -170,6 +170,9 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
 
   return (
     <div>
+      <div className="border-b border-zinc-100 px-4 py-2 text-xs text-zinc-500">
+        Deployment history for this project.
+      </div>
       <div className="flex items-center justify-between gap-3 border-b border-zinc-100 px-4 py-3">
         <div
           role="tablist"
@@ -271,7 +274,15 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
       deployments.length === 0 &&
       !detail.recordsError ? (
         <EmptyPanel>
-          No deployments yet. Use “Deploy new version” to publish this project.
+          <div className="flex flex-col items-center gap-2">
+            <p>
+              No deployments yet for this project. Use{" "}
+              <span className="font-medium text-zinc-700">
+                Deploy new version
+              </span>{" "}
+              to publish.
+            </p>
+          </div>
         </EmptyPanel>
       ) : view === "deployments" && deployments.length > 0 ? (
         deployments.map((deployment) => {

--- a/apps/aomi-build/src/features/launch/components/deployments/tabs/environment-tab.test.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/tabs/environment-tab.test.tsx
@@ -1,9 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { EnvironmentTab } from "./environment-tab";
 
 const setEnvVars = vi.fn(async () => ({ ok: true, keys: ["API_KEY"] }));
 const deleteEnvVar = vi.fn(async () => ({ ok: true, removed: true }));
+const writeText = vi.fn(async () => undefined);
 
 const detail = {
   source: {
@@ -23,49 +24,73 @@ const detail = {
 >;
 
 describe("EnvironmentTab", () => {
+  beforeEach(() => {
+    setEnvVars.mockClear();
+    deleteEnvVar.mockClear();
+    writeText.mockClear();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
   it("loads secrets on mount and lists configured keys (names only)", () => {
     render(<EnvironmentTab detail={detail} />);
     expect(detail.loadSecrets).toHaveBeenCalled();
-    // The handle prefix is stripped for display.
     expect(screen.getByText("EXISTING_KEY")).toBeInTheDocument();
-    expect(screen.getByText("Env")).toBeInTheDocument();
-    expect(screen.getAllByText("Secret").length).toBeGreaterThan(0);
+    expect(screen.getByText("Builder secret")).toBeInTheDocument();
+    expect(screen.getByText("Runtime")).toBeInTheDocument();
+    expect(screen.getByLabelText("Value hidden")).toHaveTextContent("••••");
     expect(
       screen.getByRole("button", { name: /save values/i }),
     ).toBeInTheDocument();
+    expect(screen.queryByText("Env")).not.toBeInTheDocument();
   });
 
-  it("writes plain env and masked secret values", async () => {
+  it("tells one vault story in the helper copy", () => {
     render(<EnvironmentTab detail={detail} />);
-    const envValue = screen.getByLabelText("Environment variables value");
-    const secretValue = screen.getByLabelText("Secrets value");
-    expect(envValue).toHaveAttribute("type", "text");
-    expect(secretValue).toHaveAttribute("type", "password");
+    expect(
+      screen.getByText(/one vault for/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/chat users never paste api keys/i),
+    ).toBeInTheDocument();
+  });
 
-    fireEvent.change(screen.getByLabelText("Environment variables key"), {
+  it("writes masked vault values through the single editor", async () => {
+    render(<EnvironmentTab detail={detail} />);
+    const value = screen.getByLabelText("Environment value");
+    expect(value).toHaveAttribute("type", "password");
+
+    fireEvent.change(screen.getByLabelText("Environment key"), {
       target: { value: "API_KEY" },
     });
-    fireEvent.change(envValue, {
-      target: { value: "public" },
-    });
-    fireEvent.change(screen.getByLabelText("Secrets key"), {
-      target: { value: "TOKEN" },
-    });
-    fireEvent.change(secretValue, {
+    fireEvent.change(value, {
       target: { value: "secret" },
     });
     fireEvent.click(screen.getByRole("button", { name: /save values/i }));
     await waitFor(() =>
       expect(setEnvVars).toHaveBeenCalledWith("demo", {
-        API_KEY: "public",
-        TOKEN: "secret",
+        API_KEY: "secret",
       }),
     );
   });
 
-  it("removes a configured var", async () => {
+  it("copies, overwrites, and deletes configured keys", async () => {
     render(<EnvironmentTab detail={detail} />);
-    fireEvent.click(screen.getByTitle("Remove EXISTING_KEY"));
+
+    fireEvent.click(screen.getByTitle("Copy EXISTING_KEY"));
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith("EXISTING_KEY"),
+    );
+
+    fireEvent.click(screen.getByTitle("Overwrite EXISTING_KEY"));
+    expect(screen.getByLabelText("Environment key")).toHaveValue(
+      "EXISTING_KEY",
+    );
+    expect(screen.getByLabelText("Environment value")).toHaveValue("");
+
+    fireEvent.click(screen.getByTitle("Delete EXISTING_KEY"));
     await waitFor(() =>
       expect(deleteEnvVar).toHaveBeenCalledWith("demo", "EXISTING_KEY"),
     );
@@ -84,5 +109,22 @@ describe("EnvironmentTab", () => {
       />,
     );
     expect(screen.getByText("vault unavailable")).toBeInTheDocument();
+  });
+
+  it("shows builder empty copy when no vars", () => {
+    render(
+      <EnvironmentTab
+        detail={
+          {
+            ...detail,
+            secretsByApp: { demo: [] },
+          } as typeof detail
+        }
+      />,
+    );
+    expect(screen.getByText("No variables yet")).toBeInTheDocument();
+    expect(
+      screen.getByText(/builders set these here/i),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/aomi-build/src/features/launch/components/deployments/tabs/environment-tab.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/tabs/environment-tab.tsx
@@ -1,13 +1,7 @@
 "use client";
 
-import {
-  useEffect,
-  useMemo,
-  useState,
-  type Dispatch,
-  type SetStateAction,
-} from "react";
-import { Plus, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Copy, Plus, Trash2 } from "lucide-react";
 import { useProjectDetail } from "@build/features/launch/hooks/use-project-detail";
 import { LoadingPanel } from "../ui/state-panels";
 
@@ -24,12 +18,12 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
     [detail.source],
   );
   const [app, setApp] = useState<string>("");
-  const [envRows, setEnvRows] = useState<Row[]>([{ key: "", value: "" }]);
-  const [secretRows, setSecretRows] = useState<Row[]>([{ key: "", value: "" }]);
+  const [rows, setRows] = useState<Row[]>([{ key: "", value: "" }]);
   const [status, setStatus] = useState<{
     kind: "idle" | "saving" | "done" | "error";
     message: string;
   }>({ kind: "idle", message: "" });
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
 
   useEffect(() => {
     if ((!app || !appNames.includes(app)) && appNames.length > 0) {
@@ -49,7 +43,7 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
 
   const save = async () => {
     const values: Record<string, string> = {};
-    for (const row of [...envRows, ...secretRows]) {
+    for (const row of rows) {
       const key = row.key.trim();
       if (key && row.value.length > 0) values[key] = row.value;
     }
@@ -64,8 +58,7 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
         kind: "done",
         message: `Saved ${result.keys.length} variable(s).`,
       });
-      setEnvRows([{ key: "", value: "" }]);
-      setSecretRows([{ key: "", value: "" }]);
+      setRows([{ key: "", value: "" }]);
     } catch (err) {
       setStatus({
         kind: "error",
@@ -75,14 +68,37 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
   };
 
   const remove = async (key: string) => {
-    setStatus({ kind: "saving", message: `Removing ${key}…` });
+    setStatus({ kind: "saving", message: `Deleting ${key}…` });
     try {
       await detail.deleteEnvVar(app, key);
-      setStatus({ kind: "done", message: `Removed ${key}.` });
+      setStatus({ kind: "done", message: `Deleted ${key}.` });
     } catch (err) {
       setStatus({
         kind: "error",
-        message: err instanceof Error ? err.message : "Failed to remove",
+        message: err instanceof Error ? err.message : "Failed to delete",
+      });
+    }
+  };
+
+  const overwrite = (key: string) => {
+    setRows([{ key, value: "" }]);
+    setStatus({
+      kind: "idle",
+      message: "",
+    });
+  };
+
+  const copyKey = async (key: string) => {
+    try {
+      await navigator.clipboard.writeText(key);
+      setCopiedKey(key);
+      window.setTimeout(() => {
+        setCopiedKey((current) => (current === key ? null : current));
+      }, 1500);
+    } catch {
+      setStatus({
+        kind: "error",
+        message: "Could not copy key name.",
       });
     }
   };
@@ -91,7 +107,7 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
     <div className="divide-y divide-zinc-100">
       <div className="px-4 py-3">
         <div className="flex items-center justify-between gap-3">
-          <div className="text-sm font-medium">Environment variables</div>
+          <div className="text-sm font-medium">Environment</div>
           {appNames.length === 1 && (
             <span className="rounded-md border border-zinc-200 bg-zinc-50 px-2 py-1 font-mono text-xs text-zinc-600">
               {appNames[0]}
@@ -127,11 +143,12 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
             No applications are attached to this project yet.
           </div>
         )}
-        <p className="mt-3 text-xs text-zinc-500">
-          Set environment values for{" "}
-          <span className="font-mono">{app || "this app"}</span>. Secrets are
-          masked while editing and all saved values are injected into the
-          running app.
+        <p className="mt-3 text-xs leading-5 text-zinc-500">
+          One vault for{" "}
+          <span className="font-mono">{app || "this app"}</span>. Add
+          KEY=value pairs here — they are injected into the running app.
+          Values are write-only (you cannot reveal them later). Builders set
+          these; chat users never paste API keys.
         </p>
         {detail.secretsError && (
           <div className="mt-3 rounded-md border border-red-100 bg-red-50 px-3 py-2 text-xs text-red-700">
@@ -139,25 +156,51 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
           </div>
         )}
       </div>
-      <div className="px-4 py-3">
-        <ValueEditor
-          title="Environment variables"
-          badge="Env"
-          rows={envRows}
-          setRows={setEnvRows}
-          valueType="text"
-          addLabel="Add environment variable"
-        />
 
-        <div className="mt-5 border-t border-zinc-100 pt-4">
-          <ValueEditor
-            title="Secrets"
-            badge="Secret"
-            rows={secretRows}
-            setRows={setSecretRows}
-            valueType="password"
-            addLabel="Add secret"
-          />
+      <div className="px-4 py-3">
+        <div className="mb-2 text-xs font-medium uppercase tracking-wide text-zinc-400">
+          Add or overwrite
+        </div>
+        <div className="space-y-2">
+          {rows.map((row, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <input
+                value={row.key}
+                onChange={(e) =>
+                  setRows((rs) =>
+                    rs.map((r, j) =>
+                      j === i ? { ...r, key: e.target.value } : r,
+                    ),
+                  )
+                }
+                placeholder="KEY"
+                aria-label="Environment key"
+                className="h-8 w-40 rounded-md border border-zinc-300 px-2 font-mono text-xs"
+              />
+              <input
+                value={row.value}
+                onChange={(e) =>
+                  setRows((rs) =>
+                    rs.map((r, j) =>
+                      j === i ? { ...r, value: e.target.value } : r,
+                    ),
+                  )
+                }
+                placeholder="value"
+                aria-label="Environment value"
+                type="password"
+                className="h-8 flex-1 rounded-md border border-zinc-300 px-2 text-xs"
+              />
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={() => setRows((rs) => [...rs, { key: "", value: "" }])}
+            className="inline-flex h-7 items-center gap-1 rounded-md border border-zinc-300 bg-white px-2 text-xs font-medium hover:bg-zinc-50"
+          >
+            <Plus className="size-3.5" aria-hidden />
+            Add variable
+          </button>
         </div>
 
         <div className="mt-3 flex items-center gap-3">
@@ -186,29 +229,58 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
           <div className="text-xs font-medium uppercase tracking-wide text-zinc-400">
             Configured
           </div>
-          <ul className="mt-2 space-y-1">
+          <ul className="mt-2 space-y-2">
             {currentKeys.map(({ handle, key }) => (
               <li
                 key={handle}
-                className="flex items-center justify-between gap-3 py-0.5"
+                className="flex flex-wrap items-center justify-between gap-2 py-0.5"
               >
-                <span className="flex min-w-0 items-center gap-2">
-                  <span className="rounded-sm border border-amber-200 bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-700">
-                    Secret
-                  </span>
-                  <span className="truncate font-mono text-xs text-zinc-600">
+                <span className="flex min-w-0 flex-wrap items-center gap-2">
+                  <span className="truncate font-mono text-xs text-zinc-800">
                     {key}
                   </span>
+                  <span className="rounded-sm border border-amber-200 bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-700">
+                    Builder secret
+                  </span>
+                  <span className="rounded-sm border border-zinc-200 bg-zinc-50 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-zinc-600">
+                    Runtime
+                  </span>
+                  <span
+                    className="font-mono text-xs tracking-widest text-zinc-400"
+                    title="Value is write-only and cannot be revealed"
+                    aria-label="Value hidden"
+                  >
+                    ••••
+                  </span>
                 </span>
-                <button
-                  type="button"
-                  onClick={() => void remove(key)}
-                  className="inline-flex items-center gap-1 text-xs text-zinc-400 hover:text-red-600"
-                  title={`Remove ${key}`}
-                >
-                  <Trash2 className="size-3.5" aria-hidden />
-                  Remove
-                </button>
+                <span className="flex shrink-0 items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => void copyKey(key)}
+                    className="inline-flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-800"
+                    title={`Copy ${key}`}
+                  >
+                    <Copy className="size-3.5" aria-hidden />
+                    {copiedKey === key ? "Copied" : "Copy key"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => overwrite(key)}
+                    className="text-xs text-zinc-500 hover:text-zinc-800"
+                    title={`Overwrite ${key}`}
+                  >
+                    Overwrite
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void remove(key)}
+                    className="inline-flex items-center gap-1 text-xs text-zinc-400 hover:text-red-600"
+                    title={`Delete ${key}`}
+                  >
+                    <Trash2 className="size-3.5" aria-hidden />
+                    Delete
+                  </button>
+                </span>
               </li>
             ))}
           </ul>
@@ -225,82 +297,6 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
           </div>
         )
       )}
-    </div>
-  );
-}
-
-function ValueEditor({
-  title,
-  badge,
-  rows,
-  setRows,
-  valueType,
-  addLabel,
-}: {
-  title: string;
-  badge: "Env" | "Secret";
-  rows: Row[];
-  setRows: Dispatch<SetStateAction<Row[]>>;
-  valueType: "text" | "password";
-  addLabel: string;
-}) {
-  return (
-    <div>
-      <div className="mb-2 flex items-center gap-2">
-        <div className="text-xs font-medium uppercase tracking-wide text-zinc-400">
-          {title}
-        </div>
-        <span
-          className={`rounded-sm border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
-            badge === "Env"
-              ? "border-blue-200 bg-blue-50 text-blue-700"
-              : "border-amber-200 bg-amber-50 text-amber-700"
-          }`}
-        >
-          {badge}
-        </span>
-      </div>
-      <div className="space-y-2">
-        {rows.map((row, i) => (
-          <div key={i} className="flex items-center gap-2">
-            <input
-              value={row.key}
-              onChange={(e) =>
-                setRows((rs) =>
-                  rs.map((r, j) =>
-                    j === i ? { ...r, key: e.target.value } : r,
-                  ),
-                )
-              }
-              placeholder="KEY"
-              aria-label={`${title} key`}
-              className="h-8 w-40 rounded-md border border-zinc-300 px-2 font-mono text-xs"
-            />
-            <input
-              value={row.value}
-              onChange={(e) =>
-                setRows((rs) =>
-                  rs.map((r, j) =>
-                    j === i ? { ...r, value: e.target.value } : r,
-                  ),
-                )
-              }
-              placeholder="value"
-              aria-label={`${title} value`}
-              type={valueType}
-              className="h-8 flex-1 rounded-md border border-zinc-300 px-2 text-xs"
-            />
-          </div>
-        ))}
-        <button
-          type="button"
-          onClick={() => setRows((rs) => [...rs, { key: "", value: "" }])}
-          className="inline-flex h-7 items-center gap-1 rounded-md border border-zinc-300 bg-white px-2 text-xs font-medium hover:bg-zinc-50"
-        >
-          <Plus className="size-3.5" aria-hidden />
-          {addLabel}
-        </button>
-      </div>
     </div>
   );
 }

--- a/apps/aomi-build/src/features/launch/components/deployments/tabs/environment-tab.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/tabs/environment-tab.tsx
@@ -181,7 +181,7 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
         </div>
       </div>
 
-      {currentKeys.length > 0 && (
+      {currentKeys.length > 0 ? (
         <div className="px-4 py-3">
           <div className="text-xs font-medium uppercase tracking-wide text-zinc-400">
             Configured
@@ -213,6 +213,17 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
             ))}
           </ul>
         </div>
+      ) : (
+        appNames.length > 0 && (
+          <div className="px-4 py-4 text-sm text-zinc-500">
+            <p className="font-medium text-zinc-700">No variables yet</p>
+            <p className="mt-1 text-xs leading-5">
+              Add keys your agent needs (for example{" "}
+              <span className="font-mono">BINANCE_API_KEY</span>). Builders set
+              these here — chat users never paste API keys.
+            </p>
+          </div>
+        )
       )}
     </div>
   );

--- a/apps/aomi-build/src/features/launch/components/deployments/ui/state-panels.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/ui/state-panels.tsx
@@ -20,7 +20,7 @@ export function ErrorPanel({ message }: { message: string }) {
 
 export function EmptyPanel({ children }: { children: ReactNode }) {
   return (
-    <div className="flex min-h-[260px] items-center justify-center px-4 py-10 text-center text-sm text-zinc-500">
+    <div className="flex min-h-[260px] flex-col items-center justify-center gap-2 px-4 py-10 text-center text-sm text-zinc-500">
       {children}
     </div>
   );

--- a/apps/aomi-build/src/features/operate/operate-view.tsx
+++ b/apps/aomi-build/src/features/operate/operate-view.tsx
@@ -67,10 +67,19 @@ function unitLabel(value: unknown, unit: string, digits = 1) {
   return label === "No data" ? label : `${label} ${unit}`;
 }
 
-function EmptyState({ title }: { title: string }) {
+function EmptyState({
+  title,
+  description,
+}: {
+  title: string;
+  description?: string;
+}) {
   return (
     <div className="border-border bg-surface-subtle text-dim rounded-md border px-4 py-10 text-center text-sm">
-      No {title.toLowerCase()} found.
+      <p>No {title.toLowerCase()} found.</p>
+      {description ? (
+        <p className="mt-2 text-xs leading-5">{description}</p>
+      ) : null}
     </div>
   );
 }
@@ -111,7 +120,13 @@ function Rows({
 
   if (kind === "transactions") {
     const rows = payload.transactions ?? [];
-    if (!rows.length) return <EmptyState title="Transactions" />;
+    if (!rows.length)
+      return (
+        <EmptyState
+          title="Transactions"
+          description="Transactions appear after your apps submit on-chain actions. Deploy an app and use it in chat to generate activity."
+        />
+      );
     return (
       <div className="border-border overflow-x-auto rounded-md border">
         <table className="divide-border min-w-full divide-y text-sm">


### PR DESCRIPTION
## Summary
- **Phase 1:** Clarify Projects vs Deployments, rename project Settings → Details, and thin empty states so builders know where they are and what to do next.
- **Phase 2:** Turn Account → Secrets into a project Environment picker (0 → New app, 1 → auto-open Environment, 2+ → list deep-links). No account-wide secret store.
- **Phase 3:** Make Project → Environment a single write-only vault (one story, configured rows with •••• / Copy key / Overwrite / Delete, no Reveal) so builders set keys and chat users never paste them — aligned with Cecilia’s Vercel-style env direction.

## Test plan
- [ ] Signed in: Projects title + empty/next-action copy feel clear
- [ ] Open a project: Details tab label; Deployments helper says this project only
- [ ] `/settings/secrets`: 0 / 1 / 2+ project behaviors
- [ ] Project → Environment: one add form; configured row shows Builder secret + Runtime + ••••; Copy key / Overwrite / Delete work; no Reveal
- [ ] Confirm no `.env` or real credential values in the diff