### PR TITLE
docs(aomi-build): backend↔UI map in BILLING-EXPERIENCE.md

### DIFF
--- a/apps/aomi-build/BILLING-EXPERIENCE.md
+++ b/apps/aomi-build/BILLING-EXPERIENCE.md
@@ -1,10 +1,9 @@
 # Aomi Build — Billing Experience Plan
 
-> **Status:** Phase A done — stop for staging click-through  
+> **Status:** Phase A merged (#319, #320) — stop for staging click-through  
 > **App:** `aomi/apps/aomi-build` → [build.aomi.dev](https://build.aomi.dev)  
 > **Owner:** Gordian (`0xgordian`)  
-> **Branch:** `feat/builders-billing-experience-phase-a`  
-> **Last updated:** 2026-07-12
+> **Last updated:** 2026-07-13
 
 Execution plan for the **billing experience** on Build.  
 Not a payments product. Not a rewrite of Kevin’s rails. Not fake invoice UI.
@@ -35,7 +34,7 @@ flowchart TD
 |---|---|
 | Where builders/users *see* spend, caps, empty states | x402 / Tempo / ledger / `billing.toml` runtime |
 | Account → Billing as an honest page | Partner settlement math, treasury |
-| Linking Usage ↔ Billing ↔ Environment | New payment APIs |
+| Linking Usage ↔ Billing ↔ Environment | New payment APIs (unless already exposed) |
 
 **Rules:** reuse Kevin/Han wiring; smallest fix that answers *Where am I? What is this? What next?*; no Vercel Billing clone; no mocks that look like live invoices.
 
@@ -47,10 +46,112 @@ flowchart TD
 |---|---|
 | **Project → Environment** | Builder vault — API keys so the app can run |
 | **Operate → Usage** | Meter — credits / tokens already spent |
-| **Account → Billing** | Money / plan — balance, methods, invoices *when wired* |
+| **Account → Billing** | Money / plan — methods now; balance / invoices *when HTTP exists* |
 | **Chat** | Pay in the moment — silent 402; Build explains after |
 
 Environment ≠ Billing. Usage ≠ broken Billing.
+
+Cursor-style ownership: **Usage = spend charts; Billing = payment / account money; Chat = paywall moment.**
+
+---
+
+## How the backend works (product-mono, code-checked)
+
+Verified against `product-mono` (not wishful APIs). Control plane loads prices; data plane admits, meters, charges, persists; chat closes the loop on the *next* admission.
+
+### Control plane — sidecar load & bind
+
+```mermaid
+flowchart LR
+  A["&lt;app&gt;.billing.toml<br/>sidecar data"]
+  B["AppStore<br/>sync_billing_sidecars"]
+  C["AppLoader<br/>validate or refuse"]
+  D["ToolScheduler<br/>pricing_for tool"]
+
+  A --> B --> C --> D
+```
+
+- Missing file = free app; invalid file = refuse load.
+- Pure data — never compiled, never crosses FFI.
+- Unlisted / zero-price tools stay free.
+- **Build:** no toml editor. Phase B badge only when a *read* API exists for priced tools / sidecar presence.
+
+### Data plane — admit → meter → charge → persist → feed back
+
+```mermaid
+flowchart TD
+  AH["Chat admission<br/>402 + TurnBudget"]
+  TS["Thread queue<br/>InputPrompt.budget"]
+  CC["CallConsumer<br/>price_block / BillItem"]
+  BT["process_usage_event<br/>partition fees"]
+  DB["llm_usage_events<br/>ledger"]
+
+  AH --> TS --> CC --> BT --> DB
+  DB -.->|"next admission:<br/>net_credits → TurnBudget<br/>outstanding_recipients → partner 402"| AH
+```
+
+| Hop | What happens | UI? |
+|---|---|---|
+| Admission | `compute_turn_budget`; partner settlement may 402 first | Chat only |
+| Guard | `pricing_for` → block or dispatch; charge on success only | Chat (`payment_required`) |
+| Persist | Aomi fees → turn `credits_used`; partner → `{event}:fee:{recipient}` | Ledger; not a Build page yet |
+| Feedback | `net_credits` / `outstanding_recipients` at **next** chat gate | Internal today — no HTTP |
+
+### HTTP available to UI today
+
+| Endpoint | Returns | Build home |
+|---|---|---|
+| `GET …/sources/:id/usage` | Daily credits/tokens + breakdown | **Operate → Usage** (live) |
+| `GET /api/account/usage` | Tier `credit_used` vs `credit_paid` (cap) + per-app | Portal / optional Build mirror |
+| `GET /api/account/payment` | `{ byok, streams }` — **methods only** | Account → Billing (can wire next) |
+
+### Exists in code, **not** HTTP yet
+
+| Symbol | Used for | UI implication |
+|---|---|---|
+| `TokenHandler::net_credits` | Turn budget at admission | Do **not** invent balance from Usage rollups |
+| `outstanding_recipients` | Partner 402 `pay_to` | Phase D needs a read API |
+| `AppBillingConfig` / pricing registry | App load bind | Phase B needs a presence/catalog read |
+
+---
+
+## UI map — now vs should
+
+```mermaid
+flowchart TB
+  subgraph build [Build UI]
+    ENV["Project → Environment<br/>keys vault"]
+    USAGE["Operate → Usage<br/>spend meter"]
+    BILL["Account → Billing<br/>money / methods"]
+    NAV["Settings sub-nav"]
+  end
+
+  subgraph chat [Chat]
+    PAY["Silent 402 / wallet pay"]
+  end
+
+  subgraph api [HTTP today]
+    U1["sources/:id/usage"]
+    U2["/api/account/usage"]
+    P1["/api/account/payment"]
+  end
+
+  U1 --> USAGE
+  U2 -.-> USAGE
+  P1 -.->|"methods status — next"| BILL
+  NAV --> BILL
+  NAV --> ENV
+  PAY -.->|"Build explains after"| BILL
+```
+
+| Surface | Like Cursor… | Now | Should (still backend-true) |
+|---|---|---|---|
+| **Operate → Usage** | Usage / spend charts | Live meter + honest copy | Period polish; don’t mix partner fee rows into LLM meter |
+| **Account → Billing** | Settings → Billing | Phase A guidance + links | Wire **payment methods** from `GET /api/account/payment`; later balance / partner debt when HTTP wraps existing DB helpers |
+| **Project → Environment** | Project secrets | Shipped; Secrets stays on Settings until explicit CTA (#320) | Unchanged |
+| **Chat** | Paywall moment | 402 in-band | Stay out of Build |
+
+**Do not build:** `billing.toml` editor · fake invoices · fake balance from Usage · account-wide secret store · Build “Pay now” duplicate of chat 402.
 
 ---
 
@@ -65,6 +166,7 @@ Environment ≠ Billing. Usage ≠ broken Billing.
 | `[section]/page.tsx` | Render panel when `slug === "billing"`; enable navigation to the page |
 | Settings sub-nav | `SettingsNav` + `SettingsLayout` on all `/settings` routes; Overview + sections from `settings-data.ts`; Planned/Available/Project-scoped badges |
 | Overview + Usage | One sentence: credits meter ≠ partner fees / Billing is for money-plan later |
+| Secrets entry (#320) | Single-project: stay on Settings + **Open Environment** CTA (no auto-redirect) |
 
 **Do not:** fake invoices, balance widgets, `billing.toml` editors, payment forms.
 
@@ -79,20 +181,25 @@ Environment ≠ Billing. Usage ≠ broken Billing.
 Thin signal only when an API exposes priced tools / `billing.toml`: badge or Details note (“this app may charge users”).  
 No Build form for editing `billing.toml` until product asks.
 
-**Stop gate:** Only start after Phase A feels solid.
+**Stop gate:** Only start after Phase A feels solid **and** a read API exists (code today: load-time only).
 
 ---
 
 ## Phase C — Chat-user spend (when APIs ready)
 
-Account → Billing becomes real: balance / net credits, payment method status, spend caps (if API allows), link to Usage, empty = how to top up / connect wallet.  
+Account → Billing becomes real:
+
+1. **Near-term (API exists):** payment method status via `GET /api/account/payment` (BYOK / Tempo connected?).
+2. **When wrapped:** balance / `net_credits` per method, spend caps if exposed, link to Usage, empty = how to top up / connect wallet.
+
 Chat keeps silent 402.
 
 ---
 
 ## Phase D — Partner fee visibility (later)
 
-Only when ledger exposes partner `BillItem`s: line items “Paid to partner X”; optional tx hash → Transactions.
+Only when ledger exposes partner debt / `BillItem`s over HTTP: line items “Paid to partner X”; optional tx hash → Transactions.  
+Until then partner settlement stays chat-runtime (`outstanding_recipients` at admission).
 
 ---
 
@@ -102,8 +209,9 @@ Only when ledger exposes partner `BillItem`s: line items “Paid to partner X”
 2. Settings → Billing opens (not greyed-out dead)  
 3. Copy points to **Operate → Usage** for spend  
 4. Copy points to **Secrets / Environment** for API keys  
-5. Overview / Usage helper doesn’t imply partner fees are shown there yet  
-6. No invoice table or mock balance  
+5. Secrets with one project: stay on Settings until **Open Environment**  
+6. Overview / Usage helper doesn’t imply partner fees are shown there yet  
+7. No invoice table or mock balance  
 
 ---
 

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,9 +2,14 @@
 
 ## Last Updated
 
+2026-07-13 — BILLING-EXPERIENCE.md: backend ↔ UI map (code-checked);
 2026-07-13 — Account → Secrets: no single-project auto-redirect (explicit CTA);
-2026-07-13 — Billing experience Phase A merged (PR #319); 2026-07-11 staging
-Para sign-in fix + Overview read-path perf
+2026-07-13 — Billing experience Phase A merged (PR #319)
+
+## Billing experience — backend/UI map in plan doc (2026-07-13)
+
+- Expanded `apps/aomi-build/BILLING-EXPERIENCE.md` with control/data plane
+  mermaid, HTTP-vs-internal table, and Build UI now/should map (Cursor-style).
 
 ## Account → Secrets stay-on-settings (2026-07-13)
 


### PR DESCRIPTION
## Summary

- Expands `BILLING-EXPERIENCE.md` with code-checked control/data plane diagrams.
- Tables for HTTP available today vs internal-only (`net_credits`, partner debt).
- Build UI now vs should map (Cursor-style Usage vs Billing).

## Test plan

- [ ] Skim mermaid renders on GitHub
- [ ] Confirm Phase A–D + checklist still coherent