### PR TITLE
Build P2: Home usage peek → Operate Usage

### DIFF
--- a/apps/aomi-build/src/features/launch/components/deployments/tabs/home-tab.test.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/tabs/home-tab.test.tsx
@@ -63,5 +63,26 @@ describe("HomeTab", () => {
     expect(
       screen.getByRole("link", { name: /open environment/i }),
     ).toHaveAttribute("href", "/projects/1?tab=environment");
+    expect(await screen.findByText("No traffic yet")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /^open usage$/i })).toHaveAttribute(
+      "href",
+      "/operate/usage?project=1",
+    );
+  });
+
+  it("shows credits and tokens when usage has traffic", async () => {
+    operateFetch.mockResolvedValue({
+      daily: [
+        {
+          periodUtcDay: "2026-07-12",
+          creditsUsed: 1.5,
+          inputTokens: 1000,
+          outputTokens: 250,
+        },
+      ],
+    });
+    render(<HomeTab detail={detail} tabBaseHref="/projects/1" />);
+    expect(await screen.findByText("1.50 credits")).toBeInTheDocument();
+    expect(screen.getByText(/1\.3k tokens/i)).toBeInTheDocument();
   });
 });

--- a/apps/aomi-build/src/features/launch/components/deployments/tabs/home-tab.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/tabs/home-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import Link from "next/link";
 import {
   ExternalLink,
@@ -13,19 +13,32 @@ import { operateFetch } from "@build/features/operate/client";
 import { chatAppUrl } from "@build/lib/chat-url";
 import { BUILD_GLOSSARY } from "@build/lib/glossary";
 import { projectDeploymentStatus } from "../project-deployment-status";
+import {
+  formatCompactCount,
+  summarizeProjectUsage,
+  type UsagePeek,
+} from "../usage-peek";
 import { EmptyPanel } from "../ui/state-panels";
 
 type Detail = ReturnType<typeof useProjectDetail>;
 
-type UsagePeek = {
-  creditsUsed: number;
-  tokens: number;
-  available: boolean;
-};
-
-function numberValue(value: unknown) {
-  const n = Number(value ?? 0);
-  return Number.isFinite(n) ? n : 0;
+function UsageSpark({ spark }: { spark: number[] }) {
+  if (spark.length === 0) return null;
+  return (
+    <div
+      className="mt-3 flex h-6 items-end gap-0.5"
+      aria-hidden
+      title="Credits by day"
+    >
+      {spark.map((value, index) => (
+        <span
+          key={index}
+          className="bg-foreground/25 w-1.5 rounded-sm"
+          style={{ height: `${Math.max(12, Math.round(value * 100))}%` }}
+        />
+      ))}
+    </div>
+  );
 }
 
 function StatusCard({
@@ -35,6 +48,7 @@ function StatusCard({
   actionHref,
   actionLabel,
   tone = "neutral",
+  meter,
 }: {
   label: string;
   value: string;
@@ -42,6 +56,7 @@ function StatusCard({
   actionHref?: string;
   actionLabel?: string;
   tone?: "good" | "warn" | "neutral";
+  meter?: ReactNode;
 }) {
   const toneClass =
     tone === "good"
@@ -55,6 +70,7 @@ function StatusCard({
       <div className="text-dim text-[11px] uppercase tracking-wide">{label}</div>
       <div className="text-foreground mt-1.5 text-sm font-medium">{value}</div>
       <p className="text-dim mt-1 text-xs leading-5">{hint}</p>
+      {meter}
       {actionHref && actionLabel ? (
         <Link
           href={actionHref}
@@ -65,6 +81,39 @@ function StatusCard({
       ) : null}
     </div>
   );
+}
+
+function usageCardCopy(usage: UsagePeek | null): {
+  value: string;
+  hint: string;
+  tone: "good" | "warn" | "neutral";
+} {
+  if (usage == null) {
+    return { value: "Loading…", hint: "Credits for this project.", tone: "neutral" };
+  }
+  if (!usage.available) {
+    return {
+      value: "Unavailable",
+      hint: "Could not load usage. Open Usage to retry. Not Billing.",
+      tone: "warn",
+    };
+  }
+  if (usage.creditsUsed <= 0 && usage.tokens <= 0) {
+    return {
+      value: "No traffic yet",
+      hint: "Credits appear after chat turns. Meter only — not Billing.",
+      tone: "neutral",
+    };
+  }
+  const dayHint =
+    usage.dayCount === 1
+      ? "1 day with traffic"
+      : `${usage.dayCount} days with traffic`;
+  return {
+    value: `${usage.creditsUsed.toFixed(2)} credits`,
+    hint: `${formatCompactCount(usage.tokens)} tokens · ${dayHint}. Not Billing.`,
+    tone: "good",
+  };
 }
 
 export function HomeTab({
@@ -88,22 +137,10 @@ export function HomeTab({
       daily?: Array<Record<string, unknown>>;
     }>("usage", source.id)
       .then((payload) => {
-        if (!alive) return;
-        const daily = payload.daily ?? [];
-        const totals = daily.reduce(
-          (acc, row) => ({
-            creditsUsed: acc.creditsUsed + numberValue(row.creditsUsed),
-            tokens:
-              acc.tokens +
-              numberValue(row.inputTokens) +
-              numberValue(row.outputTokens),
-          }),
-          { creditsUsed: 0, tokens: 0 },
-        );
-        setUsage({ ...totals, available: true });
+        if (alive) setUsage(summarizeProjectUsage(payload));
       })
       .catch(() => {
-        if (alive) setUsage({ creditsUsed: 0, tokens: 0, available: false });
+        if (alive) setUsage(summarizeProjectUsage(null));
       });
     return () => {
       alive = false;
@@ -157,6 +194,7 @@ export function HomeTab({
 
   const envReady = secretCount !== null && secretCount > 0;
   const envLoading = detail.secretsByApp === null && !detail.secretsError;
+  const usageCopy = usageCardCopy(usage);
 
   const nextAction =
     !isLive
@@ -237,18 +275,15 @@ export function HomeTab({
         />
         <StatusCard
           label="Usage"
-          value={
-            usage == null
-              ? "Loading…"
-              : !usage.available
-                ? "—"
-                : usage.creditsUsed > 0 || usage.tokens > 0
-                  ? `${usage.creditsUsed.toFixed(2)} credits`
-                  : "No traffic yet"
+          value={usageCopy.value}
+          hint={usageCopy.hint}
+          tone={usageCopy.tone}
+          meter={
+            usage?.available && usage.spark.length > 0 ? (
+              <UsageSpark spark={usage.spark} />
+            ) : null
           }
-          hint="Credits/tokens for this project. Not Billing."
-          tone="neutral"
-          actionHref="/operate/usage"
+          actionHref={`/operate/usage?project=${source.id}`}
           actionLabel="Open Usage"
         />
       </div>

--- a/apps/aomi-build/src/features/launch/components/deployments/usage-peek.test.ts
+++ b/apps/aomi-build/src/features/launch/components/deployments/usage-peek.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { formatCompactCount, summarizeProjectUsage } from "./usage-peek";
+
+describe("summarizeProjectUsage", () => {
+  it("totals credits and tokens and builds a spark", () => {
+    const peek = summarizeProjectUsage({
+      daily: [
+        {
+          periodUtcDay: "2026-07-11",
+          creditsUsed: 1,
+          inputTokens: 100,
+          outputTokens: 50,
+        },
+        {
+          periodUtcDay: "2026-07-12",
+          creditsUsed: 3,
+          inputTokens: 200,
+          outputTokens: 50,
+        },
+        {
+          periodUtcDay: "2026-07-12",
+          creditsUsed: 1,
+          inputTokens: 0,
+          outputTokens: 0,
+        },
+      ],
+    });
+    expect(peek.available).toBe(true);
+    expect(peek.creditsUsed).toBe(5);
+    expect(peek.tokens).toBe(400);
+    expect(peek.dayCount).toBe(2);
+    expect(peek.spark).toEqual([0.25, 1]);
+  });
+
+  it("marks null payload unavailable", () => {
+    expect(summarizeProjectUsage(null).available).toBe(false);
+  });
+});
+
+describe("formatCompactCount", () => {
+  it("formats compact magnitudes", () => {
+    expect(formatCompactCount(0)).toBe("0");
+    expect(formatCompactCount(42)).toBe("42");
+    expect(formatCompactCount(1250)).toBe("1.3k");
+    expect(formatCompactCount(12_500)).toBe("13k");
+  });
+});

--- a/apps/aomi-build/src/features/launch/components/deployments/usage-peek.ts
+++ b/apps/aomi-build/src/features/launch/components/deployments/usage-peek.ts
@@ -1,0 +1,74 @@
+export type UsagePeek = {
+  creditsUsed: number;
+  tokens: number;
+  available: boolean;
+  dayCount: number;
+  /** Normalized 0–1 bars for a compact spark (newest last). */
+  spark: number[];
+};
+
+function numberValue(value: unknown) {
+  const n = Number(value ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Compact token/credit counts for the Home glance. */
+export function formatCompactCount(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "0";
+  if (value < 1000) return value < 10 ? value.toFixed(value % 1 ? 2 : 0) : String(Math.round(value));
+  if (value < 1_000_000) return `${(value / 1000).toFixed(value < 10_000 ? 1 : 0)}k`;
+  return `${(value / 1_000_000).toFixed(1)}m`;
+}
+
+/**
+ * Summarize operate usage daily rows for the project Home card.
+ * Clarify only — same feed as Operate → Usage.
+ */
+export function summarizeProjectUsage(payload: {
+  daily?: Array<Record<string, unknown>>;
+} | null): UsagePeek {
+  if (!payload) {
+    return {
+      creditsUsed: 0,
+      tokens: 0,
+      available: false,
+      dayCount: 0,
+      spark: [],
+    };
+  }
+
+  const daily = payload.daily ?? [];
+  const totals = daily.reduce(
+    (acc, row) => ({
+      creditsUsed: acc.creditsUsed + numberValue(row.creditsUsed),
+      tokens:
+        acc.tokens +
+        numberValue(row.inputTokens) +
+        numberValue(row.outputTokens),
+    }),
+    { creditsUsed: 0, tokens: 0 },
+  );
+
+  const byDay = new Map<string, number>();
+  for (const row of daily) {
+    const day = String(row.periodUtcDay ?? "").trim();
+    if (!day) continue;
+    byDay.set(day, (byDay.get(day) ?? 0) + numberValue(row.creditsUsed));
+  }
+  const days = [...byDay.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  const slice = days.slice(-7);
+  const max = Math.max(...slice.map(([, v]) => v), 0);
+  const spark =
+    slice.length === 0
+      ? []
+      : max <= 0
+        ? slice.map(() => 0)
+        : slice.map(([, v]) => v / max);
+
+  return {
+    ...totals,
+    available: true,
+    dayCount: byDay.size,
+    spark,
+  };
+}

--- a/apps/aomi-build/src/features/operate/operate-view.test.tsx
+++ b/apps/aomi-build/src/features/operate/operate-view.test.tsx
@@ -3,6 +3,11 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { OperateView, truncateAddress } from "./operate-view";
 
 const operateFetch = vi.fn();
+const searchParams = { current: new URLSearchParams("") };
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => searchParams.current,
+}));
 
 vi.mock("@build/components/control-plane/github-session-context", () => ({
   useGitHubSession: () => ({
@@ -28,6 +33,7 @@ describe("truncateAddress", () => {
 describe("OperateView transactions", () => {
   beforeEach(() => {
     operateFetch.mockReset();
+    searchParams.current = new URLSearchParams("");
   });
 
   it("renders denser columns from wire fields and truncates addresses", async () => {
@@ -82,5 +88,20 @@ describe("OperateView transactions", () => {
       "href",
       "/projects",
     );
+  });
+
+  it("honors ?project= when loading operate data", async () => {
+    searchParams.current = new URLSearchParams("project=42");
+    operateFetch.mockResolvedValue({
+      sources: [{ id: 42, repositoryLink: "a/b", apps: [] }],
+      daily: [],
+      breakdown: [],
+    });
+
+    render(<OperateView kind="usage" />);
+
+    await waitFor(() => {
+      expect(operateFetch).toHaveBeenCalledWith("usage", 42);
+    });
   });
 });

--- a/apps/aomi-build/src/features/operate/operate-view.tsx
+++ b/apps/aomi-build/src/features/operate/operate-view.tsx
@@ -10,6 +10,7 @@ import {
   WalletCards,
 } from "lucide-react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import {
   useGitHubSession,
@@ -457,13 +458,21 @@ function operateCacheKey(
   return `${accountKey}:${kind}:${sourceId ?? "all"}`;
 }
 
+function projectIdFromSearch(raw: string | null): number | null {
+  if (!raw) return null;
+  const id = Number(raw);
+  return Number.isSafeInteger(id) && id > 0 ? id : null;
+}
+
 export function OperateView({ kind }: { kind: OperateKind }) {
   const { account } = useGitHubSession();
+  const searchParams = useSearchParams();
+  const projectFromUrl = projectIdFromSearch(searchParams.get("project"));
   const accountCacheKey = operateAccountCacheKey(account);
+  const [sourceId, setSourceId] = useState<number | null>(projectFromUrl);
   const initialCacheKey = accountCacheKey
-    ? operateCacheKey(accountCacheKey, kind, null)
+    ? operateCacheKey(accountCacheKey, kind, sourceId)
     : null;
-  const [sourceId, setSourceId] = useState<number | null>(null);
   const [payload, setPayload] = useState<OperatePayload | null>(
     () => (initialCacheKey ? operateCache.get(initialCacheKey) : null) ?? null,
   );
@@ -476,6 +485,10 @@ export function OperateView({ kind }: { kind: OperateKind }) {
   const sources = useMemo(() => payload?.sources ?? [], [payload?.sources]);
   const canPage = kind === "transactions" || kind === "logs";
   const nextCursor = canPage ? payload?.nextCursor : null;
+
+  useEffect(() => {
+    if (projectFromUrl != null) setSourceId(projectFromUrl);
+  }, [projectFromUrl]);
 
   useEffect(() => {
     if (account.loading) {

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,7 @@
 
 ## Last Updated
 
+2026-07-13 — Build P2 usage peek (Home meter → Operate Usage);
 2026-07-13 — Build P2 Deployments timeline (history that reads as history);
 2026-07-13 — Build Live status consistency (one story across list/Home/Deployments);
 2026-07-13 — Build P2 Project home (live / keys / Open Chat / usage glance);
@@ -11,9 +12,16 @@
 2026-07-13 — Billing option A: methods live on Chat (no fake Build fetch);
 2026-07-13 — BILLING-EXPERIENCE.md: backend ↔ UI map (code-checked)
 
+## Build P2 usage peek (2026-07-13)
+
+Branch `feat/build-p2-usage-peek`:
+
+- Home Usage card: credits + tokens + day spark; Environment ≠ Billing copy.
+- Deep link `/operate/usage?project=<id>`; Operate honors `?project=`.
+
 ## Build P2 Deployments timeline (2026-07-13)
 
-Branch `feat/build-p2-deployments-timeline`:
+Branch `feat/build-p2-deployments-timeline` (PR #334):
 
 - Deployments tab summary uses the same Live story + history count.
 - Rows lead with app names + Current; deployment id is secondary.


### PR DESCRIPTION
## Summary
- Home **Usage** card: credits + compact tokens + day spark; Environment ≠ Billing copy kept.
- Deep link \`/operate/usage?project=<id>\`; Operate honors \`?project=\` for the source filter.
- Same operate usage feed — clarify only, no Billing invent.

## Test plan
- [ ] Open project Home → Usage shows No traffic / credits / Unavailable honestly
- [ ] With traffic: credits + tokens + spark visible
- [ ] Open Usage → lands on Operate Usage with that project selected
- [ ] Focused vitest: usage-peek, home-tab, operate-view