### PR TITLE
fix(aomi-build): keep Account → Secrets on settings until explicit click

### DIFF
--- a/apps/aomi-build/BUILDERS-EXPERIENCE.md
+++ b/apps/aomi-build/BUILDERS-EXPERIENCE.md
@@ -111,9 +111,11 @@ flowchart LR
 flowchart LR
   Secrets["/settings/secrets"] --> N{project_count}
   N -->|0| Empty["Explain + New app CTA"]
-  N -->|1| Auto["Replace to /projects/id?tab=environment"]
+  N -->|1| One["Teach + Open Environment CTA"]
   N -->|2plus| List["List projects → Environment"]
 ```
+
+Stay on Account Settings until the builder clicks through. No auto-redirect.
 
 | Piece | Action |
 |---|---|
@@ -124,9 +126,9 @@ flowchart LR
 
 **Do not** add a secret editor on this page.
 
-**Done when:** No dead button; 0 / 1 / 2+ behaviors work; builders land in Environment.
+**Done when:** No dead button; 0 / 1 / 2+ stay on Settings until click; builders land in Environment only after an explicit CTA.
 
-**Stop gate:** Open `/settings/secrets` signed in. Does it feel like guidance, not a broken settings page?
+**Stop gate:** Open `/settings/secrets` with one project. Do you stay in Account and choose to open Environment?
 
 ---
 

--- a/apps/aomi-build/src/app/(control-plane)/settings/settings-secrets-panel.test.tsx
+++ b/apps/aomi-build/src/app/(control-plane)/settings/settings-secrets-panel.test.tsx
@@ -1,11 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
-
-const replace = vi.fn();
-
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ replace }),
-}));
+import { render, screen } from "@testing-library/react";
 
 vi.mock("@build/features/launch/hooks/use-projects", () => ({
   useProjects: vi.fn(),
@@ -18,7 +12,6 @@ const useProjectsMock = vi.mocked(useProjects);
 
 describe("SettingsSecretsPanel", () => {
   beforeEach(() => {
-    replace.mockReset();
     useProjectsMock.mockReset();
   });
 
@@ -41,7 +34,7 @@ describe("SettingsSecretsPanel", () => {
     );
   });
 
-  it("auto-routes a single project to its Environment tab", async () => {
+  it("stays on Settings for a single project with an Environment CTA", () => {
     useProjectsMock.mockReturnValue({
       state: {
         status: "ready",
@@ -61,9 +54,12 @@ describe("SettingsSecretsPanel", () => {
     });
 
     render(<SettingsSecretsPanel />);
-    await waitFor(() =>
-      expect(replace).toHaveBeenCalledWith("/projects/7?tab=environment"),
-    );
+
+    expect(screen.getByText(/Secrets are managed per project/i)).toBeTruthy();
+    expect(screen.getByText(/alice\/only-bot/i)).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: /Open Environment/i }),
+    ).toHaveAttribute("href", "/projects/7?tab=environment");
   });
 
   it("lists projects that deep-link to Environment", () => {
@@ -101,6 +97,5 @@ describe("SettingsSecretsPanel", () => {
       "href",
       "/projects/4?tab=environment",
     );
-    expect(replace).not.toHaveBeenCalled();
   });
 });

--- a/apps/aomi-build/src/app/(control-plane)/settings/settings-secrets-panel.tsx
+++ b/apps/aomi-build/src/app/(control-plane)/settings/settings-secrets-panel.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
 import { ArrowRight } from "lucide-react";
 
 import { useProjects } from "@build/features/launch/hooks/use-projects";
@@ -24,16 +22,7 @@ function projectLabel(source: {
 }
 
 export function SettingsSecretsPanel() {
-  const router = useRouter();
   const { state } = useProjects();
-
-  useEffect(() => {
-    if (state.status !== "ready") return;
-    if (state.sources.length !== 1) return;
-    const only = state.sources[0];
-    if (!only) return;
-    router.replace(environmentHref(only.id));
-  }, [router, state]);
 
   if (state.status === "loading") {
     return <LoadingPanel label="Loading projects…" />;
@@ -68,7 +57,31 @@ export function SettingsSecretsPanel() {
   }
 
   if (state.sources.length === 1) {
-    return <LoadingPanel label="Opening project environment…" />;
+    const only = state.sources[0]!;
+    const label = projectLabel(only);
+
+    return (
+      <div className="space-y-3">
+        <div className="rounded-lg border border-border bg-surface-1 p-4">
+          <div className="text-sm font-medium text-foreground">
+            Secrets are managed per project
+          </div>
+          <p className="mt-2 text-[13px] text-dim">
+            Secrets for{" "}
+            <span className="text-foreground font-medium">{label}</span> live
+            on that project&apos;s Environment tab. There is no account-wide
+            secret store.
+          </p>
+          <Link
+            href={environmentHref(only.id)}
+            className="mt-4 inline-flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-[12px] font-medium text-primary-foreground transition hover:bg-brand-hover"
+          >
+            Open Environment
+            <ArrowRight className="size-3.5" aria-hidden />
+          </Link>
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -94,9 +107,7 @@ export function SettingsSecretsPanel() {
                 <div className="text-foreground truncate text-sm font-medium">
                   {projectLabel(source)}
                 </div>
-                <div className="text-dim mt-0.5 text-xs">
-                  Environment →
-                </div>
+                <div className="text-dim mt-0.5 text-xs">Environment →</div>
               </div>
               <ArrowRight className="text-dim size-4 shrink-0" aria-hidden />
             </Link>

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,9 +2,17 @@
 
 ## Last Updated
 
-2026-07-13 — Billing experience Phase A: settings sub-nav on PR #319 branch;
-2026-07-12 — Billing experience Phase A (local branch); 2026-07-11 staging Para
-sign-in fix + Overview read-path perf
+2026-07-13 — Account → Secrets: no single-project auto-redirect (explicit CTA);
+2026-07-13 — Billing experience Phase A merged (PR #319); 2026-07-11 staging
+Para sign-in fix + Overview read-path perf
+
+## Account → Secrets stay-on-settings (2026-07-13)
+
+Branch `feat/settings-secrets-no-auto-redirect`:
+
+- Single-project path no longer `router.replace`s to Environment.
+- Account → Secrets stays put with teaching copy + **Open Environment** CTA.
+- 0 / 2+ behaviors unchanged. Tests updated in `settings-secrets-panel.test.tsx`.
 
 ## Billing experience Phase A — settings sub-nav (2026-07-13)
 


### PR DESCRIPTION
## Summary

- Single-project Account → Secrets no longer `router.replace`s to Project → Environment.
- Stays on Settings with teaching copy naming the project and an **Open Environment** CTA.
- 0-project empty state and 2+ project picker unchanged. Updates Phase 2 flow in `BUILDERS-EXPERIENCE.md`.

## Why

Silent bounce broke Account mental model (especially with the new settings sub-nav). Destination stays Environment; entry teaches and routes only on click.

## Test plan

- [ ] `/settings/secrets` with **1 project** — stay on Settings; see project name + Open Environment
- [ ] Click CTA → `/projects/{id}?tab=environment`
- [ ] Browser Back returns to Settings → Secrets
- [ ] 0 projects → New app CTA; 2+ → project list
- [ ] `pnpm exec vitest run src/app/(control-plane)/settings/settings-secrets-panel.test.tsx`