### PR TITLE
Build P2: Deployments timeline (history that reads)

### DIFF
--- a/apps/aomi-build/src/features/launch/components/deployments/deployment-timeline.test.ts
+++ b/apps/aomi-build/src/features/launch/components/deployments/deployment-timeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildActivityList, buildDeploymentList } from "./deployment-timeline";
+import { buildActivityList, buildDeploymentList, sortDeploymentsForTimeline } from "./deployment-timeline";
 
 describe("buildDeploymentList", () => {
   it("returns [] for null", () => {
@@ -62,8 +62,34 @@ describe("buildDeploymentList", () => {
       "dep_1_ra_new0",
       "dep_1_ra_old0",
     ]);
-    
+
     expect(rows[0].actor).toBe("bob");
+  });
+
+  it("sorts current first for the timeline view", () => {
+    const rows = sortDeploymentsForTimeline([
+      {
+        deploymentId: "dep_old",
+        commit: "old",
+        apps: ["bot"],
+        releaseTags: ["t-old"],
+        current: true,
+        actor: "alice",
+        sdkVersion: "3.0.1",
+        createdAt: 5,
+      },
+      {
+        deploymentId: "dep_new",
+        commit: "new",
+        apps: ["bot"],
+        releaseTags: ["t-new"],
+        current: false,
+        actor: "bob",
+        sdkVersion: "3.0.1",
+        createdAt: 20,
+      },
+    ]);
+    expect(rows.map((r) => r.deploymentId)).toEqual(["dep_old", "dep_new"]);
   });
 
   it("flattens activity newest-first with app names", () => {

--- a/apps/aomi-build/src/features/launch/components/deployments/deployment-timeline.ts
+++ b/apps/aomi-build/src/features/launch/components/deployments/deployment-timeline.ts
@@ -69,6 +69,16 @@ export function buildDeploymentList(
   return [...byId.values()].sort((a, b) => b.createdAt - a.createdAt);
 }
 
+/** Current first, then newest. Used after runtime remaps `current`. */
+export function sortDeploymentsForTimeline(
+  deployments: TimelineDeployment[],
+): TimelineDeployment[] {
+  return [...deployments].sort((a, b) => {
+    if (a.current !== b.current) return a.current ? -1 : 1;
+    return b.createdAt - a.createdAt;
+  });
+}
+
 export function buildActivityList(
   recordsByApp: Record<string, DeploymentRecord[]> | null,
 ): TimelineActivity[] {

--- a/apps/aomi-build/src/features/launch/components/deployments/format-relative-time.test.ts
+++ b/apps/aomi-build/src/features/launch/components/deployments/format-relative-time.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { formatRelativeTime } from "./format-relative-time";
+
+describe("formatRelativeTime", () => {
+  const now = Date.parse("2026-07-13T15:00:00Z");
+
+  it("formats recent and older windows", () => {
+    expect(formatRelativeTime(now / 1000 - 10, now)).toBe("just now");
+    expect(formatRelativeTime(now / 1000 - 120, now)).toBe("2m ago");
+    expect(formatRelativeTime(now / 1000 - 7200, now)).toBe("2h ago");
+    expect(formatRelativeTime(now / 1000 - 90000, now)).toBe("1d ago");
+  });
+});

--- a/apps/aomi-build/src/features/launch/components/deployments/format-relative-time.ts
+++ b/apps/aomi-build/src/features/launch/components/deployments/format-relative-time.ts
@@ -1,0 +1,21 @@
+/** Compact relative time for deployment history rows. */
+export function formatRelativeTime(
+  unixSeconds: number,
+  nowMs: number = Date.now(),
+): string {
+  const deltaSec = Math.round((nowMs - unixSeconds * 1000) / 1000);
+  if (!Number.isFinite(deltaSec)) return "unknown time";
+  if (deltaSec < 45) return "just now";
+  if (deltaSec < 90) return "1m ago";
+  if (deltaSec < 3600) return `${Math.round(deltaSec / 60)}m ago`;
+  if (deltaSec < 5400) return "1h ago";
+  if (deltaSec < 86400) return `${Math.round(deltaSec / 3600)}h ago`;
+  if (deltaSec < 172800) return "1d ago";
+  if (deltaSec < 86400 * 30) return `${Math.round(deltaSec / 86400)}d ago`;
+  const date = new Date(unixSeconds * 1000);
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}

--- a/apps/aomi-build/src/features/launch/components/deployments/tabs/deployments-tab.test.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/tabs/deployments-tab.test.tsx
@@ -72,27 +72,27 @@ describe("DeploymentsTab", () => {
   it("renders deployments from the DB timeline, current first", async () => {
     renderTab(<DeploymentsTab detail={detail} />);
     expect(detail.loadRecords).toHaveBeenCalled();
-    expect(await screen.findByText("dep_1_ra_currentcmt")).toBeInTheDocument();
+    expect(await screen.findByText(/Live · my-bot · 2 deployments/i)).toBeInTheDocument();
+    expect(screen.getAllByText("my-bot").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("dep_1_ra_currentcmt")).toBeInTheDocument();
     expect(screen.getByText("dep_1_ra_oldcommit1")).toBeInTheDocument();
     expect(screen.getByText("Current")).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: /activity/i })).toHaveAttribute(
+    expect(screen.getByRole("tab", { name: /promotions/i })).toHaveAttribute(
       "aria-selected",
       "false",
     );
   });
 
-  it("renders promotion activity in the Activity subtab", async () => {
+  it("renders promotion activity in the Promotions subtab", async () => {
     renderTab(<DeploymentsTab detail={detail} />);
-    fireEvent.click(screen.getByRole("tab", { name: /activity/i }));
-    expect(screen.getByRole("tab", { name: /activity/i })).toHaveAttribute(
+    fireEvent.click(screen.getByRole("tab", { name: /promotions/i }));
+    expect(screen.getByRole("tab", { name: /promotions/i })).toHaveAttribute(
       "aria-selected",
       "true",
     );
-    expect(
-      await screen.findByText(/promoted · dep_1_ra_currentcmt/),
-    ).toBeInTheDocument();
+    expect((await screen.findAllByText(/promoted ·/)).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("dep_1_ra_currentcmt").length).toBeGreaterThan(0);
   });
-
   it("offers Deactivate in the toolbar and Promote on older deployments", () => {
     renderTab(<DeploymentsTab detail={detail} />);
     expect(

--- a/apps/aomi-build/src/features/launch/components/deployments/tabs/deployments-tab.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/tabs/deployments-tab.tsx
@@ -9,7 +9,12 @@ import { projectDeploymentStatus } from "../project-deployment-status";
 import { TimelineDeploymentRow } from "../ui/timeline-deployment-row";
 import { ConfirmDialog } from "../ui/confirm-dialog";
 import { LoadingPanel, EmptyPanel } from "../ui/state-panels";
-import { buildActivityList, buildDeploymentList } from "../deployment-timeline";
+import {
+  buildActivityList,
+  buildDeploymentList,
+  sortDeploymentsForTimeline,
+} from "../deployment-timeline";
+import { formatRelativeTime } from "../format-relative-time";
 
 type Detail = ReturnType<typeof useProjectDetail>;
 type OpState = {
@@ -73,14 +78,16 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
   );
   const deployments = useMemo(
     () =>
-      recordDeployments.map((deployment) => ({
-        ...deployment,
-        current: optimisticallyPromotedId
-          ? deployment.deploymentId === optimisticallyPromotedId
-          : runtimeCanResolveLive
-            ? deployment.releaseTags.some((tag) => liveReleaseTags.has(tag))
-            : deployment.current,
-      })),
+      sortDeploymentsForTimeline(
+        recordDeployments.map((deployment) => ({
+          ...deployment,
+          current: optimisticallyPromotedId
+            ? deployment.deploymentId === optimisticallyPromotedId
+            : runtimeCanResolveLive
+              ? deployment.releaseTags.some((tag) => liveReleaseTags.has(tag))
+              : deployment.current,
+        })),
+      ),
     [
       recordDeployments,
       optimisticallyPromotedId,
@@ -183,10 +190,26 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
     }
   };
 
+  const historyCountLabel =
+    deployments.length === 1
+      ? "1 deployment in history"
+      : `${deployments.length} deployments in history`;
+  const summaryLabel = status?.isLive
+    ? currentDeployment
+      ? `Live · ${currentDeployment.apps.join(", ") || "app"} · ${historyCountLabel}`
+      : `Live · ${historyCountLabel}`
+    : deactivated
+      ? `Deactivated · ${historyCountLabel}`
+      : deployments.length > 0
+        ? historyCountLabel
+        : status?.label ?? "No deployment";
+
   return (
     <div>
       <div className="border-b border-border px-4 py-2 text-xs text-dim">
-        Deployment history for this project.
+        <span className="text-foreground font-medium">{summaryLabel}</span>
+        <span className="text-dim"> · </span>
+        Newest and current first. Promote an older release to make it live.
       </div>
       <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
         <div
@@ -195,8 +218,8 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
           className="inline-flex rounded-md border border-border bg-surface-1 p-0.5"
         >
           {[
-            ["deployments", "Deployments"],
-            ["activity", "Activity"],
+            ["deployments", "History"],
+            ["activity", "Promotions"],
           ].map(([id, label]) => (
             <button
               key={id}
@@ -339,7 +362,9 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
       ) : null}
 
       {view === "activity" && activity.length === 0 && !detail.recordsError && (
-        <EmptyPanel>No promotion activity for this project.</EmptyPanel>
+        <EmptyPanel>
+          No promotions recorded yet. Promote a deployment to see it here.
+        </EmptyPanel>
       )}
 
       {view === "activity" && activity.length > 0 && (
@@ -349,14 +374,15 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
               key={`${row.app}-${row.deploymentId}-${row.releaseTag}-${row.createdAt}`}
               className="flex min-h-10 items-center justify-between gap-4 border-b border-border px-4 py-2 text-xs text-dim last:border-b-0"
             >
-              <span className="min-w-0 truncate font-mono">
-                promoted · {row.deploymentId}
+              <span className="min-w-0 truncate">
+                <span className="text-foreground font-medium">{row.app}</span>
+                <span className="text-dim"> · promoted · </span>
+                <span className="font-mono">{row.deploymentId}</span>
               </span>
-              <span className="shrink-0 text-right">
-                {row.app}
-                {row.current ? " · current" : ""}
-                {row.actor ? ` · ${row.actor}` : ""} ·{" "}
-                {new Date(row.createdAt * 1000).toLocaleString()}
+              <span className="shrink-0 text-right" title={new Date(row.createdAt * 1000).toLocaleString()}>
+                {row.current ? "current · " : ""}
+                {row.actor ? `${row.actor} · ` : ""}
+                {formatRelativeTime(row.createdAt)}
               </span>
             </div>
           ))}

--- a/apps/aomi-build/src/features/launch/components/deployments/ui/timeline-deployment-row.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/ui/timeline-deployment-row.tsx
@@ -1,9 +1,8 @@
 import { GitCommitHorizontal, RotateCcw } from "lucide-react";
 import type { TimelineDeployment } from "../deployment-timeline";
+import { formatRelativeTime } from "../format-relative-time";
 
-/** Deployment row rendered purely from the DB promotion records (no GitHub
- *  reads). The live deployment is marked Current; older deployments offer
- *  Promote. */
+/** Deployment row from DB promotion records. Lead with apps + status; id is secondary. */
 export function TimelineDeploymentRow({
   deployment,
   busy,
@@ -19,12 +18,18 @@ export function TimelineDeploymentRow({
 }) {
   const { deploymentId, commit, apps, current, actor, sdkVersion, createdAt } =
     deployment;
+  const title = apps.join(", ") || "Deployment";
+  const absolute = new Date(createdAt * 1000).toLocaleString();
 
   return (
-    <div className="grid min-h-[76px] grid-cols-[minmax(0,1fr)_auto] items-center gap-4 border-b border-border px-4 py-3 last:border-b-0">
+    <div
+      className={`grid min-h-[76px] grid-cols-[minmax(0,1fr)_auto] items-center gap-4 border-b border-border px-4 py-3 last:border-b-0 ${
+        current ? "bg-positive/5" : ""
+      }`}
+    >
       <div className="min-w-0">
         <div className="flex min-w-0 items-center gap-2">
-          <div className="truncate text-sm font-medium">{deploymentId}</div>
+          <div className="truncate text-sm font-medium">{title}</div>
           {current && (
             <span
               className={`shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium ${
@@ -44,12 +49,12 @@ export function TimelineDeploymentRow({
             <GitCommitHorizontal className="size-3.5" aria-hidden />
             {commit ?? "unknown"}
           </span>
-          <span>{apps.join(", ") || "no apps"}</span>
           {sdkVersion && <span>sdk {sdkVersion}</span>}
-          <span>
-            {actor ? `${actor} · ` : ""}
-            {new Date(createdAt * 1000).toLocaleString()}
-          </span>
+          {actor && <span>{actor}</span>}
+          <span title={absolute}>{formatRelativeTime(createdAt)}</span>
+        </div>
+        <div className="text-dim mt-1 truncate font-mono text-[11px]">
+          {deploymentId}
         </div>
         {message && <div className="mt-1 text-xs text-dim">{message}</div>}
       </div>

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,7 @@
 
 ## Last Updated
 
+2026-07-13 — Build P2 Deployments timeline (history that reads as history);
 2026-07-13 — Build Live status consistency (one story across list/Home/Deployments);
 2026-07-13 — Build P2 Project home (live / keys / Open Chat / usage glance);
 2026-07-13 — Build P1 control plane: ⌘K, toasts, Projects landing, glossary;
@@ -10,9 +11,17 @@
 2026-07-13 — Billing option A: methods live on Chat (no fake Build fetch);
 2026-07-13 — BILLING-EXPERIENCE.md: backend ↔ UI map (code-checked)
 
+## Build P2 Deployments timeline (2026-07-13)
+
+Branch `feat/build-p2-deployments-timeline`:
+
+- Deployments tab summary uses the same Live story + history count.
+- Rows lead with app names + Current; deployment id is secondary.
+- Current sorts first; relative timestamps; History / Promotions labels.
+
 ## Build Live status consistency (2026-07-13)
 
-Branch `fix/build-live-status-consistency`:
+Branch `fix/build-live-status-consistency` (PR #331):
 
 - Shared `projectDeploymentStatus()` wraps `deploymentLifecycleFromSource`
   so Projects list, Home, and Deployments tell the same Live story.


### PR DESCRIPTION
## Summary
- Deployments tab summary uses the shared Live story + history count.
- History rows lead with **app name + Current**; deployment id is secondary mono.
- Current sorts first; relative timestamps; **History / Promotions** labels.

## Test plan
- [ ] Open a live project → Deployments → summary shows \`Live · <app> · N deployments\`
- [ ] Current row is first and highlighted; older rows show Promote
- [ ] Promotions subtab shows app-first promotion log
- [ ] Empty live history still uses the honest empty copy from #331
- [ ] Focused vitest on timeline + deployments-tab