### PR TITLE
Bump widget package to 1.4.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ There is no dedicated automated test suite yet, so treat `pnpm run build:lib` an
 
 Commits follow short, imperative summaries (`Fix linting ci`, `Update packages for …`). Keep bodies optional but include rationale when touching build or security-sensitive files. For pull requests, add: 1) a concise description of the change and linked issue, 2) a checklist of commands you ran (lint, build, demo), and 3) screenshots or short clips for UI-impacting work. Make sure the PR mentions any `specs/` updates so reviewers can cross-check behavior changes.
 
+Before merging, audit every touched workspace against the npm publish workflow. If shipped files from a publishable npm package changed, bump that package's version in the same change (use a patch bump unless the release scope requires otherwise), refresh any affected lockfile or generated artifacts, and verify the package is publishable. Do not defer required npm version bumps until after merge.
+
 ## Security & Configuration Tips
 
 Never commit `.env` contents. Local development requires `NEXT_PUBLIC_PROJECT_ID` and `NEXT_PUBLIC_BACKEND_URL` (see README) so be sure to supply mock-safe values when recording demos. Wallet helpers in `utils/wallet.ts` assume checksummed addresses; validate inputs before invoking them, and funnel all network or key-related secrets through the backend instead of embedding them in this repo.

--- a/GOAL.md
+++ b/GOAL.md
@@ -389,3 +389,8 @@ build`, `CI=true npx -y pnpm@10.28.0 install --frozen-lockfile`, and
   and kept Show all / Collapse to recent behavior. Verified targeted ESLint,
   registry build, portal typecheck, all 221 registry tests, and a signed-in
   Chrome E2E against the local dev auth stack using an existing 19-step trace.
+- 2026-07-13 working-trace npm follow-up: audited the merged feature against the
+  main-branch npm workflow and confirmed only `@aomi-labs/widget-lib` ships the
+  touched source. Patch-bumped it from `1.4.1` to `1.4.2` and added a repository
+  rule requiring relevant publishable npm workspaces to be version-bumped before
+  future merges rather than corrected afterward.

--- a/apps/shadcn-registry/package.json
+++ b/apps/shadcn-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/widget-lib",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Shadcn registry for the Aomi widget.",
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
## Summary

- bump `@aomi-labs/widget-lib` from 1.4.1 to 1.4.2 so the Working trace UI shipped in #332 is published under a new npm version
- add an `AGENTS.md` rule requiring relevant publishable npm packages to be bumped before merge
- record the follow-up in `GOAL.md`

## Validation

- `pnpm run build:registry`
- `pnpm --filter @aomi-labs/widget-lib pack --pack-destination /tmp/aomi-widget-pack`
- confirmed `@aomi-labs/widget-lib@1.4.2` is currently available for publication

No lockfile update is required because the workspace package's own version is not represented in `pnpm-lock.yaml`.