### PR TITLE
fix(aomi-build): Billing option A — payment methods live on Chat

### DIFF
--- a/apps/aomi-build/BILLING-EXPERIENCE.md
+++ b/apps/aomi-build/BILLING-EXPERIENCE.md
@@ -1,10 +1,9 @@
 # Aomi Build — Billing Experience Plan
 
-> **Status:** Phase A done — stop for staging click-through  
+> **Status:** Phase A merged; option A — methods point to Chat (Build has no AccountBearer)  
 > **App:** `aomi/apps/aomi-build` → [build.aomi.dev](https://build.aomi.dev)  
 > **Owner:** Gordian (`0xgordian`)  
-> **Branch:** `feat/builders-billing-experience-phase-a`  
-> **Last updated:** 2026-07-12
+> **Last updated:** 2026-07-13
 
 Execution plan for the **billing experience** on Build.  
 Not a payments product. Not a rewrite of Kevin’s rails. Not fake invoice UI.
@@ -35,7 +34,7 @@ flowchart TD
 |---|---|
 | Where builders/users *see* spend, caps, empty states | x402 / Tempo / ledger / `billing.toml` runtime |
 | Account → Billing as an honest page | Partner settlement math, treasury |
-| Linking Usage ↔ Billing ↔ Environment | New payment APIs |
+| Linking Usage ↔ Billing ↔ Environment | New payment APIs (unless already exposed) |
 
 **Rules:** reuse Kevin/Han wiring; smallest fix that answers *Where am I? What is this? What next?*; no Vercel Billing clone; no mocks that look like live invoices.
 
@@ -47,10 +46,112 @@ flowchart TD
 |---|---|
 | **Project → Environment** | Builder vault — API keys so the app can run |
 | **Operate → Usage** | Meter — credits / tokens already spent |
-| **Account → Billing** | Money / plan — balance, methods, invoices *when wired* |
+| **Account → Billing** | Money / plan — methods now; balance / invoices *when HTTP exists* |
 | **Chat** | Pay in the moment — silent 402; Build explains after |
 
 Environment ≠ Billing. Usage ≠ broken Billing.
+
+Cursor-style ownership: **Usage = spend charts; Billing = payment / account money; Chat = paywall moment.**
+
+---
+
+## How the backend works (product-mono, code-checked)
+
+Verified against `product-mono` (not wishful APIs). Control plane loads prices; data plane admits, meters, charges, persists; chat closes the loop on the *next* admission.
+
+### Control plane — sidecar load & bind
+
+```mermaid
+flowchart LR
+  A["&lt;app&gt;.billing.toml<br/>sidecar data"]
+  B["AppStore<br/>sync_billing_sidecars"]
+  C["AppLoader<br/>validate or refuse"]
+  D["ToolScheduler<br/>pricing_for tool"]
+
+  A --> B --> C --> D
+```
+
+- Missing file = free app; invalid file = refuse load.
+- Pure data — never compiled, never crosses FFI.
+- Unlisted / zero-price tools stay free.
+- **Build:** no toml editor. Phase B badge only when a *read* API exists for priced tools / sidecar presence.
+
+### Data plane — admit → meter → charge → persist → feed back
+
+```mermaid
+flowchart TD
+  AH["Chat admission<br/>402 + TurnBudget"]
+  TS["Thread queue<br/>InputPrompt.budget"]
+  CC["CallConsumer<br/>price_block / BillItem"]
+  BT["process_usage_event<br/>partition fees"]
+  DB["llm_usage_events<br/>ledger"]
+
+  AH --> TS --> CC --> BT --> DB
+  DB -.->|"next admission:<br/>net_credits → TurnBudget<br/>outstanding_recipients → partner 402"| AH
+```
+
+| Hop | What happens | UI? |
+|---|---|---|
+| Admission | `compute_turn_budget`; partner settlement may 402 first | Chat only |
+| Guard | `pricing_for` → block or dispatch; charge on success only | Chat (`payment_required`) |
+| Persist | Aomi fees → turn `credits_used`; partner → `{event}:fee:{recipient}` | Ledger; not a Build page yet |
+| Feedback | `net_credits` / `outstanding_recipients` at **next** chat gate | Internal today — no HTTP |
+
+### HTTP available to UI today
+
+| Endpoint | Returns | Build home |
+|---|---|---|
+| `GET …/sources/:id/usage` | Daily credits/tokens + breakdown | **Operate → Usage** (live) |
+| `GET /api/account/usage` | Tier `credit_used` vs `credit_paid` (cap) + per-app | Portal / optional Build mirror |
+| `GET /api/account/payment` | `{ byok, streams }` — **methods only** | Account → Billing (can wire next) |
+
+### Exists in code, **not** HTTP yet
+
+| Symbol | Used for | UI implication |
+|---|---|---|
+| `TokenHandler::net_credits` | Turn budget at admission | Do **not** invent balance from Usage rollups |
+| `outstanding_recipients` | Partner 402 `pay_to` | Phase D needs a read API |
+| `AppBillingConfig` / pricing registry | App load bind | Phase B needs a presence/catalog read |
+
+---
+
+## UI map — now vs should
+
+```mermaid
+flowchart TB
+  subgraph build [Build UI]
+    ENV["Project → Environment<br/>keys vault"]
+    USAGE["Operate → Usage<br/>spend meter"]
+    BILL["Account → Billing<br/>money / methods"]
+    NAV["Settings sub-nav"]
+  end
+
+  subgraph chat [Chat]
+    PAY["Silent 402 / wallet pay"]
+  end
+
+  subgraph api [HTTP today]
+    U1["sources/:id/usage"]
+    U2["/api/account/usage"]
+    P1["/api/account/payment"]
+  end
+
+  U1 --> USAGE
+  U2 -.-> USAGE
+  P1 -.->|"methods status — next"| BILL
+  NAV --> BILL
+  NAV --> ENV
+  PAY -.->|"Build explains after"| BILL
+```
+
+| Surface | Like Cursor… | Now | Should (still backend-true) |
+|---|---|---|---|
+| **Operate → Usage** | Usage / spend charts | Live meter + honest copy | Period polish; don’t mix partner fee rows into LLM meter |
+| **Account → Billing** | Settings → Billing | Phase A guidance + links | Wire **payment methods** from `GET /api/account/payment`; later balance / partner debt when HTTP wraps existing DB helpers |
+| **Project → Environment** | Project secrets | Shipped; Secrets stays on Settings until explicit CTA (#320) | Unchanged |
+| **Chat** | Paywall moment | 402 in-band | Stay out of Build |
+
+**Do not build:** `billing.toml` editor · fake invoices · fake balance from Usage · account-wide secret store · Build “Pay now” duplicate of chat 402.
 
 ---
 
@@ -61,10 +162,11 @@ Environment ≠ Billing. Usage ≠ broken Billing.
 | Change | Action |
 |---|---|
 | `settings-data.ts` billing copy | Honest: invoices later; spend today → Usage; secrets → Environment |
-| `SettingsBillingPanel` | Client island: guidance + links (Usage, Secrets/Environment path) — no invoice UI |
+| `SettingsBillingPanel` | Honesty: methods → Chat account; Usage + Secrets + Open Chat; no invoice / no fake BYOK status |
 | `[section]/page.tsx` | Render panel when `slug === "billing"`; enable navigation to the page |
 | Settings sub-nav | `SettingsNav` + `SettingsLayout` on all `/settings` routes; Overview + sections from `settings-data.ts`; Planned/Available/Project-scoped badges |
 | Overview + Usage | One sentence: credits meter ≠ partner fees / Billing is for money-plan later |
+| Secrets entry (#320) | Single-project: stay on Settings + **Open Environment** CTA (no auto-redirect) |
 
 **Do not:** fake invoices, balance widgets, `billing.toml` editors, payment forms.
 
@@ -79,20 +181,33 @@ Environment ≠ Billing. Usage ≠ broken Billing.
 Thin signal only when an API exposes priced tools / `billing.toml`: badge or Details note (“this app may charge users”).  
 No Build form for editing `billing.toml` until product asks.
 
-**Stop gate:** Only start after Phase A feels solid.
+**Stop gate:** Only start after Phase A feels solid **and** a read API exists (code today: load-time only).
 
 ---
 
-## Phase C — Chat-user spend (when APIs ready)
+## Phase C — Chat-user spend (when APIs *and* Build account auth ready)
 
-Account → Billing becomes real: balance / net credits, payment method status, spend caps (if API allows), link to Usage, empty = how to top up / connect wallet.  
+**Blocker (2026-07-13):** `GET /api/account/payment` exists, but Build is
+GitHub-session only. Proxy does not allowlist `/api/account/*`, and
+`resolveCanonicalUserId` is a no-op — no AccountBearer. A live methods fetch
+would 404/401.
+
+**Shipped (option A):** Billing teaches BYOK / Tempo live on the **Chat
+account**, links Open Chat + Usage + Secrets, and keeps “Not available yet”
+for balance/invoices. No fake method status.
+
+**Later (option B):** Wire BetterAuth → AccountBearer into Build, allowlist
+`GET /api/account/payment`, then show real BYOK/Tempo status. After that:
+balance / `net_credits` only when HTTP wraps those helpers.
+
 Chat keeps silent 402.
 
 ---
 
 ## Phase D — Partner fee visibility (later)
 
-Only when ledger exposes partner `BillItem`s: line items “Paid to partner X”; optional tx hash → Transactions.
+Only when ledger exposes partner debt / `BillItem`s over HTTP: line items “Paid to partner X”; optional tx hash → Transactions.  
+Until then partner settlement stays chat-runtime (`outstanding_recipients` at admission).
 
 ---
 
@@ -100,10 +215,13 @@ Only when ledger exposes partner `BillItem`s: line items “Paid to partner X”
 
 1. Settings sidebar: Overview + all sections visible; active route highlighted  
 2. Settings → Billing opens (not greyed-out dead)  
-3. Copy points to **Operate → Usage** for spend  
-4. Copy points to **Secrets / Environment** for API keys  
-5. Overview / Usage helper doesn’t imply partner fees are shown there yet  
-6. No invoice table or mock balance  
+3. Payment methods copy points to **Chat account** (not a fake Build methods list)  
+4. Copy points to **Operate → Usage** for spend  
+5. Copy points to **Secrets / Environment** for API keys  
+6. Secrets with one project: stay on Settings until **Open Environment**  
+7. Open Chat link works  
+8. Overview / Usage helper doesn’t imply partner fees are shown there yet  
+9. No invoice table or mock balance / “Tempo: Connected” 
 
 ---
 

--- a/apps/aomi-build/BILLING-EXPERIENCE.md
+++ b/apps/aomi-build/BILLING-EXPERIENCE.md
@@ -162,7 +162,7 @@ flowchart TB
 | Change | Action |
 |---|---|
 | `settings-data.ts` billing copy | Honest: invoices later; spend today → Usage; secrets → Environment |
-| `SettingsBillingPanel` | Honesty: methods → Chat account; Usage + Secrets + Open Chat; no invoice / no fake BYOK status |
+| `SettingsBillingPanel` | Honesty: payment setup → Chat; Usage + Secrets + Open Chat; no rail jargon / fake status |
 | `[section]/page.tsx` | Render panel when `slug === "billing"`; enable navigation to the page |
 | Settings sub-nav | `SettingsNav` + `SettingsLayout` on all `/settings` routes; Overview + sections from `settings-data.ts`; Planned/Available/Project-scoped badges |
 | Overview + Usage | One sentence: credits meter ≠ partner fees / Billing is for money-plan later |
@@ -192,13 +192,14 @@ GitHub-session only. Proxy does not allowlist `/api/account/*`, and
 `resolveCanonicalUserId` is a no-op — no AccountBearer. A live methods fetch
 would 404/401.
 
-**Shipped (option A):** Billing teaches BYOK / Tempo live on the **Chat
-account**, links Open Chat + Usage + Secrets, and keeps “Not available yet”
-for balance/invoices. No fake method status.
+**Shipped (option A):** Billing teaches payment setup (credits, own API keys,
+wallet pay) lives on the **Chat account**, links Open Chat + Usage + Secrets,
+and keeps “Not available yet” for balance/invoices. No rail brand names
+(Tempo / BYOK / x402) in Build UI copy; no fake method status.
 
-**Later (option B):** Wire BetterAuth → AccountBearer into Build, allowlist
-`GET /api/account/payment`, then show real BYOK/Tempo status. After that:
-balance / `net_credits` only when HTTP wraps those helpers.
+**Later (option B):** Wire Chat account auth into Build, allowlist
+`GET /api/account/payment`, then show real method status in product language.
+After that: balance / `net_credits` only when HTTP wraps those helpers.
 
 Chat keeps silent 402.
 
@@ -221,7 +222,7 @@ Until then partner settlement stays chat-runtime (`outstanding_recipients` at ad
 6. Secrets with one project: stay on Settings until **Open Environment**  
 7. Open Chat link works  
 8. Overview / Usage helper doesn’t imply partner fees are shown there yet  
-9. No invoice table or mock balance / “Tempo: Connected” 
+9. No invoice table, mock balance, or rail brand names (Tempo / BYOK / x402) in Build UI 
 
 ---
 

--- a/apps/aomi-build/src/app/(control-plane)/settings/settings-billing-panel.test.tsx
+++ b/apps/aomi-build/src/app/(control-plane)/settings/settings-billing-panel.test.tsx
@@ -8,13 +8,11 @@ vi.mock("@build/lib/chat-url", () => ({
 import { SettingsBillingPanel } from "./settings-billing-panel";
 
 describe("SettingsBillingPanel", () => {
-  it("teaches methods live on Chat and does not fake invoices or balances", () => {
+  it("uses product language and does not expose rail jargon or fake invoices", () => {
     render(<SettingsBillingPanel />);
 
     expect(screen.getByText(/^payment methods$/i)).toBeInTheDocument();
-    expect(
-      screen.getByText(/live on your/i),
-    ).toBeInTheDocument();
+    expect(screen.getAllByText(/how chat users pay/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/chat account/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/not available yet/i)).toBeInTheDocument();
     expect(screen.getByText(/does not show live invoices/i)).toBeInTheDocument();
@@ -30,8 +28,10 @@ describe("SettingsBillingPanel", () => {
       "https://chat.aomi.dev",
     );
 
+    expect(screen.queryByText(/tempo/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/byok/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/x402/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/invoice #/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/\$\d/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/tempo: connected/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/aomi-build/src/app/(control-plane)/settings/settings-billing-panel.test.tsx
+++ b/apps/aomi-build/src/app/(control-plane)/settings/settings-billing-panel.test.tsx
@@ -1,22 +1,37 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+
+vi.mock("@build/lib/chat-url", () => ({
+  resolveChatUrl: () => "https://chat.aomi.dev",
+}));
+
 import { SettingsBillingPanel } from "./settings-billing-panel";
 
 describe("SettingsBillingPanel", () => {
-  it("teaches Usage vs Environment and does not fake invoices", () => {
+  it("teaches methods live on Chat and does not fake invoices or balances", () => {
     render(<SettingsBillingPanel />);
 
+    expect(screen.getByText(/^payment methods$/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/billing is not connected yet/i),
+      screen.getByText(/live on your/i),
     ).toBeInTheDocument();
+    expect(screen.getAllByText(/chat account/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/not available yet/i)).toBeInTheDocument();
     expect(screen.getByText(/does not show live invoices/i)).toBeInTheDocument();
+
     expect(
       screen.getByRole("link", { name: /operate → usage/i }),
     ).toHaveAttribute("href", "/operate/usage");
     expect(
       screen.getByRole("link", { name: /account → secrets → environment/i }),
     ).toHaveAttribute("href", "/settings/secrets");
+    expect(screen.getByRole("link", { name: /open chat/i })).toHaveAttribute(
+      "href",
+      "https://chat.aomi.dev",
+    );
+
     expect(screen.queryByText(/invoice #/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/\$\d/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/tempo: connected/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/aomi-build/src/app/(control-plane)/settings/settings-billing-panel.tsx
+++ b/apps/aomi-build/src/app/(control-plane)/settings/settings-billing-panel.tsx
@@ -1,32 +1,53 @@
 import Link from "next/link";
-import { ArrowRight, Gauge, KeyRound } from "lucide-react";
+import { ArrowRight, Gauge, KeyRound, MessageSquare } from "lucide-react";
+
+import { resolveChatUrl } from "@build/lib/chat-url";
 
 /**
- * Phase A honesty panel: Billing is not wired for invoices yet.
- * Teach the map — Usage = meter, Environment = keys — without fake chrome.
+ * Honest Billing panel: teach the map without fake methods or invoices.
+ *
+ * `GET /api/account/payment` exists on the backend but Build is GitHub-session
+ * only today (no AccountBearer / BetterAuth bridge), so we do not fetch it.
  */
 export function SettingsBillingPanel() {
+  const chatUrl = resolveChatUrl();
+
   return (
     <div className="space-y-3">
       <div className="rounded-lg border border-border bg-surface-1 p-4">
         <div className="text-sm font-medium text-foreground">
-          Billing is not connected yet
+          Payment methods
         </div>
         <p className="mt-2 text-[13px] leading-5 text-dim">
-          Plans, invoices, balance, and spend caps will live here when the
-          account billing backend is wired. This page is not a secret vault and
-          does not show live invoices today.
+          BYOK and Tempo stream status live on your{" "}
+          <span className="text-foreground font-medium">Chat account</span>,
+          not in Build. Build uses GitHub for deploy/operate; it does not yet
+          share the Chat account session needed to read payment methods here.
+        </p>
+        <p className="mt-3 text-[13px] leading-5 text-dim">
+          Manage BYOK / Tempo in Chat when signed in. This page will not invent
+          a second methods store.
+        </p>
+      </div>
+
+      <div className="rounded-lg border border-border bg-surface-1 p-4">
+        <div className="text-sm font-medium text-foreground">
+          Not available yet
+        </div>
+        <p className="mt-2 text-[13px] leading-5 text-dim">
+          Balance, invoices, spend caps, and partner fee history will land here
+          when Account billing is wired into Build. This is not a secret vault
+          and does not show live invoices today.
         </p>
         <p className="mt-3 text-[13px] leading-5 text-dim">
           <span className="text-foreground font-medium">Credits today:</span>{" "}
-          see what your apps already spent under Operate → Usage. That meter is
-          platform LLM/token usage — not partner tool fees (those settle in
-          chat when priced tools exist).
+          Operate → Usage meters platform LLM/token spend — not partner tool
+          fees (those settle in chat when priced tools run).
         </p>
         <p className="mt-3 text-[13px] leading-5 text-dim">
-          <span className="text-foreground font-medium">API keys:</span> builders
-          set those on each project&apos;s Environment tab (Account → Secrets
-          routes you there). Chat users never paste keys.
+          <span className="text-foreground font-medium">API keys:</span>{" "}
+          builders set those on each project&apos;s Environment tab (Account →
+          Secrets routes you there). Chat users never paste keys.
         </p>
       </div>
 
@@ -71,6 +92,30 @@ export function SettingsBillingPanel() {
             </div>
             <ArrowRight className="text-dim size-4 shrink-0" aria-hidden />
           </Link>
+        </li>
+        <li>
+          <a
+            href={chatUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="hover:bg-accent-hover flex items-center justify-between gap-3 px-4 py-3 transition"
+          >
+            <div className="flex min-w-0 items-start gap-3">
+              <MessageSquare
+                className="text-dim mt-0.5 size-4 shrink-0"
+                aria-hidden
+              />
+              <div className="min-w-0">
+                <div className="text-foreground text-sm font-medium">
+                  Open Chat
+                </div>
+                <div className="text-dim mt-0.5 text-xs">
+                  Sign in there to manage BYOK / Tempo and settle payments
+                </div>
+              </div>
+            </div>
+            <ArrowRight className="text-dim size-4 shrink-0" aria-hidden />
+          </a>
         </li>
       </ul>
     </div>

--- a/apps/aomi-build/src/app/(control-plane)/settings/settings-billing-panel.tsx
+++ b/apps/aomi-build/src/app/(control-plane)/settings/settings-billing-panel.tsx
@@ -6,8 +6,8 @@ import { resolveChatUrl } from "@build/lib/chat-url";
 /**
  * Honest Billing panel: teach the map without fake methods or invoices.
  *
- * `GET /api/account/payment` exists on the backend but Build is GitHub-session
- * only today (no AccountBearer / BetterAuth bridge), so we do not fetch it.
+ * Payment setup APIs exist on the backend, but Build is GitHub-session only
+ * today (no Chat account bridge), so we do not fetch method status here.
  */
 export function SettingsBillingPanel() {
   const chatUrl = resolveChatUrl();
@@ -19,14 +19,15 @@ export function SettingsBillingPanel() {
           Payment methods
         </div>
         <p className="mt-2 text-[13px] leading-5 text-dim">
-          BYOK and Tempo stream status live on your{" "}
+          How chat users pay (credits, their own API keys, wallet pay) is
+          managed on your{" "}
           <span className="text-foreground font-medium">Chat account</span>,
-          not in Build. Build uses GitHub for deploy/operate; it does not yet
-          share the Chat account session needed to read payment methods here.
+          not in Build. Build uses GitHub for deploy and operate; it does not
+          yet share the Chat session needed to show payment setup here.
         </p>
         <p className="mt-3 text-[13px] leading-5 text-dim">
-          Manage BYOK / Tempo in Chat when signed in. This page will not invent
-          a second methods store.
+          Open Chat while signed in to manage payment setup. This page will not
+          invent a second methods store.
         </p>
       </div>
 
@@ -35,14 +36,14 @@ export function SettingsBillingPanel() {
           Not available yet
         </div>
         <p className="mt-2 text-[13px] leading-5 text-dim">
-          Balance, invoices, spend caps, and partner fee history will land here
-          when Account billing is wired into Build. This is not a secret vault
-          and does not show live invoices today.
+          Balance, invoices, spend caps, and fees paid to app partners will
+          land here when account billing is wired into Build. This is not a
+          secret vault and does not show live invoices today.
         </p>
         <p className="mt-3 text-[13px] leading-5 text-dim">
           <span className="text-foreground font-medium">Credits today:</span>{" "}
-          Operate → Usage meters platform LLM/token spend — not partner tool
-          fees (those settle in chat when priced tools run).
+          Operate → Usage meters platform model/token spend — not fees that
+          settle in Chat when a priced tool runs.
         </p>
         <p className="mt-3 text-[13px] leading-5 text-dim">
           <span className="text-foreground font-medium">API keys:</span>{" "}
@@ -110,7 +111,7 @@ export function SettingsBillingPanel() {
                   Open Chat
                 </div>
                 <div className="text-dim mt-0.5 text-xs">
-                  Sign in there to manage BYOK / Tempo and settle payments
+                  Sign in there to manage how chat users pay
                 </div>
               </div>
             </div>

--- a/apps/aomi-build/src/features/operate/operate-view.tsx
+++ b/apps/aomi-build/src/features/operate/operate-view.tsx
@@ -212,14 +212,14 @@ function Rows({
       return (
         <EmptyState
           title="Usage"
-          description="Credit and token totals appear after your apps run chat turns. This is a usage meter — not invoices or partner fee settlements. Plans and balance will live under Account → Billing when wired."
+          description="Credit and token totals appear after your apps run chat turns. This is a usage meter — not invoices or fees that settle in Chat. Plans and balance will live under Account → Billing when wired."
         />
       );
     return (
       <div className="space-y-3">
         <p className="text-dim text-xs leading-5">
-          Platform LLM/token credits by app and day. Partner tool fees (when
-          priced) settle in chat — they are not listed here.{" "}
+          Platform model/token credits by app and day. Fees for priced tools
+          settle in Chat — they are not listed here.{" "}
           <Link href="/settings/billing" className="text-foreground hover:underline">
             Account → Billing
           </Link>{" "}

--- a/apps/aomi-build/src/features/overview/overview-dashboard.tsx
+++ b/apps/aomi-build/src/features/overview/overview-dashboard.tsx
@@ -147,7 +147,7 @@ export function OverviewDashboard() {
         <StatCard
           label="Credits"
           value={formatNumber(usageTotals.creditsUsed)}
-          helper="LLM/token usage meter — not partner fees or invoices"
+          helper="Model/token usage meter — not Chat fees or invoices"
         />
         <StatCard
           label="Tokens"

--- a/apps/aomi-build/src/lib/settings-api.ts
+++ b/apps/aomi-build/src/lib/settings-api.ts
@@ -87,9 +87,10 @@ export async function accountScopedFetch<T>(
   path: string,
   options?: RequestInit,
 ): Promise<T> {
-  // Same-origin `/api/account/*` through the app proxy, which injects the
-  // AccountBearer from the `aomi_session` cookie (established by
-  // AomiSessionBridge). The browser carries no bearer itself.
+  // Same-origin `/api/account/*` through the app proxy *when* the route is
+  // allowlisted and `resolveCanonicalUserId` can mint an AccountBearer.
+  // Build today is GitHub-session only — account payment routes are not
+  // wired. Prefer Operate BFF (GitHub) or Chat account surfaces until then.
   const response = await fetch(`${getBackendUrl()}${path}`, {
     ...options,
     headers: {

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,9 +2,24 @@
 
 ## Last Updated
 
-2026-07-13 — Account → Secrets: no single-project auto-redirect (explicit CTA);
-2026-07-13 — Billing experience Phase A merged (PR #319); 2026-07-11 staging
-Para sign-in fix + Overview read-path perf
+2026-07-13 — Billing option A: methods live on Chat (no fake Build fetch);
+2026-07-13 — BILLING-EXPERIENCE.md: backend ↔ UI map (code-checked);
+2026-07-13 — Account → Secrets: no single-project auto-redirect (explicit CTA)
+
+## Billing option A — payment methods on Chat (2026-07-13)
+
+Branch `feat/billing-payment-methods-status`:
+
+- Account → Billing teaches BYOK/Tempo are on the Chat account; Build lacks
+  AccountBearer so we do not call `GET /api/account/payment`.
+- Adds Open Chat link; keeps Usage + Secrets; no fake method status.
+- Clarifies `accountScopedFetch` comment (auth not wired on Build).
+- Documents auth blocker + option A/B in `BILLING-EXPERIENCE.md` Phase C.
+
+## Billing experience — backend/UI map in plan doc (2026-07-13)
+
+- Expanded `apps/aomi-build/BILLING-EXPERIENCE.md` with control/data plane
+  mermaid, HTTP-vs-internal table, and Build UI now/should map (Cursor-style).
 
 ## Account → Secrets stay-on-settings (2026-07-13)
 


### PR DESCRIPTION
## Summary

- Account → Billing teaches **BYOK / Tempo live on the Chat account** — Build is GitHub-session only and cannot call `GET /api/account/payment` without AccountBearer.
- UI: Payment methods (honest) → Not available yet (balance/invoices) → links to Usage, Secrets, and Open Chat.
- Documents auth blocker + option A/B in `BILLING-EXPERIENCE.md` (includes backend↔UI map from #321).
- Clarifies misleading `accountScopedFetch` comment.

## Why not live methods?

Proxy allowlists only GitHub OAuth; `resolveCanonicalUserId` is a no-op. Fetching would 404/401. Option B (wire BetterAuth) is a separate auth project.

## Test plan

- [ ] `/settings/billing` — Payment methods + Not available yet; no fake “Tempo: Connected”
- [ ] Links: Usage, Secrets, Open Chat (`NEXT_PUBLIC_CHAT_URL` or chat.aomi.dev)
- [ ] `pnpm exec vitest run src/app/(control-plane)/settings/settings-billing-panel.test.tsx`