### PR TITLE
fix(aomi-build): align project/deploy surfaces with dark shell

### DIFF
--- a/apps/aomi-build/BUILDERS-EXPERIENCE.md
+++ b/apps/aomi-build/BUILDERS-EXPERIENCE.md
@@ -1,9 +1,9 @@
 # Aomi Build — Builders' Experience Plan
 
-> **Status:** Phase five in progress (transactions density); Phase four deferred  
+> **Status:** Phase four in progress (theme tokens); Phase five merged  
 > **App:** `aomi/apps/aomi-build` → [build.aomi.dev](https://build.aomi.dev)  
 > **Owner:** Gordian (`0xgordian`)  
-> **Branch:** `feat/builders-experience-phase-5-transactions`  
+> **Branch:** `feat/builders-experience-phase-4-theme`  
 > **Last updated:** 2026-07-12
 
 Execution plan for improving the **builders' experience** on Han's live Build app.  

--- a/apps/aomi-build/src/features/launch/components/deployments/global-deployments-list.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/global-deployments-list.tsx
@@ -87,14 +87,14 @@ export function GlobalDeploymentsList() {
   }
 
   return (
-    <main className="min-h-screen bg-white text-zinc-950">
+    <main className="min-h-screen bg-background text-foreground">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-8 sm:px-6">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="min-w-0">
             <h1 className="text-2xl font-semibold tracking-normal">
               Deployments
             </h1>
-            <p className="mt-1 text-sm text-zinc-500">
+            <p className="mt-1 text-sm text-dim">
               Deployment history across all projects.
             </p>
           </div>
@@ -102,23 +102,23 @@ export function GlobalDeploymentsList() {
             <button
               type="button"
               onClick={reload}
-              className="inline-flex h-8 items-center justify-center gap-1.5 rounded-md border border-zinc-300 bg-white px-3 text-sm font-medium hover:bg-zinc-50"
+              className="inline-flex h-8 items-center justify-center gap-1.5 rounded-md border border-border bg-surface-1 px-3 text-sm font-medium hover:bg-accent-hover"
             >
               <RefreshCw className="size-3.5" aria-hidden />
               Refresh
             </button>
             <Link
               href="/operate/deployments/new"
-              className="inline-flex h-8 items-center justify-center rounded-md bg-zinc-900 px-3 text-sm font-medium text-white hover:bg-zinc-800"
+              className="inline-flex h-8 items-center justify-center rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:opacity-90"
             >
               New app
             </Link>
           </div>
         </div>
 
-        <div className="rounded-lg border border-zinc-200 bg-white">
-          <div className="flex flex-wrap items-center gap-2 border-b border-zinc-200 px-4 py-3">
-            <Filter className="size-4 text-zinc-400" aria-hidden />
+        <div className="rounded-lg border border-border bg-surface-1">
+          <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-3">
+            <Filter className="size-4 text-dim" aria-hidden />
             <select
               value={sourceFilter}
               onChange={(event) => {
@@ -130,7 +130,7 @@ export function GlobalDeploymentsList() {
                   router.push("/operate/deployments");
                 }
               }}
-              className="h-8 rounded-md border border-zinc-300 bg-white px-2 text-sm"
+              className="h-8 rounded-md border border-border bg-surface-1 px-2 text-sm"
             >
               <option value="all">All projects</option>
               {sources.map((source) => (
@@ -144,7 +144,7 @@ export function GlobalDeploymentsList() {
               onChange={(event) =>
                 setStatus(event.target.value as "all" | "current" | "previous")
               }
-              className="h-8 rounded-md border border-zinc-300 bg-white px-2 text-sm"
+              className="h-8 rounded-md border border-border bg-surface-1 px-2 text-sm"
             >
               <option value="all">All statuses</option>
               <option value="current">Current</option>
@@ -154,21 +154,21 @@ export function GlobalDeploymentsList() {
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="Search deployment, app, commit, release tag"
-              className="h-8 min-w-[260px] flex-1 rounded-md border border-zinc-300 px-2 text-sm"
+              className="h-8 min-w-[260px] flex-1 rounded-md border border-border px-2 text-sm"
             />
           </div>
 
           {selectedDeployment ? (
-            <div className="border-b border-zinc-200 bg-zinc-50 px-4 py-4">
+            <div className="border-b border-border bg-surface-2 px-4 py-4">
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div className="min-w-0">
-                  <div className="text-xs font-medium uppercase tracking-wide text-zinc-400">
+                  <div className="text-xs font-medium uppercase tracking-wide text-dim">
                     Selected deployment
                   </div>
                   <div className="mt-1 truncate font-mono text-sm font-medium">
                     {selectedDeployment.deploymentId}
                   </div>
-                  <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs text-zinc-500">
+                  <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs text-dim">
                     <span>
                       {selectedDeployment.repositoryLink ?? "Unknown project"}
                     </span>
@@ -182,7 +182,7 @@ export function GlobalDeploymentsList() {
                 <div className="flex shrink-0 items-center gap-2">
                   <Link
                     href={`/projects/${selectedDeployment.sourceId}`}
-                    className="inline-flex h-8 items-center rounded-md border border-zinc-300 bg-white px-3 text-xs font-medium hover:bg-zinc-50"
+                    className="inline-flex h-8 items-center rounded-md border border-border bg-surface-1 px-3 text-xs font-medium hover:bg-accent-hover"
                   >
                     Open project
                   </Link>
@@ -192,7 +192,7 @@ export function GlobalDeploymentsList() {
                         ? `/operate/deployments?project=${projectParam}`
                         : "/operate/deployments"
                     }
-                    className="inline-flex h-8 items-center rounded-md border border-zinc-300 bg-white px-3 text-xs font-medium hover:bg-zinc-50"
+                    className="inline-flex h-8 items-center rounded-md border border-border bg-surface-1 px-3 text-xs font-medium hover:bg-accent-hover"
                   >
                     Clear selection
                   </Link>
@@ -215,7 +215,7 @@ export function GlobalDeploymentsList() {
                   </p>
                   <Link
                     href="/operate/deployments/new"
-                    className="inline-flex h-8 items-center justify-center rounded-md bg-zinc-900 px-3 text-sm font-medium text-white hover:bg-zinc-800"
+                    className="inline-flex h-8 items-center justify-center rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:opacity-90"
                   >
                     New app
                   </Link>
@@ -228,12 +228,12 @@ export function GlobalDeploymentsList() {
               )}
             </EmptyPanel>
           ) : (
-            <div className="divide-y divide-zinc-100">
+            <div className="divide-y divide-border">
               {filtered.map((deployment) => (
                 <Link
                   key={`${deployment.sourceId}-${deployment.deploymentId}`}
                   href={`/operate/deployments?project=${deployment.sourceId}&deployment=${encodeURIComponent(deployment.deploymentId)}`}
-                  className="grid min-h-[76px] grid-cols-[minmax(0,1fr)_auto] items-center gap-4 px-4 py-3 hover:bg-zinc-50"
+                  className="grid min-h-[76px] grid-cols-[minmax(0,1fr)_auto] items-center gap-4 px-4 py-3 hover:bg-accent-hover"
                 >
                   <div className="min-w-0">
                     <div className="flex min-w-0 items-center gap-2">
@@ -241,12 +241,12 @@ export function GlobalDeploymentsList() {
                         {deployment.deploymentId}
                       </div>
                       {deployment.current && (
-                        <span className="shrink-0 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
+                        <span className="shrink-0 rounded-full bg-positive/10 px-2 py-0.5 text-[11px] font-medium text-positive">
                           Current
                         </span>
                       )}
                     </div>
-                    <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-zinc-500">
+                    <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-dim">
                       <span>{deployment.repositoryLink ?? "Unknown project"}</span>
                       <span>{deployment.apps.join(", ") || "no apps"}</span>
                       <span className="font-mono">
@@ -255,7 +255,7 @@ export function GlobalDeploymentsList() {
                       <span>{formatDate(deployment.createdAt)}</span>
                     </div>
                   </div>
-                  <span className="text-xs font-medium text-zinc-500">
+                  <span className="text-xs font-medium text-dim">
                     View deployment
                   </span>
                 </Link>

--- a/apps/aomi-build/src/features/launch/components/deployments/project-header.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/project-header.tsx
@@ -21,12 +21,12 @@ export function ProjectHeader({
       : `https://github.com/${source.repositoryLink}`
     : null;
   return (
-    <header className="flex min-h-14 flex-wrap items-center justify-between gap-3 border-b border-zinc-200 px-4 py-3 sm:px-6">
+    <header className="flex min-h-14 flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3 sm:px-6">
       <div className="flex min-w-0 items-center gap-2 text-sm">
-        <a href={backHref} className="text-zinc-500 hover:text-zinc-900">
+        <a href={backHref} className="text-dim hover:text-foreground">
           {backLabel}
         </a>
-        <span className="text-zinc-300">/</span>
+        <span className="text-dim">/</span>
         <span className="truncate font-semibold">
           {source?.repositoryLink ?? "Project"}
         </span>
@@ -38,7 +38,7 @@ export function ProjectHeader({
             href={repoUrl}
             target="_blank"
             rel="noreferrer"
-            className="inline-flex h-8 items-center gap-1.5 rounded-md border border-zinc-300 px-2.5 text-xs font-medium hover:bg-zinc-50"
+            className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-2.5 text-xs font-medium hover:bg-accent-hover"
           >
             <Github className="size-3.5" aria-hidden />
             GitHub
@@ -47,7 +47,7 @@ export function ProjectHeader({
         <button
           type="button"
           onClick={onRefresh}
-          className="inline-flex h-8 items-center rounded-md border border-zinc-300 bg-white px-3 text-sm font-medium hover:bg-zinc-50"
+          className="inline-flex h-8 items-center rounded-md border border-border bg-surface-1 px-3 text-sm font-medium hover:bg-accent-hover"
         >
           Refresh
         </button>

--- a/apps/aomi-build/src/features/launch/components/deployments/project-index.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/project-index.tsx
@@ -22,14 +22,14 @@ export function ProjectIndex() {
       : null;
 
   return (
-    <main className="min-h-screen bg-white text-zinc-950">
+    <main className="min-h-screen bg-background text-foreground">
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8 sm:px-6">
         <div className="flex items-center justify-between gap-4">
           <div className="min-w-0">
             <h1 className="text-2xl font-semibold tracking-normal">
               Projects
             </h1>
-            <p className="mt-1 text-sm text-zinc-500">
+            <p className="mt-1 text-sm text-dim">
               GitHub repositories connected as Aomi apps.
             </p>
           </div>
@@ -37,13 +37,13 @@ export function ProjectIndex() {
             <button
               type="button"
               onClick={reload}
-              className="inline-flex h-8 items-center justify-center rounded-md border border-zinc-300 bg-white px-3 text-sm font-medium hover:bg-zinc-50"
+              className="inline-flex h-8 items-center justify-center rounded-md border border-border bg-surface-1 px-3 text-sm font-medium hover:bg-accent-hover"
             >
               Refresh
             </button>
             <a
               href="/operate/deployments/new"
-              className="inline-flex h-8 items-center justify-center rounded-md bg-zinc-900 px-3 text-sm font-medium text-white hover:bg-zinc-800"
+              className="inline-flex h-8 items-center justify-center rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:opacity-90"
             >
               New app
             </a>
@@ -51,16 +51,16 @@ export function ProjectIndex() {
         </div>
 
         {requiredSdk && (
-          <div className="flex items-center gap-2 rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm">
-            <span className="text-zinc-500">Backend requires aomi-sdk</span>
+          <div className="flex items-center gap-2 rounded-lg border border-border bg-surface-1 px-3 py-2 text-sm">
+            <span className="text-dim">Backend requires aomi-sdk</span>
             <SdkBadge stamped={requiredSdk} required={requiredSdk} />
           </div>
         )}
 
-        <div className="overflow-hidden rounded-lg border border-zinc-200 bg-white">
-          <div className="flex h-12 items-center justify-between border-b border-zinc-200 px-4">
+        <div className="overflow-hidden rounded-lg border border-border bg-surface-1">
+          <div className="flex h-12 items-center justify-between border-b border-border px-4">
             <div className="text-sm font-medium">Projects</div>
-            <div className="text-xs text-zinc-500">
+            <div className="text-xs text-dim">
               {state.status === "ready" ? state.sources.length : 0}
             </div>
           </div>
@@ -80,7 +80,7 @@ export function ProjectIndex() {
                 </p>
                 <a
                   href="/operate/deployments/new"
-                  className="inline-flex h-8 items-center justify-center rounded-md bg-zinc-900 px-3 text-sm font-medium text-white hover:bg-zinc-800"
+                  className="inline-flex h-8 items-center justify-center rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:opacity-90"
                 >
                   New app
                 </a>

--- a/apps/aomi-build/src/features/launch/components/deployments/project-page.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/project-page.tsx
@@ -39,7 +39,7 @@ export function ProjectPage({
     : "deployments";
 
   return (
-    <main className="min-h-screen bg-white text-zinc-950">
+    <main className="min-h-screen bg-background text-foreground">
       <ProjectHeader
         source={detail.source}
         latest={detail.source?.latestDeployment ?? null}
@@ -50,7 +50,7 @@ export function ProjectPage({
       <div className="mx-auto w-full max-w-5xl px-4 py-6 sm:px-6">
         <div
           role="tablist"
-          className="mb-4 flex w-fit items-center gap-1 rounded-md bg-zinc-100 p-1 text-sm"
+          className="mb-4 flex w-fit items-center gap-1 rounded-md bg-surface-2 p-1 text-sm"
         >
           {TABS.map((tab) => (
             <button
@@ -69,15 +69,15 @@ export function ProjectPage({
               }
               className={`h-7 rounded px-2.5 text-xs font-medium ${
                 active === tab.id
-                  ? "bg-white text-zinc-950 shadow-sm"
-                  : "text-zinc-500"
+                  ? "bg-surface-1 text-foreground shadow-sm"
+                  : "text-dim"
               }`}
             >
               {tab.label}
             </button>
           ))}
         </div>
-        <div className="overflow-hidden rounded-lg border border-zinc-200 bg-white">
+        <div className="overflow-hidden rounded-lg border border-border bg-surface-1">
           {detail.loading && detail.source === null && !detail.error ? (
             <LoadingPanel label="Loading project…" />
           ) : detail.error ? (

--- a/apps/aomi-build/src/features/launch/components/deployments/project-row.test.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/project-row.test.tsx
@@ -17,7 +17,7 @@ describe("ProjectRow", () => {
       />,
     );
     const link = screen.getByRole("link", { name: /alice\/bot/ });
-    expect(link).toHaveAttribute("href", "/operate/deployments?project=42");
+    expect(link).toHaveAttribute("href", "/projects/42");
   });
 
   it("shows deployment status instead of a live app count", () => {

--- a/apps/aomi-build/src/features/launch/components/deployments/project-row.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/project-row.tsx
@@ -41,16 +41,16 @@ export function ProjectRow({
   return (
     <a
       href={href ?? `/projects/${source.id}`}
-      className="flex items-center gap-3 border-b border-zinc-100 px-4 py-3 last:border-b-0 hover:bg-zinc-50"
+      className="flex items-center gap-3 border-b border-border px-4 py-3 last:border-b-0 hover:bg-accent-hover"
     >
-      <div className="flex size-8 shrink-0 items-center justify-center rounded-md border border-zinc-200 text-xs font-medium">
+      <div className="flex size-8 shrink-0 items-center justify-center rounded-md border border-border text-xs font-medium">
         {(source.repositoryLink ?? "A").slice(0, 1).toUpperCase()}
       </div>
       <div className="min-w-0 flex-1">
         <div className="truncate text-sm font-medium">
           {source.repositoryLink ?? "Unknown repository"}
         </div>
-        <div className="mt-1 flex items-center gap-2 text-xs text-zinc-500">
+        <div className="mt-1 flex items-center gap-2 text-xs text-dim">
           <StatusDot state={deploymentState} />
           <span>{deploymentLabel}</span>
           <span aria-hidden>·</span>

--- a/apps/aomi-build/src/features/launch/components/deployments/tabs/chat-tab.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/tabs/chat-tab.tsx
@@ -19,18 +19,18 @@ export function ChatTab({ detail }: { detail: Detail }) {
   if (lifecycle.kind !== "live" || !lifecycle.chatApp) {
     return (
       <div className="flex min-h-[320px] flex-col items-center justify-center gap-4 px-4 py-10 text-center">
-        <div className="flex size-10 items-center justify-center rounded-full border border-zinc-200">
-          <MessageSquare className="size-5 text-zinc-500" aria-hidden />
+        <div className="flex size-10 items-center justify-center rounded-full border border-border">
+          <MessageSquare className="size-5 text-dim" aria-hidden />
         </div>
         <div>
           <div className="text-base font-semibold">No live chat target</div>
-          <div className="mt-1 max-w-md text-sm leading-6 text-zinc-500">
+          <div className="mt-1 max-w-md text-sm leading-6 text-dim">
             Deploy and activate a project app before opening its chat session.
           </div>
         </div>
         <Link
           href="?tab=deployments"
-          className="inline-flex h-9 items-center justify-center rounded-md bg-zinc-950 px-3 text-sm font-medium text-white hover:bg-zinc-800"
+          className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:opacity-90"
         >
           Go to deployments
         </Link>
@@ -48,7 +48,7 @@ export function ChatTab({ detail }: { detail: Detail }) {
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="min-w-0">
           <div className="text-sm font-medium">Chat</div>
-          <div className="mt-1 truncate text-xs text-zinc-500">
+          <div className="mt-1 truncate text-xs text-dim">
             {lifecycle.chatApp} · {lifecycle.repo}
           </div>
         </div>
@@ -56,7 +56,7 @@ export function ChatTab({ detail }: { detail: Detail }) {
           href={url}
           target="_blank"
           rel="noreferrer"
-          className="inline-flex h-8 items-center gap-1.5 rounded-md border border-zinc-300 bg-white px-2.5 text-xs font-medium text-zinc-800 hover:bg-zinc-50"
+          className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-surface-1 px-2.5 text-xs font-medium text-foreground hover:bg-accent-hover"
         >
           Open chat
           <ExternalLink className="size-3.5" aria-hidden />
@@ -65,7 +65,7 @@ export function ChatTab({ detail }: { detail: Detail }) {
       <iframe
         src={url}
         title={`Chat with ${lifecycle.chatApp}`}
-        className="h-[680px] w-full rounded-md border border-zinc-200 bg-white"
+        className="h-[680px] w-full rounded-md border border-border bg-surface-1"
       />
     </div>
   );

--- a/apps/aomi-build/src/features/launch/components/deployments/tabs/deployments-tab.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/tabs/deployments-tab.tsx
@@ -170,14 +170,14 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
 
   return (
     <div>
-      <div className="border-b border-zinc-100 px-4 py-2 text-xs text-zinc-500">
+      <div className="border-b border-border px-4 py-2 text-xs text-dim">
         Deployment history for this project.
       </div>
-      <div className="flex items-center justify-between gap-3 border-b border-zinc-100 px-4 py-3">
+      <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
         <div
           role="tablist"
           aria-label="Deployment views"
-          className="inline-flex rounded-md border border-zinc-200 bg-white p-0.5"
+          className="inline-flex rounded-md border border-border bg-surface-1 p-0.5"
         >
           {[
             ["deployments", "Deployments"],
@@ -191,8 +191,8 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
               onClick={() => setView(id as View)}
               className={`h-7 rounded px-2.5 text-xs font-medium ${
                 view === id
-                  ? "bg-zinc-900 text-white"
-                  : "text-zinc-600 hover:bg-zinc-50"
+                  ? "bg-primary text-primary-foreground"
+                  : "text-dim hover:bg-accent-hover"
               }`}
             >
               {label}
@@ -213,7 +213,7 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
                     })
                   : undefined
               }
-              className="inline-flex h-8 items-center justify-center gap-1.5 rounded-md border border-zinc-300 bg-white px-2.5 text-xs font-medium text-zinc-800 hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex h-8 items-center justify-center gap-1.5 rounded-md border border-border bg-surface-1 px-2.5 text-xs font-medium text-foreground hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
               title={
                 deactivated
                   ? "No deployment is live"
@@ -231,7 +231,7 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
               setOp(null);
               void detail.deployNewVersion();
             }}
-            className="inline-flex h-8 items-center justify-center gap-1.5 rounded-md bg-zinc-900 px-3 text-xs font-medium text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex h-8 items-center justify-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
             title="Deploy the source repo's latest commit and activate it"
           >
             <Rocket className="size-3.5" aria-hidden />
@@ -242,10 +242,10 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
 
       {detail.deployFlow.phase !== "idle" && (
         <div
-          className={`border-b border-zinc-100 px-4 py-2 text-xs ${
+          className={`border-b border-border px-4 py-2 text-xs ${
             detail.deployFlow.phase === "error"
-              ? "text-red-600"
-              : "text-zinc-500"
+              ? "text-destructive"
+              : "text-dim"
           }`}
         >
           {detail.deployFlow.message}
@@ -253,8 +253,8 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
       )}
 
       {deactivated && (
-        <div className="flex items-center gap-2 border-b border-red-100 bg-red-50 px-4 py-2 text-xs text-red-700">
-          <span className="rounded-full bg-red-100 px-2 py-0.5 font-medium">
+        <div className="flex items-center gap-2 border-b border-destructive/30 bg-destructive/10 px-4 py-2 text-xs text-destructive">
+          <span className="rounded-full bg-destructive/20 px-2 py-0.5 font-medium">
             Deactivated
           </span>
           <span>
@@ -265,7 +265,7 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
       )}
 
       {detail.recordsError && (
-        <div className="border-b border-red-100 bg-red-50 px-4 py-2 text-xs text-red-700">
+        <div className="border-b border-destructive/30 bg-destructive/10 px-4 py-2 text-xs text-destructive">
           {detail.recordsError}
         </div>
       )}
@@ -277,7 +277,7 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
           <div className="flex flex-col items-center gap-2">
             <p>
               No deployments yet for this project. Use{" "}
-              <span className="font-medium text-zinc-700">
+              <span className="font-medium text-foreground">
                 Deploy new version
               </span>{" "}
               to publish.
@@ -329,7 +329,7 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
           {activity.map((row) => (
             <div
               key={`${row.app}-${row.deploymentId}-${row.releaseTag}-${row.createdAt}`}
-              className="flex min-h-10 items-center justify-between gap-4 border-b border-zinc-100 px-4 py-2 text-xs text-zinc-600 last:border-b-0"
+              className="flex min-h-10 items-center justify-between gap-4 border-b border-border px-4 py-2 text-xs text-dim last:border-b-0"
             >
               <span className="min-w-0 truncate font-mono">
                 promoted · {row.deploymentId}

--- a/apps/aomi-build/src/features/launch/components/deployments/tabs/environment-tab.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/tabs/environment-tab.tsx
@@ -104,12 +104,12 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
   };
 
   return (
-    <div className="divide-y divide-zinc-100">
+    <div className="divide-y divide-border">
       <div className="px-4 py-3">
         <div className="flex items-center justify-between gap-3">
           <div className="text-sm font-medium">Environment</div>
           {appNames.length === 1 && (
-            <span className="rounded-md border border-zinc-200 bg-zinc-50 px-2 py-1 font-mono text-xs text-zinc-600">
+            <span className="rounded-md border border-border bg-surface-2 px-2 py-1 font-mono text-xs text-dim">
               {appNames[0]}
             </span>
           )}
@@ -118,7 +118,7 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
           <div
             role="tablist"
             aria-label="Application environment scope"
-            className="mt-3 flex flex-wrap gap-1 rounded-md bg-zinc-100 p-1"
+            className="mt-3 flex flex-wrap gap-1 rounded-md bg-surface-2 p-1"
           >
             {appNames.map((name) => (
               <button
@@ -129,8 +129,8 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
                 onClick={() => setApp(name)}
                 className={`h-7 rounded px-2.5 font-mono text-xs font-medium ${
                   app === name
-                    ? "bg-white text-zinc-950 shadow-sm"
-                    : "text-zinc-500 hover:text-zinc-800"
+                    ? "bg-surface-1 text-foreground shadow-sm"
+                    : "text-dim hover:text-foreground"
                 }`}
               >
                 {name}
@@ -139,11 +139,11 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
           </div>
         )}
         {appNames.length === 0 && (
-          <div className="mt-3 rounded-md border border-zinc-200 bg-zinc-50 px-3 py-2 text-xs text-zinc-500">
+          <div className="mt-3 rounded-md border border-border bg-surface-2 px-3 py-2 text-xs text-dim">
             No applications are attached to this project yet.
           </div>
         )}
-        <p className="mt-3 text-xs leading-5 text-zinc-500">
+        <p className="mt-3 text-xs leading-5 text-dim">
           One vault for{" "}
           <span className="font-mono">{app || "this app"}</span>. Add
           KEY=value pairs here — they are injected into the running app.
@@ -151,14 +151,14 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
           these; chat users never paste API keys.
         </p>
         {detail.secretsError && (
-          <div className="mt-3 rounded-md border border-red-100 bg-red-50 px-3 py-2 text-xs text-red-700">
+          <div className="mt-3 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
             {detail.secretsError}
           </div>
         )}
       </div>
 
       <div className="px-4 py-3">
-        <div className="mb-2 text-xs font-medium uppercase tracking-wide text-zinc-400">
+        <div className="mb-2 text-xs font-medium uppercase tracking-wide text-dim">
           Add or overwrite
         </div>
         <div className="space-y-2">
@@ -175,7 +175,7 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
                 }
                 placeholder="KEY"
                 aria-label="Environment key"
-                className="h-8 w-40 rounded-md border border-zinc-300 px-2 font-mono text-xs"
+                className="bg-input text-foreground h-8 w-40 rounded-md border border-border px-2 font-mono text-xs"
               />
               <input
                 value={row.value}
@@ -189,14 +189,14 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
                 placeholder="value"
                 aria-label="Environment value"
                 type="password"
-                className="h-8 flex-1 rounded-md border border-zinc-300 px-2 text-xs"
+                className="bg-input text-foreground h-8 flex-1 rounded-md border border-border px-2 text-xs"
               />
             </div>
           ))}
           <button
             type="button"
             onClick={() => setRows((rs) => [...rs, { key: "", value: "" }])}
-            className="inline-flex h-7 items-center gap-1 rounded-md border border-zinc-300 bg-white px-2 text-xs font-medium hover:bg-zinc-50"
+            className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-surface-1 px-2 text-xs font-medium hover:bg-accent-hover"
           >
             <Plus className="size-3.5" aria-hidden />
             Add variable
@@ -208,14 +208,14 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
             type="button"
             disabled={!app || status.kind === "saving"}
             onClick={() => void save()}
-            className="inline-flex h-8 items-center justify-center rounded-md bg-zinc-900 px-3 text-xs font-medium text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex h-8 items-center justify-center rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
           >
             Save values
           </button>
           {status.kind !== "idle" && (
             <span
               className={`text-xs ${
-                status.kind === "error" ? "text-red-600" : "text-zinc-500"
+                status.kind === "error" ? "text-destructive" : "text-dim"
               }`}
             >
               {status.message}
@@ -226,7 +226,7 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
 
       {currentKeys.length > 0 ? (
         <div className="px-4 py-3">
-          <div className="text-xs font-medium uppercase tracking-wide text-zinc-400">
+          <div className="text-xs font-medium uppercase tracking-wide text-dim">
             Configured
           </div>
           <ul className="mt-2 space-y-2">
@@ -236,17 +236,17 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
                 className="flex flex-wrap items-center justify-between gap-2 py-0.5"
               >
                 <span className="flex min-w-0 flex-wrap items-center gap-2">
-                  <span className="truncate font-mono text-xs text-zinc-800">
+                  <span className="truncate font-mono text-xs text-foreground">
                     {key}
                   </span>
-                  <span className="rounded-sm border border-amber-200 bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-700">
+                  <span className="rounded-sm border border-warning/40 bg-warning/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-warning">
                     Builder secret
                   </span>
-                  <span className="rounded-sm border border-zinc-200 bg-zinc-50 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-zinc-600">
+                  <span className="rounded-sm border border-border bg-surface-2 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-dim">
                     Runtime
                   </span>
                   <span
-                    className="font-mono text-xs tracking-widest text-zinc-400"
+                    className="font-mono text-xs tracking-widest text-dim"
                     title="Value is write-only and cannot be revealed"
                     aria-label="Value hidden"
                   >
@@ -257,7 +257,7 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
                   <button
                     type="button"
                     onClick={() => void copyKey(key)}
-                    className="inline-flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-800"
+                    className="inline-flex items-center gap-1 text-xs text-dim hover:text-foreground"
                     title={`Copy ${key}`}
                   >
                     <Copy className="size-3.5" aria-hidden />
@@ -266,7 +266,7 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
                   <button
                     type="button"
                     onClick={() => overwrite(key)}
-                    className="text-xs text-zinc-500 hover:text-zinc-800"
+                    className="text-xs text-dim hover:text-foreground"
                     title={`Overwrite ${key}`}
                   >
                     Overwrite
@@ -274,7 +274,7 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
                   <button
                     type="button"
                     onClick={() => void remove(key)}
-                    className="inline-flex items-center gap-1 text-xs text-zinc-400 hover:text-red-600"
+                    className="inline-flex items-center gap-1 text-xs text-dim hover:text-destructive"
                     title={`Delete ${key}`}
                   >
                     <Trash2 className="size-3.5" aria-hidden />
@@ -287,8 +287,8 @@ export function EnvironmentTab({ detail }: { detail: Detail }) {
         </div>
       ) : (
         appNames.length > 0 && (
-          <div className="px-4 py-4 text-sm text-zinc-500">
-            <p className="font-medium text-zinc-700">No variables yet</p>
+          <div className="px-4 py-4 text-sm text-dim">
+            <p className="font-medium text-foreground">No variables yet</p>
             <p className="mt-1 text-xs leading-5">
               Add keys your agent needs (for example{" "}
               <span className="font-mono">BINANCE_API_KEY</span>). Builders set

--- a/apps/aomi-build/src/features/launch/components/deployments/tabs/settings-tab.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/tabs/settings-tab.tsx
@@ -9,7 +9,7 @@ type Detail = ReturnType<typeof useProjectDetail>;
 function Row({ label, value }: { label: string; value: string }) {
   return (
     <div className="grid grid-cols-[130px_1fr] gap-3 px-4 py-3">
-      <dt className="text-zinc-500">{label}</dt>
+      <dt className="text-dim">{label}</dt>
       <dd className="min-w-0 truncate font-medium">{value}</dd>
     </div>
   );
@@ -30,29 +30,29 @@ export function SettingsTab({ detail }: { detail: Detail }) {
 
   return (
     <div className="text-sm">
-      <dl className="divide-y divide-zinc-100">
+      <dl className="divide-y divide-border">
         <Row label="Repository" value={source.repositoryLink ?? "-"} />
         <Row label="Source ID" value={`#${source.id}`} />
         <Row label="Installation" value={String(source.installationId)} />
       </dl>
-      <div className="flex items-center justify-between border-t border-zinc-200 px-4 py-3">
+      <div className="flex items-center justify-between border-t border-border px-4 py-3">
         <div>
           <div className="font-medium">SDK compatibility</div>
-          <div className="mt-1 text-xs text-zinc-500">
+          <div className="mt-1 text-xs text-dim">
             Backend requires {required ?? "unknown"}
           </div>
         </div>
         <SdkBadge stamped={stamped} required={required} />
       </div>
-      <div className="border-t border-zinc-200 px-4 py-4">
-        <div className="text-sm font-medium text-zinc-900">Danger zone</div>
-        <p className="mt-1 text-xs text-zinc-500">
+      <div className="border-t border-border px-4 py-4">
+        <div className="text-sm font-medium text-foreground">Danger zone</div>
+        <p className="mt-1 text-xs text-dim">
           Disconnecting a project is not available yet.
         </p>
         <button
           type="button"
           disabled
-          className="mt-3 inline-flex h-8 cursor-not-allowed items-center rounded-md border border-zinc-200 px-3 text-xs font-medium text-zinc-400"
+          className="mt-3 inline-flex h-8 cursor-not-allowed items-center rounded-md border border-border px-3 text-xs font-medium text-dim"
         >
           Disconnect (coming soon)
         </button>

--- a/apps/aomi-build/src/features/launch/components/deployments/ui/confirm-dialog.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/ui/confirm-dialog.tsx
@@ -19,22 +19,22 @@ export function ConfirmDialog({
       <div
         role="dialog"
         aria-label={title}
-        className="w-full max-w-sm rounded-lg border border-zinc-200 bg-white p-4 shadow-lg"
+        className="w-full max-w-sm rounded-lg border border-border bg-surface-1 p-4 shadow-lg"
       >
         <div className="text-sm font-semibold">{title}</div>
-        <p className="mt-2 text-sm text-zinc-600">{body}</p>
+        <p className="mt-2 text-sm text-dim">{body}</p>
         <div className="mt-4 flex justify-end gap-2">
           <button
             type="button"
             onClick={onCancel}
-            className="h-8 rounded-md border border-zinc-300 px-3 text-sm font-medium hover:bg-zinc-50"
+            className="h-8 rounded-md border border-border px-3 text-sm font-medium hover:bg-accent-hover"
           >
             Cancel
           </button>
           <button
             type="button"
             onClick={onConfirm}
-            className="h-8 rounded-md bg-zinc-950 px-3 text-sm font-medium text-white hover:bg-zinc-800"
+            className="h-8 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:opacity-90"
           >
             {confirmLabel}
           </button>

--- a/apps/aomi-build/src/features/launch/components/deployments/ui/sdk-badge.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/ui/sdk-badge.tsx
@@ -14,10 +14,10 @@ export function SdkBadge({
         : "missing";
   const tone =
     state === "ok"
-      ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+      ? "border-positive/40 bg-positive/10 text-positive"
       : state === "outdated"
-        ? "border-amber-200 bg-amber-50 text-amber-700"
-        : "border-zinc-200 bg-zinc-50 text-zinc-600";
+        ? "border-warning/40 bg-warning/10 text-warning"
+        : "border-border bg-surface-2 text-dim";
   return (
     <span
       data-testid="sdk-badge"

--- a/apps/aomi-build/src/features/launch/components/deployments/ui/state-panels.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/ui/state-panels.tsx
@@ -4,7 +4,7 @@ import { GITHUB_SIGNIN_URL } from "@build/features/launch/dashboard";
 
 export function LoadingPanel({ label }: { label: string }) {
   return (
-    <div className="flex min-h-[260px] items-center justify-center px-4 py-10 text-center text-sm text-zinc-500">
+    <div className="flex min-h-[260px] items-center justify-center px-4 py-10 text-center text-sm text-dim">
       {label}
     </div>
   );
@@ -12,7 +12,7 @@ export function LoadingPanel({ label }: { label: string }) {
 
 export function ErrorPanel({ message }: { message: string }) {
   return (
-    <div className="flex min-h-[260px] items-center justify-center px-4 py-10 text-center text-sm text-red-600">
+    <div className="flex min-h-[260px] items-center justify-center px-4 py-10 text-center text-sm text-destructive">
       {message}
     </div>
   );
@@ -20,7 +20,7 @@ export function ErrorPanel({ message }: { message: string }) {
 
 export function EmptyPanel({ children }: { children: ReactNode }) {
   return (
-    <div className="flex min-h-[260px] flex-col items-center justify-center gap-2 px-4 py-10 text-center text-sm text-zinc-500">
+    <div className="flex min-h-[260px] flex-col items-center justify-center gap-2 px-4 py-10 text-center text-sm text-dim">
       {children}
     </div>
   );
@@ -40,24 +40,24 @@ export function GitHubSignInPanel({ error }: { error?: string | null }) {
 
   return (
     <div className="flex min-h-[320px] flex-col items-center justify-center gap-4 px-4 py-10 text-center">
-      <div className="flex size-10 items-center justify-center rounded-full border border-zinc-200">
+      <div className="flex size-10 items-center justify-center rounded-full border border-border">
         <Github className="size-5" aria-hidden />
       </div>
       <div>
         <div className="text-base font-semibold">Sign in with GitHub</div>
-        <div className="mt-1 max-w-md text-sm leading-6 text-zinc-500">
+        <div className="mt-1 max-w-md text-sm leading-6 text-dim">
           Deployment history is scoped to repositories connected to your GitHub
           account.
         </div>
       </div>
       {errorMessage && (
-        <div className="max-w-xl rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-left text-sm leading-6 text-amber-900">
+        <div className="max-w-xl rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-left text-sm leading-6 text-warning">
           {errorMessage}
         </div>
       )}
       <a
         href={GITHUB_SIGNIN_URL}
-        className="inline-flex h-9 items-center justify-center rounded-md bg-zinc-950 px-3 text-sm font-medium text-white hover:bg-zinc-800"
+        className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:opacity-90"
       >
         Continue with GitHub
       </a>

--- a/apps/aomi-build/src/features/launch/components/deployments/ui/status-dot.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/ui/status-dot.tsx
@@ -1,9 +1,9 @@
 export function StatusDot({ state }: { state: string }) {
   const tone =
     state === "ready" || state === "live" || state === "recorded"
-      ? "bg-emerald-500"
+      ? "bg-positive"
       : state === "failed" || state === "deactivated"
-        ? "bg-red-500"
-        : "bg-zinc-400";
+        ? "bg-destructive"
+        : "bg-muted-foreground";
   return <span className={`size-2 rounded-full ${tone}`} />;
 }

--- a/apps/aomi-build/src/features/launch/components/deployments/ui/status-pill.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/ui/status-pill.tsx
@@ -1,10 +1,10 @@
 export function StatusPill({ value }: { value: string }) {
   const tone =
     value === "ready" || value === "live" || value === "recorded"
-      ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+      ? "border-positive/40 bg-positive/10 text-positive"
       : value === "failed"
-        ? "border-red-200 bg-red-50 text-red-700"
-        : "border-zinc-200 bg-zinc-50 text-zinc-700";
+        ? "border-destructive/40 bg-destructive/10 text-destructive"
+        : "border-border bg-surface-2 text-foreground";
   return (
     <span
       className={`inline-flex h-6 items-center rounded-full border px-2 text-xs font-medium ${tone}`}

--- a/apps/aomi-build/src/features/launch/components/deployments/ui/timeline-deployment-row.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/ui/timeline-deployment-row.tsx
@@ -21,7 +21,7 @@ export function TimelineDeploymentRow({
     deployment;
 
   return (
-    <div className="grid min-h-[76px] grid-cols-[minmax(0,1fr)_auto] items-center gap-4 border-b border-zinc-100 px-4 py-3 last:border-b-0">
+    <div className="grid min-h-[76px] grid-cols-[minmax(0,1fr)_auto] items-center gap-4 border-b border-border px-4 py-3 last:border-b-0">
       <div className="min-w-0">
         <div className="flex min-w-0 items-center gap-2">
           <div className="truncate text-sm font-medium">{deploymentId}</div>
@@ -29,8 +29,8 @@ export function TimelineDeploymentRow({
             <span
               className={`shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium ${
                 runtimeState === "not-loaded"
-                  ? "bg-amber-50 text-amber-700"
-                  : "bg-emerald-50 text-emerald-700"
+                  ? "bg-warning/10 text-warning"
+                  : "bg-positive/10 text-positive"
               }`}
             >
               {runtimeState === "not-loaded"
@@ -39,7 +39,7 @@ export function TimelineDeploymentRow({
             </span>
           )}
         </div>
-        <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-zinc-500">
+        <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-dim">
           <span className="inline-flex items-center gap-1 font-mono">
             <GitCommitHorizontal className="size-3.5" aria-hidden />
             {commit ?? "unknown"}
@@ -51,7 +51,7 @@ export function TimelineDeploymentRow({
             {new Date(createdAt * 1000).toLocaleString()}
           </span>
         </div>
-        {message && <div className="mt-1 text-xs text-zinc-500">{message}</div>}
+        {message && <div className="mt-1 text-xs text-dim">{message}</div>}
       </div>
 
       <div className="flex items-center gap-2">
@@ -60,7 +60,7 @@ export function TimelineDeploymentRow({
             type="button"
             disabled={busy}
             onClick={onPromote}
-            className="inline-flex h-8 items-center justify-center gap-1.5 rounded-md border border-zinc-300 bg-white px-2.5 text-xs font-medium text-zinc-800 hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex h-8 items-center justify-center gap-1.5 rounded-md border border-border bg-surface-1 px-2.5 text-xs font-medium text-foreground hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
             title="Promote this deployment to live"
           >
             <RotateCcw className="size-3.5" aria-hidden />


### PR DESCRIPTION
## Summary
- Swap zinc/white classes on Projects, project detail, Environment, and deployment lists to shared dark shell tokens (`surface` / `border` / `dim` / semantic status colors).
- Match Overview and Operate visually — class renames only, no layout redesign.
- Leave New app alone (already dark). Fix stale ProjectRow href test expectation.

## Test plan
- [ ] Projects list: dark background, rows, buttons match shell
- [ ] Open a project: tabs, Deployments, Environment, Details all dark
- [ ] Global Deployments list: filters + rows dark; Current / status chips readable
- [ ] Environment inputs and configured rows readable on dark
- [ ] Overview / Operate / New app unchanged in behavior
- [ ] `pnpm exec vitest run src/features/launch/components/deployments` passes