### PR TITLE
Build P2: deep-link polish (⌘K / Overview / Billing)

### DIFF
--- a/apps/aomi-build/src/app/(control-plane)/settings/settings-billing-panel.test.tsx
+++ b/apps/aomi-build/src/app/(control-plane)/settings/settings-billing-panel.test.tsx
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { setLastProjectId } from "@build/lib/last-project";
 
 vi.mock("@build/lib/chat-url", () => ({
   resolveChatUrl: () => "https://chat.aomi.dev",
@@ -8,6 +9,14 @@ vi.mock("@build/lib/chat-url", () => ({
 import { SettingsBillingPanel } from "./settings-billing-panel";
 
 describe("SettingsBillingPanel", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
   it("keeps short product copy without rail jargon or fake invoices", () => {
     render(<SettingsBillingPanel />);
 
@@ -31,5 +40,16 @@ describe("SettingsBillingPanel", () => {
     expect(screen.queryByText(/x402/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/invoice #/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/\$\d/)).not.toBeInTheDocument();
+  });
+
+  it("deep-links Usage and Environment to the last project when set", () => {
+    setLastProjectId(9);
+    render(<SettingsBillingPanel />);
+    expect(
+      screen.getByRole("link", { name: /operate → usage/i }),
+    ).toHaveAttribute("href", "/operate/usage?project=9");
+    expect(
+      screen.getByRole("link", { name: /secrets → environment/i }),
+    ).toHaveAttribute("href", "/projects/9?tab=environment");
   });
 });

--- a/apps/aomi-build/src/app/(control-plane)/settings/settings-billing-panel.tsx
+++ b/apps/aomi-build/src/app/(control-plane)/settings/settings-billing-panel.tsx
@@ -1,7 +1,10 @@
+"use client";
+
 import Link from "next/link";
 import { ArrowRight, Gauge, KeyRound, MessageSquare } from "lucide-react";
 
 import { resolveChatUrl } from "@build/lib/chat-url";
+import { lastEnvironmentHref, lastUsageHref } from "@build/lib/deep-links";
 
 /**
  * Billing guidance: payment setup lives on Chat; spend meter is Usage.
@@ -34,7 +37,7 @@ export function SettingsBillingPanel() {
       <ul className="divide-border overflow-hidden rounded-lg border border-border bg-surface-1 divide-y">
         <li>
           <Link
-            href="/operate/usage"
+            href={lastUsageHref()}
             className="hover:bg-accent-hover flex items-center justify-between gap-3 px-4 py-3 transition"
           >
             <div className="flex min-w-0 items-start gap-3">
@@ -53,7 +56,7 @@ export function SettingsBillingPanel() {
         </li>
         <li>
           <Link
-            href="/settings/secrets"
+            href={lastEnvironmentHref()}
             className="hover:bg-accent-hover flex items-center justify-between gap-3 px-4 py-3 transition"
           >
             <div className="flex min-w-0 items-start gap-3">

--- a/apps/aomi-build/src/components/control-plane/command-palette.test.tsx
+++ b/apps/aomi-build/src/components/control-plane/command-palette.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { setLastProjectId } from "@build/lib/last-project";
 
 const push = vi.fn();
 
@@ -15,10 +16,12 @@ import {
 describe("CommandPalette", () => {
   beforeEach(() => {
     push.mockClear();
+    window.localStorage.clear();
   });
 
   afterEach(() => {
     document.body.innerHTML = "";
+    window.localStorage.clear();
   });
 
   it("opens from the header Search event", async () => {
@@ -56,5 +59,30 @@ describe("CommandPalette", () => {
         screen.queryByRole("dialog", { name: /command palette/i }),
       ).toBeNull();
     });
+  });
+
+  it("deep-links last project Home, Environment, and Usage", async () => {
+    setLastProjectId(42);
+    render(<CommandPalette />);
+    openCommandPalette();
+
+    await screen.findByRole("dialog", { name: /command palette/i });
+
+    fireEvent.click(screen.getByRole("button", { name: /^last project\b/i }));
+    expect(push).toHaveBeenCalledWith("/projects/42");
+
+    push.mockClear();
+    openCommandPalette();
+    await screen.findByRole("dialog", { name: /command palette/i });
+    fireEvent.click(
+      screen.getByRole("button", { name: /^environment \/ secrets\b/i }),
+    );
+    expect(push).toHaveBeenCalledWith("/projects/42?tab=environment");
+
+    push.mockClear();
+    openCommandPalette();
+    await screen.findByRole("dialog", { name: /command palette/i });
+    fireEvent.click(screen.getByRole("button", { name: /^usage\b/i }));
+    expect(push).toHaveBeenCalledWith("/operate/usage?project=42");
   });
 });

--- a/apps/aomi-build/src/components/control-plane/command-palette.tsx
+++ b/apps/aomi-build/src/components/control-plane/command-palette.tsx
@@ -14,6 +14,12 @@ import {
   WalletCards,
   type LucideIcon,
 } from "lucide-react";
+import {
+  lastEnvironmentHref,
+  lastProjectHref,
+  lastUsageHref,
+} from "@build/lib/deep-links";
+import { getLastProjectId } from "@build/lib/last-project";
 
 type CommandItem = {
   id: string;
@@ -24,78 +30,111 @@ type CommandItem = {
   keywords?: string;
 };
 
-const COMMANDS: CommandItem[] = [
-  {
-    id: "projects",
-    label: "Projects",
-    hint: "Your connected repositories",
-    href: "/projects",
-    icon: FolderKanban,
-    keywords: "project app repo",
-  },
-  {
-    id: "new-app",
-    label: "New app",
-    hint: "Import and deploy from GitHub",
-    href: "/operate/deployments/new",
-    icon: Plus,
-    keywords: "create deploy import",
-  },
-  {
-    id: "deployments",
-    label: "Deployments",
-    hint: "Operate → Deployments",
-    href: "/operate/deployments",
-    icon: Rocket,
-    keywords: "release promote live",
-  },
-  {
-    id: "transactions",
-    label: "Transactions",
-    hint: "Operate → Transactions",
-    href: "/operate/transactions",
-    icon: WalletCards,
-    keywords: "tx spend",
-  },
-  {
-    id: "usage",
-    label: "Usage",
-    hint: "Credits and tokens meter",
-    href: "/operate/usage",
-    icon: Gauge,
-    keywords: "credits tokens meter",
-  },
-  {
-    id: "settings",
-    label: "Settings",
-    hint: "Account settings",
-    href: "/settings",
-    icon: Settings,
-  },
-  {
-    id: "secrets",
-    label: "Secrets",
-    hint: "Open Environment from Settings",
-    href: "/settings/secrets",
-    icon: KeyRound,
-    keywords: "environment keys env",
-  },
-  {
-    id: "integrations",
-    label: "Integrations",
-    hint: "Bots and channels",
-    href: "/integrations",
-    icon: Plug,
-  },
-  {
-    id: "overview",
-    label: "Overview",
-    hint: "Stats and recent activity",
-    href: "/overview",
-    icon: Home,
-    keywords: "dashboard home",
-  },
-];
+function buildCommands(): CommandItem[] {
+  const lastId = getLastProjectId();
+  const items: CommandItem[] = [
+    {
+      id: "project-home",
+      label: lastId ? "Last project" : "Projects",
+      hint: lastId
+        ? "Open project Home"
+        : "Your connected repositories",
+      href: lastProjectHref(),
+      icon: FolderKanban,
+      keywords: "project app repo home",
+    },
+  ];
+
+  if (lastId) {
+    items.push({
+      id: "projects",
+      label: "All projects",
+      hint: "Your connected repositories",
+      href: "/projects",
+      icon: FolderKanban,
+      keywords: "project list",
+    });
+    items.push({
+      id: "project-deployments",
+      label: "Project deployments",
+      hint: "History for last project",
+      href: lastProjectHref("deployments"),
+      icon: Rocket,
+      keywords: "release promote live history",
+    });
+  }
+
+  items.push(
+    {
+      id: "new-app",
+      label: "New app",
+      hint: "Import and deploy from GitHub",
+      href: "/operate/deployments/new",
+      icon: Plus,
+      keywords: "create deploy import",
+    },
+    {
+      id: "deployments",
+      label: "Deployments",
+      hint: "Operate → Deployments",
+      href: "/operate/deployments",
+      icon: Rocket,
+      keywords: "release promote live",
+    },
+    {
+      id: "transactions",
+      label: "Transactions",
+      hint: "Operate → Transactions",
+      href: "/operate/transactions",
+      icon: WalletCards,
+      keywords: "tx spend",
+    },
+    {
+      id: "usage",
+      label: "Usage",
+      hint: lastId
+        ? "Credits for last project"
+        : "Credits and tokens meter",
+      href: lastUsageHref(),
+      icon: Gauge,
+      keywords: "credits tokens meter",
+    },
+    {
+      id: "settings",
+      label: "Settings",
+      hint: "Account settings",
+      href: "/settings",
+      icon: Settings,
+    },
+    {
+      id: "secrets",
+      label: "Environment / Secrets",
+      hint: lastId
+        ? "Keys on last project Environment"
+        : "Open Environment from Settings",
+      href: lastEnvironmentHref(),
+      icon: KeyRound,
+      keywords: "environment keys env secrets",
+    },
+    {
+      id: "integrations",
+      label: "Integrations",
+      hint: "Bots and channels",
+      href: "/integrations",
+      icon: Plug,
+    },
+    {
+      id: "overview",
+      label: "Overview",
+      hint: "Stats and recent activity",
+      href: "/overview",
+      icon: Home,
+      keywords: "dashboard home",
+    },
+  );
+
+  return items;
+}
 
 const OPEN_EVENT = "aomi-build:open-command-palette";
 
@@ -115,10 +154,11 @@ export function CommandPalette() {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
+  const [commands, setCommands] = useState<CommandItem[]>(() => buildCommands());
 
   const filtered = useMemo(
-    () => COMMANDS.filter((item) => matches(item, query.trim())),
-    [query],
+    () => commands.filter((item) => matches(item, query.trim())),
+    [commands, query],
   );
 
   useEffect(() => {
@@ -151,7 +191,10 @@ export function CommandPalette() {
     if (!open) {
       setQuery("");
       setActive(0);
+      return;
     }
+    // Refresh last-project targets each time the palette opens.
+    setCommands(buildCommands());
   }, [open]);
 
   useEffect(() => {

--- a/apps/aomi-build/src/features/overview/overview-dashboard.tsx
+++ b/apps/aomi-build/src/features/overview/overview-dashboard.tsx
@@ -14,6 +14,8 @@ import {
 import { useGlobalDeploymentRecords } from "@build/features/launch/components/deployments/use-global-deployment-records";
 import { operateFetch } from "@build/features/operate/client";
 import { BUILD_GLOSSARY } from "@build/lib/glossary";
+import { lastUsageHref, projectHref } from "@build/lib/deep-links";
+import { getLastProjectId } from "@build/lib/last-project";
 
 type UsagePayload = {
   daily?: Array<Record<string, any>>;
@@ -201,7 +203,7 @@ export function OverviewDashboard() {
               {deployments.slice(0, 5).map((deployment) => (
                 <Link
                   key={`${deployment.sourceId}-${deployment.deploymentId}`}
-                  href={`/operate/deployments?project=${deployment.sourceId}&deployment=${encodeURIComponent(deployment.deploymentId)}`}
+                  href={projectHref(deployment.sourceId, "deployments")}
                   className="hover:bg-accent-hover flex items-center justify-between gap-3 px-4 py-3 text-sm"
                 >
                   <div className="min-w-0">
@@ -260,7 +262,7 @@ export function OverviewDashboard() {
             </div>
           </Link>
           <Link
-            href="/operate/usage"
+            href={lastUsageHref()}
             className="border-border bg-surface-1 hover:bg-accent-hover rounded-md border p-4"
           >
             <Gauge className="text-dim size-4" aria-hidden />
@@ -270,9 +272,11 @@ export function OverviewDashboard() {
             <div className="text-dim mt-1 text-xs">
               {usageError
                 ? `Usage unavailable: ${usageError}`
-                : latestDeployment
-                  ? "Credits by app"
-                  : "Appears after app traffic"}
+                : getLastProjectId()
+                  ? "Credits for last project"
+                  : latestDeployment
+                    ? "Credits by app"
+                    : "Appears after app traffic"}
             </div>
           </Link>
         </div>

--- a/apps/aomi-build/src/lib/deep-links.test.ts
+++ b/apps/aomi-build/src/lib/deep-links.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { setLastProjectId } from "./last-project";
+import {
+  lastEnvironmentHref,
+  lastProjectHref,
+  lastUsageHref,
+  projectHref,
+  usageHref,
+} from "./deep-links";
+
+describe("deep-links", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("builds project and usage hrefs", () => {
+    expect(projectHref(42)).toBe("/projects/42");
+    expect(projectHref(42, "home")).toBe("/projects/42");
+    expect(projectHref(42, "environment")).toBe(
+      "/projects/42?tab=environment",
+    );
+    expect(usageHref(42)).toBe("/operate/usage?project=42");
+    expect(usageHref(null)).toBe("/operate/usage");
+  });
+
+  it("falls back when there is no last project", () => {
+    expect(lastProjectHref()).toBe("/projects");
+    expect(lastProjectHref("deployments")).toBe("/projects");
+    expect(lastUsageHref()).toBe("/operate/usage");
+    expect(lastEnvironmentHref()).toBe("/settings/secrets");
+  });
+
+  it("uses the last project when set", () => {
+    setLastProjectId(7);
+    expect(lastProjectHref()).toBe("/projects/7");
+    expect(lastProjectHref("deployments")).toBe("/projects/7?tab=deployments");
+    expect(lastUsageHref()).toBe("/operate/usage?project=7");
+    expect(lastEnvironmentHref()).toBe("/projects/7?tab=environment");
+  });
+});

--- a/apps/aomi-build/src/lib/deep-links.ts
+++ b/apps/aomi-build/src/lib/deep-links.ts
@@ -1,0 +1,46 @@
+import { getLastProjectId } from "./last-project";
+
+/** Project page tabs — keep in sync with `ProjectPage` TABS. */
+export type ProjectTab =
+  | "home"
+  | "deployments"
+  | "chat"
+  | "environment"
+  | "settings";
+
+/** Deep link into a project. Home omits `?tab=` (default). */
+export function projectHref(sourceId: number, tab?: ProjectTab): string {
+  if (!Number.isSafeInteger(sourceId) || sourceId <= 0) return "/projects";
+  if (!tab || tab === "home") return `/projects/${sourceId}`;
+  return `/projects/${sourceId}?tab=${tab}`;
+}
+
+/** Last opened project, or the Projects list when none. */
+export function lastProjectHref(tab?: ProjectTab): string {
+  const id = getLastProjectId();
+  if (!id) return "/projects";
+  return projectHref(id, tab);
+}
+
+/** Operate Usage, optionally scoped to one project. */
+export function usageHref(sourceId?: number | null): string {
+  if (
+    sourceId != null &&
+    Number.isSafeInteger(sourceId) &&
+    sourceId > 0
+  ) {
+    return `/operate/usage?project=${sourceId}`;
+  }
+  return "/operate/usage";
+}
+
+export function lastUsageHref(): string {
+  return usageHref(getLastProjectId());
+}
+
+/** Secrets / Environment: last project tab, else Settings → Secrets hub. */
+export function lastEnvironmentHref(): string {
+  const id = getLastProjectId();
+  if (!id) return "/settings/secrets";
+  return projectHref(id, "environment");
+}

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,7 @@
 
 ## Last Updated
 
+2026-07-14 — Build P2 deep-link polish (⌘K / Billing / Overview → right tab);
 2026-07-13 — Build P2 usage peek (Home meter → Operate Usage);
 2026-07-13 — Build P2 Deployments timeline (history that reads as history);
 2026-07-13 — Build Live status consistency (one story across list/Home/Deployments);
@@ -12,9 +13,18 @@
 2026-07-13 — Billing option A: methods live on Chat (no fake Build fetch);
 2026-07-13 — BILLING-EXPERIENCE.md: backend ↔ UI map (code-checked)
 
+## Build P2 deep-link polish (2026-07-14)
+
+Branch `feat/build-p2-deep-links`:
+
+- Shared `deep-links.ts` for project tabs, last-project Home, Environment, Usage.
+- ⌘K Last project / Environment / Usage prefer last project when set.
+- Overview recent deploys → project Deployments tab; Usage card / Billing links
+  use last-project scoped Usage / Environment when available.
+
 ## Build P2 usage peek (2026-07-13)
 
-Branch `feat/build-p2-usage-peek`:
+Branch `feat/build-p2-usage-peek` (PR #335):
 
 - Home Usage card: credits + tokens + day spark; Environment ≠ Billing copy.
 - Deep link `/operate/usage?project=<id>`; Operate honors `?project=`.


### PR DESCRIPTION
## Summary
- Shared \`deep-links.ts\` for project tabs + last-project Home / Environment / Usage.
- ⌘K: **Last project**, **Project deployments**, Environment/Secrets, Usage prefer last project when set.
- Overview recent deploys → project Deployments tab; Usage + Billing shortcuts use last-project scope when available.

## Test plan
- [ ] Open a project, then ⌘K → Last project → Home
- [ ] ⌘K → Environment / Secrets → \`?tab=environment\`
- [ ] ⌘K → Usage → \`/operate/usage?project=<id>\`
- [ ] Overview recent deploy row opens project Deployments tab
- [ ] Billing links follow last project when set
- [ ] Focused vitest: deep-links, command-palette, settings-billing-panel