### PR TITLE
Build P2: Project home (live / keys / Open Chat)

### DIFF
--- a/apps/aomi-build/src/features/launch/components/deployments/project-page.test.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/project-page.test.tsx
@@ -1,10 +1,30 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { ToastProvider } from "@build/components/control-plane/toast";
+
+const searchParams = { current: new URLSearchParams("") };
 
 vi.mock("next/navigation", () => ({
-  useSearchParams: () => new URLSearchParams("tab=environment"),
+  useSearchParams: () => searchParams.current,
   useRouter: () => ({ push: vi.fn() }),
 }));
+
+vi.mock("@build/features/operate/client", () => ({
+  operateFetch: vi.fn(async () => ({ daily: [] })),
+}));
+
+vi.mock("@aomi-labs/deploy/lifecycle", () => ({
+  deploymentLifecycleFromSource: () => ({
+    kind: "empty",
+    repo: "a/b",
+    statusLabel: "No deployment",
+    statusTone: "muted",
+    message: "No deployment recorded yet.",
+    appNames: [],
+    releaseTags: [],
+  }),
+}));
+
 vi.mock("@build/features/launch/hooks/use-project-detail", () => ({
   useProjectDetail: () => ({
     source: {
@@ -21,19 +41,48 @@ vi.mock("@build/features/launch/hooks/use-project-detail", () => ({
     historyError: null,
     secretsByApp: {},
     secretsError: null,
+    recordsByApp: {},
+    recordsError: null,
+    deployFlow: { phase: "idle" },
     loadHistory: vi.fn(),
     loadSecrets: vi.fn(),
+    loadRecords: vi.fn(),
     rollback: vi.fn(),
     reload: vi.fn(),
+    deployNewVersion: vi.fn(),
+    promote: vi.fn(),
+    deactivate: vi.fn(),
   }),
 }));
 
 import { ProjectPage } from "./project-page";
 
+function renderPage() {
+  return render(
+    <ToastProvider>
+      <ProjectPage sourceId={1} tabBaseHref="/projects/1" />
+    </ToastProvider>,
+  );
+}
+
 describe("ProjectPage", () => {
+  beforeEach(() => {
+    searchParams.current = new URLSearchParams("");
+  });
+
+  it("defaults to the Home tab", () => {
+    renderPage();
+    expect(screen.getByRole("tab", { name: /^home$/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByText("Project home")).toBeInTheDocument();
+  });
+
   it("renders the tab named by ?tab=", () => {
-    render(<ProjectPage sourceId={1} />);
-    expect(screen.getByRole("tab", { name: /environment/i })).toHaveAttribute(
+    searchParams.current = new URLSearchParams("tab=deployments");
+    renderPage();
+    expect(screen.getByRole("tab", { name: /deployments/i })).toHaveAttribute(
       "aria-selected",
       "true",
     );

--- a/apps/aomi-build/src/features/launch/components/deployments/project-page.test.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/project-page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { ToastProvider } from "@build/components/control-plane/toast";
 
 const searchParams = { current: new URLSearchParams("") };
@@ -82,9 +82,10 @@ describe("ProjectPage", () => {
   it("renders the tab named by ?tab=", () => {
     searchParams.current = new URLSearchParams("tab=deployments");
     renderPage();
-    expect(screen.getByRole("tab", { name: /deployments/i })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
+    const projectTabs = screen.getAllByRole("tablist")[0];
+    expect(
+      within(projectTabs).getByRole("tab", { name: /^deployments$/i }),
+    ).toHaveAttribute("aria-selected", "true");
+    expect(screen.queryByText("Project home")).not.toBeInTheDocument();
   });
 });

--- a/apps/aomi-build/src/features/launch/components/deployments/project-page.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/project-page.tsx
@@ -8,10 +8,12 @@ import { ProjectHeader } from "./project-header";
 import { ChatTab } from "./tabs/chat-tab";
 import { DeploymentsTab } from "./tabs/deployments-tab";
 import { EnvironmentTab } from "./tabs/environment-tab";
+import { HomeTab } from "./tabs/home-tab";
 import { SettingsTab } from "./tabs/settings-tab";
 import { LoadingPanel, ErrorPanel } from "./ui/state-panels";
 
 const TABS = [
+  { id: "home", label: "Home" },
   { id: "deployments", label: "Deployments" },
   { id: "chat", label: "Chat" },
   { id: "environment", label: "Environment" },
@@ -38,7 +40,7 @@ export function ProjectPage({
   const raw = searchParams.get("tab");
   const active: TabId = TABS.some((t) => t.id === raw)
     ? (raw as TabId)
-    : "deployments";
+    : "home";
 
   useEffect(() => {
     setLastProjectId(sourceId);
@@ -88,6 +90,8 @@ export function ProjectPage({
             <LoadingPanel label="Loading project…" />
           ) : detail.error ? (
             <ErrorPanel message={detail.error} />
+          ) : active === "home" ? (
+            <HomeTab detail={detail} tabBaseHref={tabBaseHref} />
           ) : active === "deployments" ? (
             <DeploymentsTab detail={detail} />
           ) : active === "chat" ? (

--- a/apps/aomi-build/src/features/launch/components/deployments/tabs/home-tab.test.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/tabs/home-tab.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const loadSecrets = vi.fn();
+const operateFetch = vi.fn();
+
+vi.mock("@aomi-labs/deploy/lifecycle", () => ({
+  deploymentLifecycleFromSource: () => ({
+    kind: "empty",
+    repo: "a/b",
+    statusLabel: "No deployment",
+    statusTone: "muted",
+    message: "No deployment recorded yet.",
+    appNames: [],
+    releaseTags: [],
+  }),
+}));
+
+vi.mock("@build/features/operate/client", () => ({
+  operateFetch: (...args: unknown[]) => operateFetch(...args),
+}));
+
+vi.mock("@build/features/launch/hooks/use-project-detail", () => ({
+  useProjectDetail: () => detail,
+}));
+
+const detail = {
+  source: {
+    id: 1,
+    repositoryLink: "a/b",
+    apps: [],
+    latestDeployment: null,
+    installationId: 5,
+  },
+  loading: false,
+  error: null,
+  secretsByApp: {},
+  secretsError: null,
+  loadSecrets,
+} as unknown as ReturnType<
+  typeof import("@build/features/launch/hooks/use-project-detail").useProjectDetail
+>;
+
+import { HomeTab } from "./home-tab";
+
+describe("HomeTab", () => {
+  beforeEach(() => {
+    loadSecrets.mockClear();
+    operateFetch.mockReset();
+    operateFetch.mockResolvedValue({ daily: [] });
+  });
+
+  it("shows status cards and a deploy next action when not live", async () => {
+    render(<HomeTab detail={detail} tabBaseHref="/projects/1" />);
+
+    expect(loadSecrets).toHaveBeenCalled();
+    expect(screen.getByText("Project home")).toBeInTheDocument();
+    expect(screen.getByText("Not live")).toBeInTheDocument();
+    expect(screen.getByText("Keys missing")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("link", { name: /deploy new version/i }),
+    ).toHaveAttribute("href", "/projects/1?tab=deployments");
+    expect(
+      screen.getByRole("link", { name: /open environment/i }),
+    ).toHaveAttribute("href", "/projects/1?tab=environment");
+  });
+});

--- a/apps/aomi-build/src/features/launch/components/deployments/tabs/home-tab.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/tabs/home-tab.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  ExternalLink,
+  KeyRound,
+  MessageSquare,
+  Rocket,
+} from "lucide-react";
+import { deploymentLifecycleFromSource } from "@aomi-labs/deploy/lifecycle";
+import { useProjectDetail } from "@build/features/launch/hooks/use-project-detail";
+import { operateFetch } from "@build/features/operate/client";
+import { chatAppUrl } from "@build/lib/chat-url";
+import { BUILD_GLOSSARY } from "@build/lib/glossary";
+import { EmptyPanel } from "../ui/state-panels";
+
+type Detail = ReturnType<typeof useProjectDetail>;
+
+type UsagePeek = {
+  creditsUsed: number;
+  tokens: number;
+  available: boolean;
+};
+
+function numberValue(value: unknown) {
+  const n = Number(value ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function StatusCard({
+  label,
+  value,
+  hint,
+  actionHref,
+  actionLabel,
+  tone = "neutral",
+}: {
+  label: string;
+  value: string;
+  hint: string;
+  actionHref?: string;
+  actionLabel?: string;
+  tone?: "good" | "warn" | "neutral";
+}) {
+  const toneClass =
+    tone === "good"
+      ? "border-emerald-500/30 bg-emerald-500/5"
+      : tone === "warn"
+        ? "border-amber-500/30 bg-amber-500/5"
+        : "border-border bg-surface-2";
+
+  return (
+    <div className={`rounded-md border px-3 py-3 ${toneClass}`}>
+      <div className="text-dim text-[11px] uppercase tracking-wide">{label}</div>
+      <div className="text-foreground mt-1.5 text-sm font-medium">{value}</div>
+      <p className="text-dim mt-1 text-xs leading-5">{hint}</p>
+      {actionHref && actionLabel ? (
+        <Link
+          href={actionHref}
+          className="text-foreground mt-3 inline-flex text-xs font-medium underline underline-offset-2 hover:opacity-80"
+        >
+          {actionLabel}
+        </Link>
+      ) : null}
+    </div>
+  );
+}
+
+export function HomeTab({
+  detail,
+  tabBaseHref,
+}: {
+  detail: Detail;
+  tabBaseHref?: string;
+}) {
+  const source = detail.source;
+  const [usage, setUsage] = useState<UsagePeek | null>(null);
+
+  useEffect(() => {
+    detail.loadSecrets();
+  }, [detail]);
+
+  useEffect(() => {
+    if (!source) return;
+    let alive = true;
+    operateFetch<{
+      daily?: Array<Record<string, unknown>>;
+    }>("usage", source.id)
+      .then((payload) => {
+        if (!alive) return;
+        const daily = payload.daily ?? [];
+        const totals = daily.reduce(
+          (acc, row) => ({
+            creditsUsed: acc.creditsUsed + numberValue(row.creditsUsed),
+            tokens:
+              acc.tokens +
+              numberValue(row.inputTokens) +
+              numberValue(row.outputTokens),
+          }),
+          { creditsUsed: 0, tokens: 0 },
+        );
+        setUsage({ ...totals, available: true });
+      })
+      .catch(() => {
+        if (alive) setUsage({ creditsUsed: 0, tokens: 0, available: false });
+      });
+    return () => {
+      alive = false;
+    };
+  }, [source]);
+
+  const lifecycle = useMemo(
+    () => (source ? deploymentLifecycleFromSource(source) : null),
+    [source],
+  );
+
+  const secretCount = useMemo(() => {
+    if (!detail.secretsByApp) return null;
+    return Object.values(detail.secretsByApp).reduce(
+      (sum, keys) => sum + keys.length,
+      0,
+    );
+  }, [detail.secretsByApp]);
+
+  if (!source || !lifecycle) {
+    return <EmptyPanel>Project not found.</EmptyPanel>;
+  }
+
+  const tabHref = (tab: string) =>
+    tabBaseHref ? `${tabBaseHref}?tab=${tab}` : `?tab=${tab}`;
+
+  const isLive = lifecycle.kind === "live" && Boolean(lifecycle.chatApp);
+  const chatUrl = isLive
+    ? chatAppUrl(lifecycle.chatApp!, {
+        locked: true,
+        applicationId: lifecycle.chatApplicationId,
+      })
+    : null;
+
+  const liveValue =
+    lifecycle.kind === "live"
+      ? "Live"
+      : lifecycle.kind === "building" || lifecycle.kind === "build_ready"
+        ? lifecycle.statusLabel
+        : lifecycle.kind === "failed"
+          ? lifecycle.statusLabel
+          : "Not live";
+
+  const liveTone =
+    lifecycle.kind === "live"
+      ? "good"
+      : lifecycle.kind === "failed"
+        ? "warn"
+        : "warn";
+
+  const envReady = secretCount !== null && secretCount > 0;
+  const envLoading = detail.secretsByApp === null && !detail.secretsError;
+
+  const nextAction =
+    !isLive
+      ? {
+          href: tabHref("deployments"),
+          label: "Deploy new version",
+          copy: "Publish a deployment, then set keys and open chat.",
+        }
+      : !envReady
+        ? {
+            href: tabHref("environment"),
+            label: "Open Environment",
+            copy: "Add API keys so the live app can call tools.",
+          }
+        : chatUrl
+          ? {
+              href: chatUrl,
+              label: "Open Chat",
+              copy: "App is live and keys look set. Try it in chat.",
+              external: true,
+            }
+          : {
+              href: tabHref("chat"),
+              label: "Open Chat tab",
+              copy: "Continue in the Chat tab.",
+            };
+
+  return (
+    <div className="divide-y divide-border">
+      <div className="px-4 py-4">
+        <div className="text-sm font-medium text-foreground">Project home</div>
+        <p className="text-dim mt-1 max-w-2xl text-xs leading-5">
+          {BUILD_GLOSSARY.project.meaning} Check live status, environment keys,
+          and open chat from here.
+        </p>
+      </div>
+
+      <div className="grid gap-3 p-4 sm:grid-cols-2">
+        <StatusCard
+          label="Live"
+          value={liveValue}
+          hint={
+            isLive
+              ? `${lifecycle.chatApp} is active.`
+              : lifecycle.message || "Deploy and activate an app to go live."
+          }
+          tone={liveTone}
+          actionHref={tabHref("deployments")}
+          actionLabel="View deployments"
+        />
+        <StatusCard
+          label="Environment"
+          value={
+            envLoading
+              ? "Loading…"
+              : detail.secretsError
+                ? "Unavailable"
+                : envReady
+                  ? `${secretCount} key${secretCount === 1 ? "" : "s"} set`
+                  : "Keys missing"
+          }
+          hint={BUILD_GLOSSARY.environment.meaning}
+          tone={envReady ? "good" : "warn"}
+          actionHref={tabHref("environment")}
+          actionLabel="Open Environment"
+        />
+        <StatusCard
+          label="Chat"
+          value={isLive ? "Ready" : "Needs live app"}
+          hint={
+            isLive
+              ? "Open the chat session for this app."
+              : "Chat unlocks after a live deployment."
+          }
+          tone={isLive ? "good" : "neutral"}
+          actionHref={isLive ? tabHref("chat") : tabHref("deployments")}
+          actionLabel={isLive ? "Chat tab" : "Go to deployments"}
+        />
+        <StatusCard
+          label="Usage"
+          value={
+            usage == null
+              ? "Loading…"
+              : !usage.available
+                ? "—"
+                : usage.creditsUsed > 0 || usage.tokens > 0
+                  ? `${usage.creditsUsed.toFixed(2)} credits`
+                  : "No traffic yet"
+          }
+          hint="Credits/tokens for this project. Not Billing."
+          tone="neutral"
+          actionHref="/operate/usage"
+          actionLabel="Open Usage"
+        />
+      </div>
+
+      <div className="border-border bg-surface-2/40 px-4 py-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-sm font-medium text-foreground">Next</div>
+            <p className="text-dim mt-1 text-xs leading-5">{nextAction.copy}</p>
+          </div>
+          {"external" in nextAction && nextAction.external ? (
+            <a
+              href={nextAction.href}
+              target="_blank"
+              rel="noreferrer"
+              className="bg-primary text-primary-foreground inline-flex h-9 items-center gap-1.5 rounded-md px-3 text-sm font-medium hover:opacity-90"
+            >
+              <MessageSquare className="size-3.5" aria-hidden />
+              {nextAction.label}
+              <ExternalLink className="size-3.5" aria-hidden />
+            </a>
+          ) : (
+            <Link
+              href={nextAction.href}
+              className="bg-primary text-primary-foreground inline-flex h-9 items-center gap-1.5 rounded-md px-3 text-sm font-medium hover:opacity-90"
+            >
+              {nextAction.label === "Deploy new version" ? (
+                <Rocket className="size-3.5" aria-hidden />
+              ) : nextAction.label === "Open Environment" ? (
+                <KeyRound className="size-3.5" aria-hidden />
+              ) : (
+                <MessageSquare className="size-3.5" aria-hidden />
+              )}
+              {nextAction.label}
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,11 +2,21 @@
 
 ## Last Updated
 
+2026-07-13 — Build P2 Project home (live / keys / Open Chat / usage glance);
 2026-07-13 — Build P1 control plane: ⌘K, toasts, Projects landing, glossary;
 2026-07-13 — Build P0 trust: Soon labels, gate Integrations Save, human errors;
 2026-07-13 — Build UI copy polish (em dashes / hedging essays);
 2026-07-13 — Billing option A: methods live on Chat (no fake Build fetch);
 2026-07-13 — BILLING-EXPERIENCE.md: backend ↔ UI map (code-checked)
+
+## Build P2 Project home (2026-07-13)
+
+Branch `feat/build-p2-project-home`:
+
+- Project pages default to a **Home** tab with Live / Environment / Chat /
+  Usage status cards and one Next CTA (deploy → keys → Open Chat).
+- Reuses `deploymentLifecycleFromSource`, secrets load, and operate usage peek.
+- Existing Deployments / Chat / Environment / Details tabs unchanged.
 
 ## Build UI copy polish (2026-07-13)
 

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -11,7 +11,7 @@
 
 ## Build P2 Project home (2026-07-13)
 
-Branch `feat/build-p2-project-home`:
+Branch `feat/build-p2-project-home` (PR #330):
 
 - Project pages default to a **Home** tab with Live / Environment / Chat /
   Usage status cards and one Next CTA (deploy → keys → Open Chat).


### PR DESCRIPTION
## Summary
- Add a **Home** tab as the default project view.
- Status cards: **Live**, **Environment**, **Chat**, **Usage** (thin peek).
- One **Next** CTA: deploy → set keys → Open Chat.
- Reuses existing lifecycle, secrets, and operate usage APIs. Other tabs unchanged.

## Test plan
- [ ] Open a project from Projects → lands on **Home**
- [ ] Empty/not-live project shows Deploy next CTA
- [ ] With keys missing, Environment CTA works (\`?tab=environment\`)
- [ ] Live + keys → Open Chat external link
- [ ] Deployments / Chat / Environment / Details still work via tabs
- [ ] \`pnpm --filter aomi-build exec vitest run …home-tab.test …project-page.test\`