### PR TITLE
feat(aomi-build): densify Operate transactions table

### DIFF
--- a/apps/aomi-build/BUILDERS-EXPERIENCE.md
+++ b/apps/aomi-build/BUILDERS-EXPERIENCE.md
@@ -1,9 +1,9 @@
 # Aomi Build — Builders' Experience Plan
 
-> **Status:** Phase three done — stop for Cecilia/Han review  
+> **Status:** Phase five in progress (transactions density); Phase four deferred  
 > **App:** `aomi/apps/aomi-build` → [build.aomi.dev](https://build.aomi.dev)  
 > **Owner:** Gordian (`0xgordian`)  
-> **Branch:** `feat/builders-experience-phase-1`  
+> **Branch:** `feat/builders-experience-phase-5-transactions`  
 > **Last updated:** 2026-07-12
 
 Execution plan for improving the **builders' experience** on Han's live Build app.  

--- a/apps/aomi-build/src/features/operate/operate-view.test.tsx
+++ b/apps/aomi-build/src/features/operate/operate-view.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { OperateView, truncateAddress } from "./operate-view";
+
+const operateFetch = vi.fn();
+
+vi.mock("@build/components/control-plane/github-session-context", () => ({
+  useGitHubSession: () => ({
+    account: { loading: false, signedIn: true, login: "gordian" },
+  }),
+}));
+
+vi.mock("./client", () => ({
+  operateFetch: (...args: unknown[]) => operateFetch(...args),
+}));
+
+describe("truncateAddress", () => {
+  it("shortens long hex addresses and leaves short values alone", () => {
+    expect(truncateAddress("0x1234567890abcdef1234567890abcdef12345678")).toBe(
+      "0x1234…5678",
+    );
+    expect(truncateAddress("0xabc")).toBe("0xabc");
+    expect(truncateAddress("")).toBe("");
+    expect(truncateAddress(null)).toBe("");
+  });
+});
+
+describe("OperateView transactions", () => {
+  beforeEach(() => {
+    operateFetch.mockReset();
+  });
+
+  it("renders denser columns from wire fields and truncates addresses", async () => {
+    operateFetch.mockResolvedValue({
+      sources: [],
+      transactions: [
+        {
+          id: "1",
+          application: "demo",
+          status: "confirmed",
+          chainId: 8453,
+          fromAddress: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          toAddress: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          value: "1000000000000000000",
+          description: "Swap USDC",
+          txHash: "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          createdAt: 1_700_000_000,
+        },
+      ],
+      nextCursor: null,
+    });
+
+    render(<OperateView kind="transactions" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("demo")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("From")).toBeInTheDocument();
+    expect(screen.getByText("Value")).toBeInTheDocument();
+    expect(screen.getByText("Description")).toBeInTheDocument();
+    expect(screen.getByText("0xaaaa…aaaa")).toBeInTheDocument();
+    expect(screen.getByText("0xbbbb…bbbb")).toBeInTheDocument();
+    expect(screen.getByText("0xcccc…cccc")).toBeInTheDocument();
+    expect(screen.getByText("1000000000000000000")).toBeInTheDocument();
+    expect(screen.getByText("Swap USDC")).toBeInTheDocument();
+  });
+
+  it("shows a clearer empty state when there are no transactions", async () => {
+    operateFetch.mockResolvedValue({
+      sources: [],
+      transactions: [],
+      nextCursor: null,
+    });
+
+    render(<OperateView kind="transactions" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/no transactions found/i)).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/configure its environment/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/aomi-build/src/features/operate/operate-view.tsx
+++ b/apps/aomi-build/src/features/operate/operate-view.tsx
@@ -50,6 +50,20 @@ function secondsLabel(value: unknown) {
   return n > 0 ? new Date(n * 1000).toLocaleString() : "";
 }
 
+/** Truncate 0x addresses for dense table cells; leave short/empty values alone. */
+export function truncateAddress(value: unknown, chars = 4): string {
+  const raw = String(value ?? "").trim();
+  if (!raw) return "";
+  if (raw.length <= chars * 2 + 2) return raw;
+  return `${raw.slice(0, chars + 2)}…${raw.slice(-chars)}`;
+}
+
+function valueLabel(value: unknown): string {
+  const raw = String(value ?? "").trim();
+  if (!raw || raw === "0") return "—";
+  return raw;
+}
+
 function numberLabel(value: unknown, digits = 1) {
   if (value === null || value === undefined || value === "") return "No data";
   const n = Number(value);
@@ -124,7 +138,7 @@ function Rows({
       return (
         <EmptyState
           title="Transactions"
-          description="Transactions appear after your apps submit on-chain actions. Deploy an app and use it in chat to generate activity."
+          description="On-chain actions from your apps show up here. Deploy an app, configure its Environment, and use it in chat to generate activity."
         />
       );
     return (
@@ -136,7 +150,10 @@ function Rows({
               <th className="px-3 py-2">App</th>
               <th className="px-3 py-2">Status</th>
               <th className="px-3 py-2">Chain</th>
+              <th className="px-3 py-2">From</th>
               <th className="px-3 py-2">To</th>
+              <th className="px-3 py-2">Value</th>
+              <th className="px-3 py-2">Description</th>
               <th className="px-3 py-2">Hash</th>
             </tr>
           </thead>
@@ -149,11 +166,32 @@ function Rows({
                 <td className="px-3 py-2">{tx.application}</td>
                 <td className="px-3 py-2">{tx.status}</td>
                 <td className="px-3 py-2">{tx.chainId}</td>
-                <td className="max-w-48 truncate px-3 py-2 font-mono text-xs">
-                  {tx.toAddress}
+                <td
+                  className="max-w-36 truncate px-3 py-2 font-mono text-xs"
+                  title={String(tx.fromAddress ?? "")}
+                >
+                  {truncateAddress(tx.fromAddress)}
                 </td>
-                <td className="max-w-48 truncate px-3 py-2 font-mono text-xs">
-                  {tx.txHash ?? ""}
+                <td
+                  className="max-w-36 truncate px-3 py-2 font-mono text-xs"
+                  title={String(tx.toAddress ?? "")}
+                >
+                  {truncateAddress(tx.toAddress)}
+                </td>
+                <td className="whitespace-nowrap px-3 py-2 font-mono text-xs">
+                  {valueLabel(tx.value)}
+                </td>
+                <td
+                  className="max-w-56 truncate px-3 py-2 text-xs"
+                  title={String(tx.description ?? "")}
+                >
+                  {tx.description ? String(tx.description) : "—"}
+                </td>
+                <td
+                  className="max-w-36 truncate px-3 py-2 font-mono text-xs"
+                  title={String(tx.txHash ?? "")}
+                >
+                  {truncateAddress(tx.txHash)}
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
## Summary
- Add **From**, **Value**, and **Description** columns to Operate → Transactions using fields already on the wire.
- Truncate From / To / Hash for denser rows (full value on hover).
- Clarify the empty state (deploy → Environment → chat); no new filters or APIs.

## Test plan
- [ ] Operate → Transactions with data: new columns render; addresses/hashes truncated
- [ ] Hover truncated cells: full address/hash in `title`
- [ ] Empty state copy mentions Environment / chat path
- [ ] Load more still works when a cursor is present
- [ ] `pnpm exec vitest run src/features/operate/operate-view.test.tsx` passes