### PR TITLE
docs: update database environment references

### DIFF
--- a/apps/landing/content/guides/reference/architecture.mdx
+++ b/apps/landing/content/guides/reference/architecture.mdx
@@ -348,7 +348,7 @@ flowchart TB
 | Variable               | Required | Purpose                      |
 | ---------------------- | -------- | ---------------------------- |
 | `ANTHROPIC_API_KEY`    | Yes      | Claude API access            |
-| `DATABASE_URL`         | Yes      | PostgreSQL/SQLite connection |
+| `DATABASE_URL`         | Yes      | Backend Postgres connection; staging and production use separate Supabase project URLs |
 | `BRAVE_SEARCH_API_KEY` | No       | Web search                   |
 | `ETHERSCAN_API_KEY`    | No       | Contract data                |
 | `ALCHEMY_API_KEY`      | No       | RPC endpoints                |

--- a/docs/fe-deploy.md
+++ b/docs/fe-deploy.md
@@ -76,7 +76,7 @@ stateDiagram-v2
 | `POST /api/platforms/:platform/sources/{create-from-template,sync-installed}` | create repo from template / resolve+upsert an existing install to get `app_source.id`                                                                                        |
 | `POST /api/platforms/:platform/{deploy,activate}`                             | push candidate / activate a built release                                                                                                                                    |
 
-**Portal BFF** — `aomi-widget/apps/portal/src/app/api/launch/*` (each proxies the BE)
+**Portal BFF** — `aomi/apps/portal/src/app/api/launch/*` (each proxies the BE)
 
 | BFF route                         | → Backend                                                                                                                |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ sources_of_truth:
 
 # Repo Wiki Index
 
-`docs/` is the maintained knowledge surface for `aomi-widget`. Topic folders capture durable implementation knowledge under `facts/`, while generated inventories support discovery and ownership lookup.
+`docs/` is the maintained knowledge surface for `aomi`. Topic folders capture durable implementation knowledge under `facts/`, while generated inventories support discovery and ownership lookup.
 
 ## Primary Entry Points
 

--- a/docs/topics/development/facts/workspace.md
+++ b/docs/topics/development/facts/workspace.md
@@ -15,7 +15,7 @@ sources_of_truth:
 
 # Development Workspace
 
-`aomi-widget` is a pnpm workspace that ships the widget UI, React runtime, TypeScript client, CLI, auth support, and app validation surfaces from one TypeScript repo.
+`aomi` is a pnpm workspace that ships the widget UI, React runtime, TypeScript client, CLI, auth support, and app validation surfaces from one TypeScript repo.
 
 ## Workspace Shape
 

--- a/docs/topics/index.md
+++ b/docs/topics/index.md
@@ -12,7 +12,7 @@ sources_of_truth:
 
 # Repo Wiki Topics
 
-These topic pages are the maintained knowledge surface for `aomi-widget`. They are organized as semantic topic folders with raw facts under `facts/`; optional diagrams belong under `diagrahm/`, and scratch work belongs under `tmp/`.
+These topic pages are the maintained knowledge surface for `aomi`. They are organized as semantic topic folders with raw facts under `facts/`; optional diagrams belong under `diagrahm/`, and scratch work belongs under `tmp/`.
 
 Use `./scripts/repowiki list` to enumerate topics and `./scripts/repowiki look <topic>` to open one directly. Topic command handling comes from the neighboring `product-mono` Rust `repowiki` binary; this repo owns the wrapper, config, docs surface, and the local `./aomi` link that lets generated inventories reuse the shared Rust workspace metadata.
 


### PR DESCRIPTION
## Summary

- Clarify the landing architecture reference so `DATABASE_URL` points at environment-specific backend Postgres/Supabase URLs.
- Update active docs that still named the repo/workspace as `aomi-widget` to the current `aomi` name.
- Keep the frontend deploy doc's BFF path aligned with the current repo name.

## Validation

- `git diff --check`
- Targeted scans for old/new Supabase project refs and stale active-doc workspace naming.