### PR TITLE
Retire legacy CLI session schema

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -18,6 +18,11 @@ Current session goal: complete the Auth BFF BetterAuth cleanup, remove legacy
 endpoints, keep canonical backend UUIDs stable, and verify with CLI E2E before
 manual handoff.
 
+2026-07-13 follow-up: staging and production now use separate Supabase
+databases. Local schema convergence applies the backend's forward drop instead
+of recreating the retired `bff_cli_device_sessions` / `bff_cli_sessions`
+tables; fresh databases also finish replay with that drop.
+
 Progress:
 
 - Removed runtime `/api/bff/auth/siwe/*`, `/api/bff/auth/exchange`, and

--- a/memory/2026-07-13.md
+++ b/memory/2026-07-13.md
@@ -1,0 +1,19 @@
+# 2026-07-13
+
+## Align local auth schema with isolated staging
+
+- Staging moved from the production Supabase project to the isolated
+  `chatbot/staging` branch (`cmwkmjpfbffmdiluvgtu`). Portal and backend still
+  share one database within an environment, but staging and production no
+  longer share a database with each other.
+- Replaced the incremental local-schema hook that reapplied
+  `20260624010000_bff_cli_sessions.sql` with the forward
+  `20260713000000_drop_legacy_bff_cli_sessions.sql` migration. The legacy CLI
+  device flow has been replaced by Better Auth sessions and short-lived
+  portal-owned PKCE grants.
+- Fresh local databases continue to replay every backend migration, including
+  the new forward migration that drops `bff_cli_device_sessions` and
+  `bff_cli_sessions`.
+- Kept historical review records and migrations intact; updated maintained
+  comments and checks only where "shared database" could be misread as shared
+  across staging and production.

--- a/packages/account/src/db/pool.ts
+++ b/packages/account/src/db/pool.ts
@@ -1,10 +1,11 @@
 import { Pool } from "pg";
 
 /**
- * The single Postgres pool for the one shared database: BetterAuth's session
- * tables and the canonical account graph (`users` / `auth_providers` /
- * `public_keys`) live side by side, so a user the portal creates is
- * immediately found by the backend's find-only `DbUser::get`.
+ * The single Postgres pool for this environment's database: BetterAuth's
+ * session tables and the canonical account graph (`users` /
+ * `auth_providers` / `public_keys`) live side by side, so a user the portal
+ * creates is immediately found by the backend connected to the same
+ * environment. Staging and production use different databases.
  *
  * Connection string comes from `DATABASE_URL` — the only DB env var in this
  * package. Never hard-code it; it carries the DB password. Node runtime only

--- a/packages/account/test/env.test.ts
+++ b/packages/account/test/env.test.ts
@@ -31,7 +31,7 @@ describe("readAccountAuthEnv", () => {
     );
   });
 
-  it("requires the one shared database URL in every environment", () => {
+  it("requires an explicit database URL in every environment", () => {
     for (const NODE_ENV of ["development", "test", "production"]) {
       expect(() =>
         readAccountAuthEnv({

--- a/scripts/dev-auth-stack.sh
+++ b/scripts/dev-auth-stack.sh
@@ -138,8 +138,8 @@ ensure_backend_schema() {
 
   echo "Converging local backend schema from $migrations_dir"
 
-  if ! psql "$LOCAL_DB_URL" -tAc "select to_regclass('public.bff_cli_sessions')" | grep -q bff_cli_sessions; then
-    apply_migration 20260624010000_bff_cli_sessions.sql
+  if psql "$LOCAL_DB_URL" -tAc "select to_regclass('public.bff_cli_device_sessions') is not null or to_regclass('public.bff_cli_sessions') is not null" | grep -q t; then
+    apply_migration 20260713000000_drop_legacy_bff_cli_sessions.sql
   fi
 
   if ! psql "$LOCAL_DB_URL" -tAc "select to_regclass('public.threads')" | grep -q threads; then

--- a/specs/FINAL-REVIEW-CHECKLIST.md
+++ b/specs/FINAL-REVIEW-CHECKLIST.md
@@ -262,7 +262,7 @@ absent.
 Impact:
 
 The secret is exposed in source/history, and local or unconfigured runs can
-silently connect to the hosted shared DB.
+silently connect to the hosted production DB.
 
 Fix checklist:
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -3,9 +3,9 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach, vi } from "vitest";
 
-// One shared DB, no in-code fallback: suites that import the account package's
-// query/better-auth modules need a URL present. pg never connects until the
-// first query, so a placeholder is safe for unit tests.
+// One DB per environment, no in-code fallback: suites that import the account
+// package's query/better-auth modules need a URL present. pg never connects
+// until the first query, so a placeholder is safe for unit tests.
 process.env.DATABASE_URL ??=
   "postgresql://postgres:postgres@127.0.0.1:5432/vitest_placeholder";
 process.env.AOMI_CLI_STRICT_EXIT = "1";


### PR DESCRIPTION
## What changed

- replace local schema convergence that recreated the retired BFF CLI session tables with the forward drop migration
- clarify that portal and backend share one database within an environment, while staging and production use separate databases
- update the active goal, review checklist wording, test description, and dated work record

## Why

The CLI/native auth flow now uses Better Auth sessions and short-lived portal-owned PKCE grants. Recreating `bff_cli_device_sessions` and `bff_cli_sessions` locally contradicted the current backend migration stack and the isolated staging database rollout.

## Dependency

Merge aomi-labs/product-mono#798 first. This script invokes `20260713000000_drop_legacy_bff_cli_sessions.sql` from the sibling product-mono checkout when an existing local database still contains either legacy table.

## Impact

Fresh local databases still replay the full migration sequence and finish with the forward drop. Existing local databases converge by applying that same idempotent drop. No production or staging configuration is changed by this PR.

## Validation

- `bash -n scripts/dev-auth-stack.sh`
- `pnpm exec vitest run packages/account/test/env.test.ts` (9/9 passed)
- Prettier check on all changed Markdown and TypeScript files
- `git diff --check`
