### PR TITLE
feat(aomi-build): AI Builder Create surface on /build (P0–P2)

### DIFF
--- a/apps/aomi-build/AI-BUILDER-EXPERIENCE.md
+++ b/apps/aomi-build/AI-BUILDER-EXPERIENCE.md
@@ -1,0 +1,468 @@
+# Aomi Build — AI Builder (Create / “Chat Mock”) Plan
+
+> **Status:** P0–P2 + partial P4 landed (craft port). **Next = P3** (nodes + compile/test) — biggest gap vs Cecilia sketches.  
+> **App:** `aomi/apps/aomi-build` → [build.aomi.dev](https://build.aomi.dev)  
+> **Reference mock:** `aomi-build` repo → `apps/portal` `/build`  
+> **Owner:** Gordian (`0xgordian`) — experience + mock UI  
+> **Backend / Smithers stream:** Han (`POST /api/build` + SSE — **not in product-mono yet**)  
+> **Branch:** `feat/build-enable-route`  
+> **Last updated:** 2026-07-14 (post-craft review)
+
+Local source of truth for bringing the **AI Builder** onto the live control plane.  
+Pair with a Scrum Board issue so Cecilia/Han can see status. This file alone is not team sync.
+
+Related:
+
+- [BUILDERS-EXPERIENCE.md](./BUILDERS-EXPERIENCE.md) — manage/deploy/operate polish (**mostly done**; do not reopen for chrome)
+- [BILLING-EXPERIENCE.md](./BILLING-EXPERIENCE.md) — pay on Chat, not fake Build billing
+
+---
+
+## One-sentence goal
+
+Ship a **nested-in-shell** Create experience on live `/build`: describe intent → Smithers-shaped plan/generate → review/compile → hand off to GitHub/Projects — using the **mock as craft reference**, not as a drop-in portal clone.
+
+---
+
+## Why this exists (Cecilia)
+
+```text
+@gordian how's the chat mock up… build page is more or less done…
+focus on the next highest value… don't get yourself trapped
+```
+
+Decoded with product sketches + code:
+
+| Phrase | Means |
+|--------|--------|
+| **Chat mock** | Chat-**like** AI Builder on **Build** (create), not `chat.aomi.dev` |
+| **Build more or less done** | Manage/deploy/Environment clarity is good enough — stop trapping there |
+| **Next highest value** | Create / generate journey mock inside live Build |
+| **Don't get trapped** | Ship stages; don't polish Cursor chrome forever |
+
+Architecture sketch (team):
+
+- `chat.aomi.dev` — user runtime, BetterAuth, **no build**
+- `build.aomi.dev` — builder, GitHub login, deploy/operate **and** (next) Create
+- **Gordian** = mock experience → **Han** = wiring → **final** `build.aomi.dev`
+
+Wireframe sketch (product journey):
+
+1. Manage deployment (today — Projects/Operate)
+2. Build new app — “what do u wanna build?” + Smithers nodes
+3. Tool layer done → compile → aomi-run → download / init GitHub
+
+---
+
+## Platform map (truthful)
+
+Two hosts. Build has **two modes**. Create is not a third product hostname.
+
+```mermaid
+flowchart TB
+  subgraph hosts [Hosts]
+    Chat["chat.aomi.dev\nRuntime · BetterAuth\nTalk to live agent"]
+    Build["build.aomi.dev\nControl plane · GitHub"]
+  end
+
+  subgraph buildModes [build.aomi.dev modes]
+    Manage["Manage\nProjects · Deploy · Env · Operate\nHan wired · Gordian polished"]
+    Create["Create · AI Builder\n/build sidebar\nMock experience · Han SSE later"]
+  end
+
+  Build --> Manage
+  Build --> Create
+  Create -->|"after ship + activate"| Chat
+  Manage -->|"Open Chat tab"| Chat
+```
+
+### What exists in code today
+
+```mermaid
+flowchart LR
+  subgraph mockRepo ["aomi-build repo MOCK"]
+    MockBuild["/build\nImmersive BuildLayout\nComposer · sessions · stream\nlocalStorage timers"]
+  end
+
+  subgraph liveApp ["aomi/apps/aomi-build LIVE"]
+    Shell["ControlPlaneShell"]
+    Scaffold["/build BuildView\ncomposer · stream · files\nlocal mock pipeline"]
+    BFF["/api/bff/*\ndeploy · operate · github"]
+  end
+
+  subgraph localGen ["Local generate today"]
+    Smither["aomi-smither CLI\n+ Gateway"]
+  end
+
+  subgraph be ["product-mono"]
+    Manager["platforms + github-app\nLIVE"]
+    Planned["POST /api/build + SSE\nNOT IMPLEMENTED"]
+  end
+
+  MockBuild -.->|"reference only"| Scaffold
+  Scaffold --> Shell
+  Shell --> BFF --> Manager
+  Scaffold -.x.-> Planned
+  Smither --> Manager
+```
+
+| Layer | Path | Status |
+|-------|------|--------|
+| Mock Create UI | `aomi-build/.../app/build` | Strong prototype |
+| Live `/build` | `apps/aomi-build/.../build` | Create craft in shell (local mock run) |
+| Live manage/deploy | Projects / Operate BFFs | Live (Han) |
+| Hosted Smithers API | `POST /api/build` | **Docs only** |
+| Local Smithers | `aomi/packages/smither` | CLI exists |
+| Runtime chat | `chat.aomi.dev` | Live; Build deep-links here |
+
+---
+
+## Product journey (correct target)
+
+Not “prompt → dump code.” Workflow:
+
+```mermaid
+flowchart TD
+  D[Describe intent] --> P[Plan · Smithers nodes]
+  P --> G[Generate · show tools + files]
+  G --> C[Compile]
+  C --> T[Test · aomi-run]
+  T --> S[Ship · download / init GitHub]
+  S --> Dep[Deploy from Projects]
+  Dep --> Chat[Open chat.aomi.dev]
+```
+
+Every stage needs: loading · error · success · back · next (when interactive).
+
+### Live journey stages (target naming)
+
+1. **Describe** — intent in, not code  
+2. **Plan** — Smithers nodes compose work  
+3. **Generate** — review tool layer + source  
+4. **Compile & test** — compile, then aomi-run  
+5. **Ship** — download / init GitHub → manage on Projects  
+
+**Honesty check after craft port:** stream UI still uses mock labels `plan → generate → validate → ready` (from original mock), mapped into journey chips. Visual pipeline ≠ full sketch yet — **no node cards, no explicit Compile / aomi-run buttons**. That is P3.
+
+---
+
+## Plan review (2026-07-14) — adjustments
+
+Reviewed after craft port. Direction stays. Phase diagram and priorities update as follows:
+
+| Finding | Adjustment |
+|---------|------------|
+| Sparse P1 was wrong; craft port fixed feel | Keep rule: **mock craft first**, thin scaffold never again |
+| P1 + P2 + most of P4 landed in one craft slice | Treat P0–P2 + P4(banner/history) as **done on branch**; don't re-do |
+| Still Cursor-ish (Plan/Multitask pills, model chip) | **Tighten before Cecilia demo**: drop or relabel Multitask; keep one honest “Local mock” chip |
+| Cecilia wireframe = nodes + compile + aomi-run + download/init GitHub | **P3 is now the highest-value remaining product work** — not more timeline polish |
+| Ship banner → Projects only; GitHub init Soon; no download | Finish P4 leftovers on P3 pass: mock **Download**, clearer init copy |
+| File layout listed `smithers-nodes.tsx` | Still missing — create in P3 |
+| Platform diagram said “Scaffold” | Already updated to craft pipeline — keep truthful |
+| P5 Han seams not urgent for demo | Defer until after P3 + Cecilia stop gate |
+| Risk: polish forever / get trapped | After P3 → **show Cecilia** → only then PR polish or P5 |
+
+### Revised phase flowchart
+
+```mermaid
+flowchart TD
+  Done[P0_P2_partialP4_done] --> P3[P3_Nodes_Compile_Test]
+  P3 --> Gate[Show_Cecilia]
+  Gate --> FinishP4[P4_finish_download_init_copy]
+  FinishP4 --> PR[Open_PR_preview]
+  PR --> P5[P5_Han_SSE_seams]
+```
+
+---
+
+## Mock vs target (do not confuse)
+
+### Mock (`aomi-build` portal `/build`) — craft reference
+
+```mermaid
+flowchart LR
+  Rail[Session rail] --> Thread[Chat thread]
+  Thread --> Ctx[Context panel]
+  Empty[Centered composer + templates] --> Thread
+  Thread --> Pipe["Timers: plan→generate→validate→ready"]
+  Pipe --> DeployCTA["Open deployment /deploy/id"]
+```
+
+Traits:
+
+- Immersive **BuildLayout** (replaces dashboard chrome)
+- Cursor-style Compose (model chips, Plan/Multitask, Customize marketplace)
+- Fake stages as **progress labels in chat**, not node graph
+- Handoff = **Deploy**, not GitHub ship
+
+### Target (live control plane `/build`)
+
+```mermaid
+flowchart LR
+  CP[ControlPlaneShell nav] --> BuildPage["features/build BuildView"]
+  BuildPage --> Composer[Intent composer]
+  Composer --> Nodes[Smithers node story UI]
+  Nodes --> Files[File tree + stream]
+  Files --> Ship[Ship banner → Projects / GitHub]
+```
+
+Traits:
+
+- Nested in Han’s shell (no second global sidebar)
+- Journey matches Cecilia sketches
+- Mock driver until SSE; no fake manager APIs
+- Manage stays on Projects/Operate
+
+---
+
+## Import policy
+
+**Do not port wholesale.** Extract patterns into `features/build/`.
+
+| Bring over (adapt) | Do not copy as-is |
+|--------------------|-------------------|
+| Composer empty-state feel / `composer-surface` | Immersive `BuildLayout` |
+| `build-stream-timeline.tsx` | Deploy CTA → `/deploy/[id]` |
+| `file-tree-preview.tsx` | Customize marketplace as MVP |
+| Template gallery + template list | Monolithic mock `page.tsx` |
+| Session types + `use-build-session` as **local mock** | `@/` aliases, custom Icon pack, heavy DropdownMenu stack |
+| Ship-handoff **pattern** (rewrite CTAs) | Billing Upgrade card on rail |
+
+Live already has many mock-era tokens in `globals.css` (`composer-surface`, `panel-row`, `action-pill`, `text-dim`, …).
+
+---
+
+## Rules (same spirit as BUILDERS-EXPERIENCE)
+
+1. **Clarify, don't invent** — no fake `POST /api/build` responses painted as live.
+2. **Nest in `ControlPlaneShell`** — never replace global nav with BuildLayout.
+3. **Mock driver until Han SSE** — timers / localStorage OK if copy says mock / local.
+4. **Reuse live patterns** — thin `page.tsx` → `features/*`; GitHub session; existing toasts.
+5. **Smallest phase that reviews** — one vertical slice per PR when possible.
+6. **Don't reopen manage polish** — Cecilia: Build manage is “more or less done.”
+7. **Hand off to Projects** after Ship — don't invent a parallel deploy console on `/build`.
+
+---
+
+## Target file layout
+
+```text
+apps/aomi-build/src/
+  app/(control-plane)/build/page.tsx          # thin re-export (exists)
+  features/build/
+    build-view.tsx                            # orchestrator (scaffold exists)
+    contracts.ts                              # session / stage / node types
+    templates.ts                              # starters from mock
+    hooks/use-build-session.ts                # local mock driver
+    storage/build-session-storage.ts
+    components/
+      intent-composer.tsx                     # describe CTA
+      template-gallery.tsx
+      smithers-nodes.tsx                      # plan visualization (sketch)
+      build-stream-timeline.tsx
+      file-tree-preview.tsx
+      session-history.tsx                     # in-page, not immersive rail
+      ship-handoff-banner.tsx                 # → Projects / GitHub copy
+```
+
+---
+
+## PR track (how you review without rushing main)
+
+You view **locally** (`pnpm run dev:aomi-build` → `/build`) and/or on the **Vercel preview** from each PR. Merge to `main` only after you OK — agents do not auto-merge.
+
+| PR | Phase(s) | Branch | Status |
+|----|----------|--------|--------|
+| **PR-A** | P0 + P1 + P2 + partial P4 (craft in shell) | `feat/build-enable-route` | Open next — click through locally first |
+| **PR-B** | P3 Smithers nodes + compile / aomi-run | `feat/build-p3-smithers-nodes` | After PR-A exists; implement next |
+| **PR-C** | P4 finish (download + GitHub-init copy) | `feat/build-p4-ship-polish` | After P3 / Cecilia gate |
+| **PR-D** | P5 Han SSE seams (no fake live) | `feat/build-p5-sse-seams` | After Han has API or accepted stubs |
+
+```mermaid
+flowchart LR
+  Local[View_local] --> PRA[PR_A_preview]
+  PRA --> YouOK1[You_OK]
+  YouOK1 --> Main1[Merge_main]
+  Main1 --> PRB[PR_B_P3]
+  PRB --> YouOK2[You_OK]
+  YouOK2 --> Main2[Merge_main]
+  Main2 --> PRC[PR_C]
+  PRC --> PRD[PR_D]
+```
+
+### Phase status board
+
+| Phase | What | Done? | Ships in |
+|-------|------|-------|----------|
+| **P0** | Enable Build nav + `/build` route | Yes | PR-A |
+| **P1** | Intent composer + templates + session chrome | Yes | PR-A |
+| **P1 craft** | Mock feel nested in shell | Yes | PR-A |
+| **P2** | Stream timeline + file tree + local timers | Yes | PR-A |
+| **P3** | Smithers **nodes** + Compile + aomi-run | **No — next** | PR-B |
+| **P4** | Ship banner + history | Partial (banner/history yes; download/init copy no) | Rest → PR-C |
+| **P5** | `POST /api/build` client seams | No | PR-D |
+
+---
+
+## Implementation phases
+
+```mermaid
+flowchart TD
+  P0[P0 Route unlock] --> P1[P1 Intent empty state]
+  P1 --> G1[Review: feels like Create]
+  G1 --> P2[P2 Mock run stream + files]
+  P2 --> G2[Review: journey visible]
+  G2 --> P3[P3 Smithers nodes + compile_test CTAs]
+  P3 --> G3[Show Cecilia]
+  G3 --> P4[P4 Ship handoff + session history]
+  P4 --> P5[P5 Seams for Han SSE]
+  P5 --> Later[Later: Customize · real aomi-run · GitHub init API]
+```
+
+### P0 — Route unlock ✅ (this branch)
+
+- [x] Sidebar Build `enabled: true`
+- [x] `/build` page + scaffold journey + disabled Start
+- [ ] Merge when ready (PR) so staging shows Create surface
+
+**Done when:** Click Build → no Soon, no 404.
+
+### P1 — Intent empty state ✅ (this branch)
+
+**Goal:** First viewport matches “what do you wanna build?”
+
+- [x] Working **intent composer** (client-only)
+- [x] Template gallery seeds prompts
+- [x] Journey strip on empty + active session
+- [x] Submit seeds a **local** session + active chrome (stream stub for P2)
+
+**Source craft:** mock empty composer + template gallery  
+**Skipped:** model picker DropdownMenu, Customize marketplace, immersive BuildLayout
+
+**Done when:** Type arb-bot prompt → see active session chrome.
+
+### P1 craft port ✅ (this branch)
+
+Nested in `ControlPlaneShell` (not BuildLayout). Ported mock craft:
+
+- [x] Composer surface + action pills; model chip **visual-only** (no DropdownMenu)
+- [x] Chat messages + light markdown
+- [x] Template gallery polish
+- [x] Local mock pipeline plan→generate→validate→ready → journey stages
+- [x] `build-stream-timeline` + `file-tree-preview` (main + lg context column)
+- [x] `ship-handoff-banner` → `/projects` (not `/deploy/[id]`)
+- [x] Thin in-page session history (xl left column) — no Upgrade rail
+- [x] Honest “Local mock” labeling on timers / chips
+
+### P2 — Mock run: stream + files ✅ (landed with craft port)
+
+**Goal:** After submit, builder sees progress + artifacts.
+
+- [x] Adapt `use-build-session` timers to **live stage names** (Describe→…→Ship)
+- [x] `build-stream-timeline` + `file-tree-preview` in main / side column inside shell
+- [x] Assistant/status copy with thin markdown; honest local-mock labeling
+
+**Done when:** One click-through shows stream completing and a file tree appearing.
+
+### P3 — Smithers nodes + compile / test affordances ⬅️ NEXT
+
+**Goal:** Closer to Cecilia wireframe than Cursor thread. **This closes the biggest product gap.**
+
+- [ ] Add `components/smithers-nodes.tsx` — plan step shows **node cards** (e.g. `aomi-openapi-gen` hype / binance) — mock data OK
+- [ ] Show nodes during / after `plan` (not only progress list)
+- [ ] Explicit **Compile** and **Test with aomi-run** controls after generate (mock success / fail)
+- [ ] Copy: “smither writes smither” / agent nodes — honest that stream is local
+- [ ] Soften Cursor residue: remove or hide **Multitask**; keep one local-mock affordance
+- [ ] Optional with P3: mock **Download your code** on ship banner
+
+**Done when:** Cecilia can point at nodes + compile/test and say “that’s the product.”
+
+**Stop gate:** Loom/GIF click-through → Cecilia/Han before more chrome.
+
+### P4 — Ship handoff + light history ✅ (partial with craft port)
+
+- [x] Banner: **Open Projects** (+ GitHub init Soon)
+- [x] In-page session history (not second global sidebar)
+- [x] Never deep-link to mock portal `/deploy/[id]`
+- [ ] Download (mock) button — fold into P3 pass
+- [ ] GitHub init copy: disabled with clear “needs Han API” (not ambiguous Soon forever)
+
+**Done when:** End of flow lands on manage path without confusion.
+
+### P5 — Han seams (no fake live)
+
+Document + thin client stubs only:
+
+```text
+POST /api/build          # start (planned)
+GET  /api/build/status   # SSE (planned)
+```
+
+- Feature flag or `MOCK_BUILD=1` default on
+- When Han ships, swap driver behind `use-build-session`
+
+**Out of scope until Han:** real codegen, real aomi-run, real GitHub create-repo from Build.
+
+---
+
+## Ownership
+
+| Person | Owns |
+|--------|------|
+| **Gordian** | Journey, layout nested in shell, mock interactions, copy, empty/error/success |
+| **Han** | Smithers hosted stream, GitHub create/init APIs, any compile/run remote |
+| **Cecilia** | Sign-off on Create feel vs manage; node/compile priority |
+
+---
+
+## Explicit non-goals (MVP)
+
+- Rebuilding mock portal as live app  
+- Replacing `ControlPlaneShell`  
+- Customize / plugins marketplace  
+- Inventing Billing or Chat-portal UX on `/build`  
+- Calling local timers “Smithers production”  
+- More Projects/Deployments chrome polish  
+
+---
+
+## Click-through checklist (every phase)
+
+1. Sidebar **Build** clickable → `/build`  
+2. Empty Create state readable without explaining  
+3. Run mock once → stages advance → files or nodes appear  
+4. Ship → Projects (or clear disabled reason)  
+5. Global nav still works (Overview / Projects / Operate)  
+6. Mobile: usable enough; craft remains desktop-first  
+
+If anything feels more like Cursor than Aomi Create → cut chrome, keep journey.
+
+---
+
+## Done enough (show Cecilia)
+
+- `/build` is Create, not another dashboard page  
+- Prompt → **Smithers nodes visible** → generate/files → **compile / aomi-run affordances** → ship toward GitHub/Projects  
+- Manage path untouched and still the place for deploy/operate  
+- Honest mock labeling until Han SSE  
+- Not stuck polishing Cursor pills
+
+---
+
+## Quick reference: repos
+
+| Repo / path | Role |
+|-------------|------|
+| `aomi-build` (standalone) | Historical mock portal — **reference** |
+| `aomi/apps/aomi-build` | Live control plane — **implement here** |
+| `aomi/packages/smither` | Local CLI generate — parallel track, not this UI yet |
+| `product-mono` manager | Deploy/operate live; `/api/build` absent |
+
+---
+
+## Next action
+
+1. Click through current craft: `/build` empty → run → stream/files → Open Projects.  
+2. Implement **P3** (nodes + compile/test + soft Cursor trim + optional download).  
+3. Stop gate for Cecilia — then PR (P0–P3) for preview/staging.  
+4. Only after that: P5 Han SSE seams.

--- a/apps/aomi-build/src/app/(control-plane)/build/page.tsx
+++ b/apps/aomi-build/src/app/(control-plane)/build/page.tsx
@@ -1,0 +1,5 @@
+import { BuildView } from "@build/features/build/build-view";
+
+export default function BuildPage() {
+  return <BuildView />;
+}

--- a/apps/aomi-build/src/components/control-plane/control-plane-shell.tsx
+++ b/apps/aomi-build/src/components/control-plane/control-plane-shell.tsx
@@ -74,7 +74,7 @@ const navGroups: NavGroup[] = [
   {
     title: "Build",
     items: [
-      { label: "Build", href: "/build", icon: Hammer, enabled: false },
+      { label: "Build", href: "/build", icon: Hammer, enabled: true },
     ],
   },
   {

--- a/apps/aomi-build/src/features/build/build-view.tsx
+++ b/apps/aomi-build/src/features/build/build-view.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Files, History, LayoutTemplate } from "lucide-react";
+
+import { BuildStreamTimeline } from "@build/features/build/components/build-stream-timeline";
+import {
+  ChatMessage,
+  TypingIndicator,
+} from "@build/features/build/components/chat-message";
+import { FileTreePreview } from "@build/features/build/components/file-tree-preview";
+import { IntentComposer } from "@build/features/build/components/intent-composer";
+import { SessionHistory } from "@build/features/build/components/session-history";
+import { ShipHandoffBanner } from "@build/features/build/components/ship-handoff-banner";
+import { TemplateGallery } from "@build/features/build/components/template-gallery";
+import { JOURNEY_STAGES } from "@build/features/build/contracts";
+import { useBuildSession } from "@build/features/build/hooks/use-build-session";
+import { useStreamingText } from "@build/features/build/hooks/use-streaming-text";
+import { BUILD_TEMPLATES } from "@build/features/build/templates";
+import { cn } from "@build/lib/utils";
+
+const actionPills = [
+  { label: "Plan New Idea", hint: "⇧Tab", action: "plan" },
+  { label: "Multitask", action: "multitask" },
+];
+
+function StreamingMessage({
+  content,
+  onDone,
+  model,
+}: {
+  content: string;
+  onDone: () => void;
+  model?: string;
+}) {
+  const { displayed, isStreaming, skipToEnd } = useStreamingText(content, true);
+
+  useEffect(() => {
+    if (!isStreaming && displayed) onDone();
+  }, [isStreaming, displayed, onDone]);
+
+  return (
+    <ChatMessage
+      role="assistant"
+      content={displayed}
+      isStreaming={isStreaming}
+      onStop={skipToEnd}
+      model={model}
+    />
+  );
+}
+
+function ContextPanelSection({
+  title,
+  icon: Icon,
+  children,
+}: {
+  title: string;
+  icon: typeof History;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-2">
+      <div className="text-subtle flex items-center gap-1.5 px-1 text-[12px] font-medium">
+        <Icon className="text-dim size-3.5" />
+        {title}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+/**
+ * AI Builder Create surface. Nested in ControlPlaneShell — no BuildLayout.
+ */
+export function BuildView() {
+  const [input, setInput] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const {
+    activeSessionId,
+    stageId,
+    messages,
+    streamEvents,
+    fileTree,
+    isGenerating,
+    streamingMessageId,
+    setStreamingMessageId,
+    shipReady,
+    showStreamInThread,
+    loadSession,
+    startNewSession,
+    runBuildPipeline,
+    handleStreamComplete,
+    recentSessions,
+  } = useBuildSession();
+
+  const scrollToBottom = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    requestAnimationFrame(() => {
+      el.scrollTop = el.scrollHeight;
+    });
+  }, []);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [
+    messages,
+    streamingMessageId,
+    showStreamInThread,
+    shipReady,
+    scrollToBottom,
+  ]);
+
+  const handleSend = useCallback(() => {
+    const text = input.trim();
+    if (!text || isGenerating) return;
+    setInput("");
+    runBuildPipeline(text, (assistantMsg) => {
+      setStreamingMessageId(assistantMsg.id);
+    });
+  }, [input, isGenerating, runBuildPipeline, setStreamingMessageId]);
+
+  const handleStreamDone = useCallback(() => {
+    handleStreamComplete();
+  }, [handleStreamComplete]);
+
+  const handleActionPill = useCallback((action: string) => {
+    if (action === "plan") {
+      setInput("Help me plan a new agent idea: ");
+    } else if (action === "multitask") {
+      setInput("Run these build tasks in parallel: ");
+    }
+  }, []);
+
+  const handleTemplateSelect = useCallback(
+    (template: (typeof BUILD_TEMPLATES)[0]) => {
+      setInput(template.prompt);
+    },
+    [],
+  );
+
+  const handleSelectSession = useCallback(
+    (id: string) => {
+      loadSession(id);
+    },
+    [loadSession],
+  );
+
+  const handleNewSession = useCallback(() => {
+    startNewSession();
+    setInput("");
+  }, [startNewSession]);
+
+  const isEmpty = messages.length === 0;
+  const stageIndex = JOURNEY_STAGES.findIndex((s) => s.id === stageId);
+
+  return (
+    <div className="flex h-[calc(100dvh-2.75rem)] min-h-0 w-full">
+      {/* Optional thin session column — in-page, not BuildLayout rail */}
+      <aside className="border-border hidden w-[220px] shrink-0 flex-col gap-3 overflow-y-auto border-r p-3 xl:flex">
+        <SessionHistory
+          sessions={recentSessions}
+          activeSessionId={activeSessionId}
+          onSelect={handleSelectSession}
+          onNewSession={handleNewSession}
+        />
+      </aside>
+
+      <section className="bg-background flex min-w-0 flex-1 flex-col">
+        {!isEmpty ? (
+          <div className="border-border hidden h-10 items-center justify-between border-b px-4 sm:flex">
+            <ol className="flex flex-wrap items-center gap-1.5">
+              {JOURNEY_STAGES.map((stage, index) => {
+                const active = index === stageIndex;
+                const done = index < stageIndex;
+                return (
+                  <li
+                    key={stage.id}
+                    className={cn(
+                      "rounded-full border px-2 py-0.5 text-[10px]",
+                      active
+                        ? "border-foreground/30 text-foreground bg-surface-1"
+                        : done
+                          ? "border-border text-dim"
+                          : "border-border/60 text-dim/70",
+                    )}
+                  >
+                    {stage.title}
+                  </li>
+                );
+              })}
+            </ol>
+            <span className="text-dim text-[11px]">Local mock · timers</span>
+          </div>
+        ) : null}
+
+        <div className="flex min-h-0 flex-1">
+          <div className="flex min-w-0 flex-1 flex-col">
+            <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
+              {isEmpty ? (
+                <div className="flex h-full items-center justify-center px-4 py-10">
+                  <div className="w-full max-w-[640px]">
+                    <div className="mb-6 space-y-1 text-center sm:text-left">
+                      <h1 className="text-foreground text-base font-medium">
+                        Build
+                      </h1>
+                      <p className="text-dim text-sm leading-6">
+                        Describe what you want — local mock plans and generates
+                        — then ship to Projects. Real Smithers SSE comes later.
+                      </p>
+                    </div>
+                    <IntentComposer
+                      value={input}
+                      onChange={setInput}
+                      onSubmit={handleSend}
+                      disabled={isGenerating}
+                      isLoading={isGenerating}
+                      actionPills={actionPills}
+                      onActionPillClick={handleActionPill}
+                      placeholder="What do you want to build?"
+                    />
+                    <TemplateGallery
+                      templates={BUILD_TEMPLATES}
+                      onSelect={handleTemplateSelect}
+                    />
+                  </div>
+                </div>
+              ) : (
+                <div className="px-4">
+                  {messages.map((msg) => {
+                    if (streamingMessageId === msg.id) {
+                      return (
+                        <StreamingMessage
+                          key={msg.id}
+                          content={msg.content}
+                          model={msg.model}
+                          onDone={handleStreamDone}
+                        />
+                      );
+                    }
+                    return (
+                      <ChatMessage
+                        key={msg.id}
+                        role={msg.role}
+                        content={msg.content}
+                        timestamp={msg.timestamp}
+                        model={msg.model}
+                      />
+                    );
+                  })}
+
+                  {showStreamInThread ? (
+                    <div className="mx-auto my-4 max-w-3xl">
+                      <BuildStreamTimeline events={streamEvents} />
+                    </div>
+                  ) : null}
+
+                  {shipReady ? <ShipHandoffBanner /> : null}
+
+                  {isGenerating && !streamingMessageId ? (
+                    <TypingIndicator />
+                  ) : null}
+                </div>
+              )}
+            </div>
+
+            {!isEmpty ? (
+              <div className="border-border border-t p-4">
+                <div className="mx-auto max-w-3xl">
+                  <IntentComposer
+                    value={input}
+                    onChange={setInput}
+                    onSubmit={handleSend}
+                    disabled={isGenerating}
+                    isLoading={isGenerating}
+                    compact
+                    showContextStrip={false}
+                    footerHint=""
+                    actionPills={actionPills}
+                    onActionPillClick={handleActionPill}
+                  />
+                </div>
+              </div>
+            ) : null}
+          </div>
+
+          {!isEmpty ? (
+            <aside className="border-border bg-surface-1/40 hidden w-[300px] shrink-0 flex-col gap-4 overflow-y-auto border-l p-3 lg:flex">
+              <ContextPanelSection title="Build stream" icon={History}>
+                <BuildStreamTimeline events={streamEvents} compact />
+              </ContextPanelSection>
+
+              <ContextPanelSection title="Files" icon={Files}>
+                <FileTreePreview tree={fileTree} />
+              </ContextPanelSection>
+
+              <ContextPanelSection title="Templates" icon={LayoutTemplate}>
+                <div className="space-y-1">
+                  {BUILD_TEMPLATES.slice(0, 4).map((template) => (
+                    <button
+                      key={template.id}
+                      type="button"
+                      onClick={() => handleTemplateSelect(template)}
+                      className="panel-row w-full text-left"
+                    >
+                      <p className="text-foreground text-[13px]">
+                        {template.name}
+                      </p>
+                      <p className="text-subtle mt-0.5 text-[12px]">
+                        {template.description}
+                      </p>
+                    </button>
+                  ))}
+                </div>
+              </ContextPanelSection>
+            </aside>
+          ) : null}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/aomi-build/src/features/build/components/build-stream-timeline.tsx
+++ b/apps/aomi-build/src/features/build/components/build-stream-timeline.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Check, Circle, Loader2 } from "lucide-react";
+
+import {
+  STREAM_STAGE_LABELS,
+  type BuildStreamEvent,
+} from "@build/features/build/contracts";
+import { cn } from "@build/lib/utils";
+
+type BuildStreamTimelineProps = {
+  events: BuildStreamEvent[];
+  compact?: boolean;
+};
+
+export function BuildStreamTimeline({
+  events,
+  compact,
+}: BuildStreamTimelineProps) {
+  return (
+    <div
+      className={cn(
+        "border-border bg-surface-1 rounded-lg border",
+        compact ? "p-3" : "p-4",
+      )}
+    >
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <p className="text-subtle text-[12px] font-medium">Build progress</p>
+        <span className="text-dim text-[10px]">Local mock</span>
+      </div>
+      <ol className="space-y-3">
+        {events.map((event) => (
+          <li key={event.stage} className="flex gap-3">
+            <div className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center">
+              {event.status === "done" ? (
+                <Check className="text-positive size-3.5" />
+              ) : event.status === "active" ? (
+                <Loader2 className="text-warning size-3.5 animate-spin" />
+              ) : (
+                <Circle className="text-dim size-3" />
+              )}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="text-foreground text-[12px] font-medium">
+                  {STREAM_STAGE_LABELS[event.stage]}
+                </span>
+                {event.status === "active" ? (
+                  <span className="text-warning text-[10px]">Running</span>
+                ) : null}
+                {event.time ? (
+                  <span className="text-dim text-[10px]">{event.time}</span>
+                ) : null}
+              </div>
+              <p className="text-subtle mt-0.5 text-[12px]">{event.message}</p>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/apps/aomi-build/src/features/build/components/chat-message.tsx
+++ b/apps/aomi-build/src/features/build/components/chat-message.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { Bot, Square } from "lucide-react";
+
+import { MarkdownContent } from "@build/features/build/components/markdown-content";
+
+export type ChatMessageProps = {
+  role: "user" | "assistant" | "system";
+  content: string;
+  isStreaming?: boolean;
+  onStop?: () => void;
+  timestamp?: string;
+  model?: string;
+};
+
+export function ChatMessage({
+  role,
+  content,
+  isStreaming,
+  onStop,
+  timestamp,
+  model,
+}: ChatMessageProps) {
+  const isUser = role === "user";
+
+  if (isUser) {
+    return (
+      <div className="group w-full py-4">
+        <div className="mx-auto max-w-3xl">
+          <div className="text-dim mb-1.5 flex items-center gap-2 text-[11px]">
+            <span>You</span>
+            {timestamp ? <span>{timestamp}</span> : null}
+          </div>
+          <div className="text-foreground text-[13px] leading-relaxed">
+            {content}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-border/60 group w-full border-b py-5">
+      <div className="mx-auto max-w-3xl">
+        <div className="text-muted-foreground mb-2 flex items-center gap-1.5 text-[11px]">
+          <Bot className="size-3" />
+          <span className="text-subtle font-medium">
+            {role === "system" ? "Aomi" : "Agent"}
+          </span>
+          {model ? <span>{model}</span> : null}
+          {timestamp ? <span>{timestamp}</span> : null}
+        </div>
+
+        <MarkdownContent content={content} />
+        {isStreaming ? (
+          <span className="bg-foreground/60 mt-1 inline-block h-4 w-[2px] animate-pulse" />
+        ) : null}
+
+        {isStreaming && onStop ? (
+          <button
+            type="button"
+            onClick={onStop}
+            className="border-border bg-surface-1 text-muted-foreground hover:text-foreground mt-3 flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-[11px] transition-colors"
+          >
+            <Square className="size-2.5 fill-current" />
+            Skip
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function TypingIndicator() {
+  return (
+    <div className="border-border/60 w-full border-b py-5">
+      <div className="mx-auto max-w-3xl">
+        <div className="text-muted-foreground mb-2 flex items-center gap-1.5 text-[11px]">
+          <Bot className="size-3" />
+          <span>Agent</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <span className="bg-muted-foreground h-1.5 w-1.5 animate-bounce rounded-full [animation-delay:0ms]" />
+          <span className="bg-muted-foreground h-1.5 w-1.5 animate-bounce rounded-full [animation-delay:150ms]" />
+          <span className="bg-muted-foreground h-1.5 w-1.5 animate-bounce rounded-full [animation-delay:300ms]" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/aomi-build/src/features/build/components/file-tree-preview.tsx
+++ b/apps/aomi-build/src/features/build/components/file-tree-preview.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { ChevronRight, File, Folder } from "lucide-react";
+
+import type { BuildFileNode } from "@build/features/build/contracts";
+import { cn } from "@build/lib/utils";
+
+function FileTreeNode({
+  node,
+  depth = 0,
+}: {
+  node: BuildFileNode;
+  depth?: number;
+}) {
+  const isFolder = node.type === "folder";
+  const name = node.path.split("/").pop() ?? node.path;
+
+  return (
+    <div>
+      <div
+        className={cn(
+          "flex items-center gap-1.5 rounded px-1.5 py-1 text-[12px]",
+          depth > 0 && "ml-3",
+        )}
+        style={{ paddingLeft: depth * 12 + 6 }}
+      >
+        {isFolder ? (
+          <Folder className="text-warning size-3.5 shrink-0" />
+        ) : (
+          <File className="text-link size-3.5 shrink-0" />
+        )}
+        <span className={cn(isFolder ? "text-foreground" : "text-subtle")}>
+          {name}
+        </span>
+        {isFolder ? (
+          <ChevronRight className="text-dim ml-auto size-3" />
+        ) : null}
+      </div>
+      {node.children?.map((child) => (
+        <FileTreeNode key={child.path} node={child} depth={depth + 1} />
+      ))}
+    </div>
+  );
+}
+
+type FileTreePreviewProps = {
+  tree: BuildFileNode[];
+  className?: string;
+};
+
+export function FileTreePreview({ tree, className }: FileTreePreviewProps) {
+  if (!tree.length) {
+    return (
+      <div className={cn("panel-inset p-4 text-center", className)}>
+        <p className="text-dim text-[12px]">
+          Files appear as the local mock generates.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("panel-inset overflow-hidden p-2", className)}>
+      <p className="text-dim mb-2 px-1.5 text-[11px] font-medium tracking-wide uppercase">
+        Generated files
+      </p>
+      {tree.map((node) => (
+        <FileTreeNode key={node.path} node={node} />
+      ))}
+    </div>
+  );
+}

--- a/apps/aomi-build/src/features/build/components/intent-composer.tsx
+++ b/apps/aomi-build/src/features/build/components/intent-composer.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { ArrowUp, Laptop, Loader2 } from "lucide-react";
+import { useCallback, useEffect, useRef } from "react";
+
+import { cn } from "@build/lib/utils";
+
+type ActionPill = {
+  label: string;
+  hint?: string;
+  action?: string;
+};
+
+type IntentComposerProps = {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  disabled?: boolean;
+  isLoading?: boolean;
+  placeholder?: string;
+  actionPills?: ActionPill[];
+  onActionPillClick?: (action: string) => void;
+  /** Visual-only model chip — no picker (DropdownMenu not in live app). */
+  modelLabel?: string;
+  compact?: boolean;
+  showContextStrip?: boolean;
+  footerHint?: string;
+};
+
+export function IntentComposer({
+  value,
+  onChange,
+  onSubmit,
+  disabled,
+  isLoading,
+  placeholder = "What do you want to build?",
+  actionPills,
+  onActionPillClick,
+  modelLabel = "Local mock",
+  compact = false,
+  showContextStrip = true,
+  footerHint = "Local mock for now — Smithers streaming is not wired yet.",
+}: IntentComposerProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const adjustHeight = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, compact ? 140 : 180)}px`;
+  }, [compact]);
+
+  useEffect(() => {
+    adjustHeight();
+  }, [value, adjustHeight]);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Tab" && e.shiftKey) {
+        e.preventDefault();
+        onActionPillClick?.("plan");
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onActionPillClick]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        if (!disabled && !isLoading && value.trim()) onSubmit();
+      }
+    },
+    [disabled, isLoading, value, onSubmit],
+  );
+
+  const canSend = Boolean(value.trim()) && !disabled && !isLoading;
+
+  return (
+    <div className="w-full">
+      {showContextStrip ? (
+        <div className="mb-2.5 flex items-center gap-1">
+          <span className="context-chip cursor-default" title="Local mock workspace">
+            aomi
+          </span>
+          <span
+            className="context-chip cursor-default"
+            title="Timers only until SSE"
+          >
+            <Laptop className="size-3.5 opacity-70" />
+            Local mock
+          </span>
+        </div>
+      ) : null}
+
+      <div
+        className={cn(
+          "composer-surface",
+          compact ? "px-3.5 py-3" : "px-4 py-3.5",
+        )}
+      >
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={disabled || isLoading}
+          placeholder={placeholder}
+          rows={compact ? 2 : 3}
+          className={cn(
+            "text-foreground placeholder:text-dim w-full resize-none bg-transparent text-[14px] leading-relaxed outline-none disabled:opacity-50",
+            compact ? "min-h-[48px]" : "min-h-[80px]",
+          )}
+        />
+
+        <div className="mt-3 flex items-center justify-between">
+          <span
+            className="context-chip cursor-default rounded-full border border-transparent px-2.5 py-1"
+            title="Model selection arrives with Smithers SSE"
+          >
+            {modelLabel}
+          </span>
+
+          <button
+            type="button"
+            onClick={onSubmit}
+            disabled={!canSend}
+            className={cn(
+              "flex h-9 w-9 items-center justify-center rounded-full transition-all duration-150",
+              canSend
+                ? "bg-primary text-primary-foreground hover:bg-brand-hover shadow-sm hover:scale-[1.03]"
+                : "bg-surface-3 text-dim",
+            )}
+            aria-label="Send message"
+          >
+            {isLoading ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <ArrowUp className="size-4" />
+            )}
+          </button>
+        </div>
+      </div>
+
+      {actionPills && actionPills.length > 0 ? (
+        <div className="mt-3 flex flex-wrap items-center justify-center gap-2">
+          {actionPills.map((pill) => (
+            <button
+              key={pill.label}
+              type="button"
+              onClick={() => onActionPillClick?.(pill.action ?? pill.label)}
+              className="action-pill"
+            >
+              {pill.label}
+              {pill.hint ? (
+                <span className="text-dim text-[11px]">{pill.hint}</span>
+              ) : null}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      {footerHint ? (
+        <p className="text-dim mt-4 text-center text-[12px] leading-relaxed">
+          {footerHint}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/aomi-build/src/features/build/components/markdown-content.tsx
+++ b/apps/aomi-build/src/features/build/components/markdown-content.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { cn } from "@build/lib/utils";
+
+function renderInline(text: string): ReactNode[] {
+  const parts: ReactNode[] = [];
+  const regex = /(`[^`]+`|\*\*[^*]+\*\*)/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index));
+    }
+    const token = match[0];
+    if (token.startsWith("`")) {
+      parts.push(<code key={match.index}>{token.slice(1, -1)}</code>);
+    } else if (token.startsWith("**")) {
+      parts.push(<strong key={match.index}>{token.slice(2, -2)}</strong>);
+    }
+    lastIndex = match.index + token.length;
+  }
+
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+
+  return parts;
+}
+
+export function MarkdownContent({
+  content,
+  className,
+}: {
+  content: string;
+  className?: string;
+}) {
+  const blocks = content.split(/(```[\s\S]*?```)/g).filter(Boolean);
+
+  return (
+    <div className={cn("md-thread text-[13px] leading-relaxed", className)}>
+      {blocks.map((block, i) => {
+        if (block.startsWith("```")) {
+          const inner = block.replace(/^```\w*\n?/, "").replace(/```$/, "");
+          return (
+            <pre key={i}>
+              <code>{inner.trimEnd()}</code>
+            </pre>
+          );
+        }
+
+        const lines = block.split("\n");
+        const elements: ReactNode[] = [];
+        let listItems: string[] = [];
+        let listType: "ul" | "ol" | null = null;
+
+        const flushList = () => {
+          if (!listItems.length || !listType) return;
+          const ListTag = listType;
+          elements.push(
+            <ListTag key={`list-${elements.length}`}>
+              {listItems.map((item, idx) => (
+                <li key={idx}>{renderInline(item)}</li>
+              ))}
+            </ListTag>,
+          );
+          listItems = [];
+          listType = null;
+        };
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) {
+            flushList();
+            continue;
+          }
+
+          const olMatch = trimmed.match(/^\d+\.\s+(.+)$/);
+          const ulMatch = trimmed.match(/^[-*]\s+(.+)$/);
+
+          if (olMatch) {
+            if (listType && listType !== "ol") flushList();
+            listType = "ol";
+            listItems.push(olMatch[1]);
+            continue;
+          }
+
+          if (ulMatch) {
+            if (listType && listType !== "ul") flushList();
+            listType = "ul";
+            listItems.push(ulMatch[1]);
+            continue;
+          }
+
+          flushList();
+          elements.push(
+            <p key={`p-${elements.length}`}>{renderInline(trimmed)}</p>,
+          );
+        }
+
+        flushList();
+        return <div key={i}>{elements}</div>;
+      })}
+    </div>
+  );
+}

--- a/apps/aomi-build/src/features/build/components/session-history.tsx
+++ b/apps/aomi-build/src/features/build/components/session-history.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { History } from "lucide-react";
+
+import type { BuildSession } from "@build/features/build/contracts";
+import { JOURNEY_STAGES } from "@build/features/build/contracts";
+import { cn } from "@build/lib/utils";
+
+type SessionHistoryProps = {
+  sessions: BuildSession[];
+  activeSessionId: string | null;
+  onSelect: (id: string) => void;
+  onNewSession: () => void;
+  className?: string;
+};
+
+function statusTone(status: BuildSession["status"]) {
+  if (status === "healthy") return "bg-positive/10 text-positive";
+  if (status === "failed") return "bg-destructive/10 text-destructive";
+  if (status === "running") return "bg-warning/10 text-warning";
+  return "bg-surface-2 text-dim";
+}
+
+function stageLabel(stageId: BuildSession["stageId"]) {
+  return JOURNEY_STAGES.find((s) => s.id === stageId)?.title ?? stageId;
+}
+
+/**
+ * Thin in-page session list — not an immersive BuildLayout rail.
+ */
+export function SessionHistory({
+  sessions,
+  activeSessionId,
+  onSelect,
+  onNewSession,
+  className,
+}: SessionHistoryProps) {
+  return (
+    <div className={cn("flex flex-col gap-2", className)}>
+      <div className="flex items-center justify-between gap-2 px-1">
+        <div className="text-subtle flex items-center gap-1.5 text-[12px] font-medium">
+          <History className="text-dim size-3.5" />
+          Sessions
+        </div>
+        <button
+          type="button"
+          onClick={onNewSession}
+          className="text-dim hover:text-foreground text-[11px] transition-colors"
+        >
+          New
+        </button>
+      </div>
+      <div className="space-y-1">
+        {sessions.slice(0, 8).map((session) => (
+          <button
+            key={session.id}
+            type="button"
+            onClick={() => onSelect(session.id)}
+            className={cn(
+              "panel-row w-full text-left",
+              activeSessionId === session.id && "border-border-hover bg-accent-selected",
+            )}
+          >
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-foreground truncate text-[13px]">
+                {session.title}
+              </p>
+              <span
+                className={cn(
+                  "shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium capitalize",
+                  statusTone(session.status),
+                )}
+              >
+                {session.status}
+              </span>
+            </div>
+            <p className="text-dim mt-0.5 text-[11px]">
+              {stageLabel(session.stageId)} · {session.updatedAt}
+            </p>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/aomi-build/src/features/build/components/ship-handoff-banner.tsx
+++ b/apps/aomi-build/src/features/build/components/ship-handoff-banner.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+import { FolderKanban, Rocket } from "lucide-react";
+
+/**
+ * End-of-run handoff → manage path (Projects), never /deploy/[id].
+ */
+export function ShipHandoffBanner() {
+  return (
+    <div className="border-positive/30 bg-positive/5 mx-auto my-4 flex max-w-3xl flex-col gap-3 rounded-lg border px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <p className="text-foreground text-[13px] font-medium">
+          Local mock ready — ship toward Projects
+        </p>
+        <p className="text-subtle text-[12px]">
+          Review the generated files, then manage deploy from Projects. Real
+          Smithers SSE is not wired yet.
+        </p>
+      </div>
+      <div className="flex shrink-0 flex-wrap items-center gap-2">
+        <Link
+          href="/projects"
+          className="bg-primary text-primary-foreground hover:bg-brand-hover inline-flex h-8 items-center gap-1.5 rounded-md px-3 text-[12px] font-medium transition-colors"
+        >
+          <FolderKanban className="size-3.5" />
+          Open Projects
+        </Link>
+        <span className="text-dim inline-flex h-8 items-center gap-1.5 rounded-md border border-dashed px-3 text-[11px]">
+          <Rocket className="size-3.5" />
+          GitHub init · Soon
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/aomi-build/src/features/build/components/template-gallery.tsx
+++ b/apps/aomi-build/src/features/build/components/template-gallery.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { LayoutTemplate } from "lucide-react";
+
+import type { BuildTemplate } from "@build/features/build/contracts";
+
+type TemplateGalleryProps = {
+  templates: BuildTemplate[];
+  onSelect: (template: BuildTemplate) => void;
+};
+
+export function TemplateGallery({ templates, onSelect }: TemplateGalleryProps) {
+  return (
+    <div className="mt-8 w-full">
+      <div className="text-subtle mb-3 flex items-center gap-2 text-[12px] font-medium">
+        <LayoutTemplate className="text-dim size-3.5" />
+        Start from a template
+      </div>
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        {templates.map((template) => (
+          <button
+            key={template.id}
+            type="button"
+            onClick={() => onSelect(template)}
+            className="panel-row hover:border-border-hover hover:bg-accent-hover/40 text-left transition-colors"
+          >
+            <p className="text-foreground text-[13px] font-medium">
+              {template.name}
+            </p>
+            <p className="text-subtle mt-0.5 line-clamp-2 text-[11px]">
+              {template.description}
+            </p>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/aomi-build/src/features/build/contracts.ts
+++ b/apps/aomi-build/src/features/build/contracts.ts
@@ -1,0 +1,240 @@
+export type JourneyStageId =
+  | "describe"
+  | "plan"
+  | "generate"
+  | "compile_test"
+  | "ship";
+
+export type JourneyStage = {
+  id: JourneyStageId;
+  title: string;
+  detail: string;
+};
+
+export const JOURNEY_STAGES: JourneyStage[] = [
+  {
+    id: "describe",
+    title: "Describe",
+    detail: "What do you want to build? Intent in, not code.",
+  },
+  {
+    id: "plan",
+    title: "Plan",
+    detail: "Smithers nodes compose the work (codegen, tooling, APIs).",
+  },
+  {
+    id: "generate",
+    title: "Generate",
+    detail: "Review the tool layer and source as it lands.",
+  },
+  {
+    id: "compile_test",
+    title: "Compile & test",
+    detail: "Compile, then exercise with aomi-run before you commit.",
+  },
+  {
+    id: "ship",
+    title: "Ship",
+    detail: "Download, init a GitHub repo, then deploy from Projects.",
+  },
+];
+
+/** Local mock pipeline stages shown in the stream timeline. */
+export type BuildStreamStage = "plan" | "generate" | "validate" | "ready";
+
+export type BuildMessage = {
+  id: string;
+  role: "user" | "assistant" | "system";
+  content: string;
+  timestamp: string;
+  model?: string;
+};
+
+export type BuildFileNode = {
+  path: string;
+  type: "file" | "folder";
+  children?: BuildFileNode[];
+};
+
+export type BuildStreamEvent = {
+  time: string;
+  stage: BuildStreamStage;
+  message: string;
+  status: "done" | "active" | "pending";
+};
+
+export type BuildSessionStatus = "queued" | "running" | "healthy" | "failed";
+
+export type BuildSession = {
+  id: string;
+  title: string;
+  status: BuildSessionStatus;
+  model: string;
+  updatedAt: string;
+  runtime: string;
+  stageId: JourneyStageId;
+  templateId?: string;
+  messages: BuildMessage[];
+  streamEvents: BuildStreamEvent[];
+  fileTree: BuildFileNode[];
+};
+
+export type BuildTemplate = {
+  id: string;
+  name: string;
+  description: string;
+  category: "trading" | "social" | "infra" | "research";
+  /** Seed text put into the intent composer when selected. */
+  prompt: string;
+};
+
+/** Map mock pipeline stages → product journey stages. */
+export const STREAM_TO_JOURNEY: Record<BuildStreamStage, JourneyStageId> = {
+  plan: "plan",
+  generate: "generate",
+  validate: "compile_test",
+  ready: "ship",
+};
+
+export const STREAM_STAGE_LABELS: Record<BuildStreamStage, string> = {
+  plan: "Plan",
+  generate: "Generate",
+  validate: "Compile & test",
+  ready: "Ship",
+};
+
+export const defaultStreamTemplate: BuildStreamEvent[] = [
+  {
+    time: "",
+    stage: "plan",
+    message: "Analyzing prompt and composing Smithers plan.",
+    status: "pending",
+  },
+  {
+    time: "",
+    stage: "generate",
+    message: "Generating project files and configuration.",
+    status: "pending",
+  },
+  {
+    time: "",
+    stage: "validate",
+    message: "Running compile and lint checks (local mock).",
+    status: "pending",
+  },
+  {
+    time: "",
+    stage: "ready",
+    message: "Artifacts ready — ship toward Projects / GitHub.",
+    status: "pending",
+  },
+];
+
+export const generatedFileTree: BuildFileNode[] = [
+  {
+    path: "aomi-agent",
+    type: "folder",
+    children: [
+      { path: "aomi-agent/src/index.ts", type: "file" },
+      { path: "aomi-agent/src/agent.ts", type: "file" },
+      { path: "aomi-agent/src/config.ts", type: "file" },
+      { path: "aomi-agent/src/handlers.ts", type: "file" },
+      { path: "aomi-agent/tests/agent.test.ts", type: "file" },
+      { path: "aomi-agent/aomi.toml", type: "file" },
+      { path: "aomi-agent/package.json", type: "file" },
+    ],
+  },
+];
+
+export const mockBuildResponse = `Done. Here's what the local mock generated:
+
+- \`src/agent.ts\` — Main agent loop with retry logic
+- \`src/config.ts\` — Configuration management
+- \`src/handlers.ts\` — Event handlers for on-chain actions
+- \`tests/agent.test.ts\` — Unit tests
+
+Checks passed in the local mock. Next: ship to Projects / GitHub — real Smithers SSE is not wired yet.`;
+
+export const seedBuildSessions: BuildSession[] = [
+  {
+    id: "run_1203_arb_bot",
+    title: "Hyperliquid and Binance arb bot",
+    status: "healthy",
+    model: "Local mock",
+    updatedAt: "2m ago",
+    runtime: "5m 12s",
+    stageId: "ship",
+    templateId: "tpl_trading_agent",
+    messages: [
+      {
+        id: "m1",
+        role: "user",
+        content:
+          "Build a cross-exchange arbitrage agent for Hyperliquid and Binance.",
+        timestamp: "11:58",
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: `Done. Here's what I built:
+
+- \`src/agent.ts\` — Main strategy loop with retry logic
+- \`src/exchanges/hyperliquid.ts\` — Hyperliquid client
+- \`src/exchanges/binance.ts\` — Binance client
+- \`src/risk/limits.ts\` — Position and exposure limits
+- \`tests/agent.test.ts\` — Unit tests
+
+All checks passed. Ready to ship toward Projects.`,
+        timestamp: "12:03",
+        model: "Local mock",
+      },
+    ],
+    streamEvents: [
+      {
+        time: "12:02:04",
+        stage: "plan",
+        message: "Analyzing prompt and selecting trading template.",
+        status: "done",
+      },
+      {
+        time: "12:02:21",
+        stage: "generate",
+        message: "Generating strategy, wallet service, and execution loop.",
+        status: "done",
+      },
+      {
+        time: "12:02:44",
+        stage: "validate",
+        message: "Running compile and lint checks against generated files.",
+        status: "done",
+      },
+      {
+        time: "12:03:02",
+        stage: "ready",
+        message: "Artifacts ready. Ship toward Projects / GitHub.",
+        status: "done",
+      },
+    ],
+    fileTree: [
+      {
+        path: "arb-bot",
+        type: "folder",
+        children: [
+          { path: "arb-bot/src/agent.ts", type: "file" },
+          { path: "arb-bot/src/config.ts", type: "file" },
+          {
+            path: "arb-bot/src/exchanges",
+            type: "folder",
+            children: [
+              { path: "arb-bot/src/exchanges/hyperliquid.ts", type: "file" },
+              { path: "arb-bot/src/exchanges/binance.ts", type: "file" },
+            ],
+          },
+          { path: "arb-bot/src/risk/limits.ts", type: "file" },
+          { path: "arb-bot/tests/agent.test.ts", type: "file" },
+          { path: "arb-bot/aomi.toml", type: "file" },
+        ],
+      },
+    ],
+  },
+];

--- a/apps/aomi-build/src/features/build/hooks/use-build-session.ts
+++ b/apps/aomi-build/src/features/build/hooks/use-build-session.ts
@@ -1,0 +1,243 @@
+"use client";
+
+import { useCallback, useRef, useState, useSyncExternalStore } from "react";
+
+import {
+  STREAM_TO_JOURNEY,
+  defaultStreamTemplate,
+  generatedFileTree,
+  mockBuildResponse,
+  type BuildFileNode,
+  type BuildMessage,
+  type BuildSession,
+  type BuildStreamEvent,
+  type JourneyStageId,
+} from "@build/features/build/contracts";
+import {
+  emptySessions,
+  findSessionById,
+  loadPersistedSessions,
+  mergeSessions,
+  savePersistedSession,
+  subscribeBuildSessions,
+} from "@build/features/build/storage/build-session-storage";
+
+function nowTime() {
+  const d = new Date();
+  return `${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}`;
+}
+
+function nowStamp() {
+  const d = new Date();
+  return `${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}:${d.getSeconds().toString().padStart(2, "0")}`;
+}
+
+const stageMessages: Record<BuildStreamEvent["stage"], string> = {
+  plan: "Analyzing prompt and composing Smithers plan (local mock).",
+  generate: "Generating project files and configuration (local mock).",
+  validate: "Running compile, lint, and type checks (local mock).",
+  ready: "Artifacts ready. Ship toward Projects / GitHub.",
+};
+
+/**
+ * Local Create-session driver with timer pipeline.
+ * Honest mock until Han SSE — copy labels this as local mock.
+ */
+export function useBuildSession() {
+  const persistedSessions = useSyncExternalStore(
+    subscribeBuildSessions,
+    loadPersistedSessions,
+    () => emptySessions,
+  );
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const [stageId, setStageId] = useState<JourneyStageId>("describe");
+  const [messages, setMessages] = useState<BuildMessage[]>([]);
+  const [streamEvents, setStreamEvents] = useState<BuildStreamEvent[]>([]);
+  const [fileTree, setFileTree] = useState<BuildFileNode[]>([]);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [streamingMessageId, setStreamingMessageId] = useState<string | null>(
+    null,
+  );
+  const [shipReady, setShipReady] = useState(false);
+  const [showStreamInThread, setShowStreamInThread] = useState(false);
+  const timersRef = useRef<number[]>([]);
+
+  const recentSessions = mergeSessions(persistedSessions);
+
+  const clearTimers = useCallback(() => {
+    timersRef.current.forEach((id) => window.clearTimeout(id));
+    timersRef.current = [];
+  }, []);
+
+  const loadSession = useCallback(
+    (sessionId: string) => {
+      clearTimers();
+      const session = findSessionById(sessionId, persistedSessions);
+      if (!session) return;
+      setActiveSessionId(sessionId);
+      setStageId(session.stageId);
+      setMessages(session.messages);
+      setStreamEvents(session.streamEvents);
+      setFileTree(session.fileTree);
+      setShipReady(session.status === "healthy");
+      setShowStreamInThread(false);
+      setIsGenerating(false);
+      setStreamingMessageId(null);
+    },
+    [clearTimers, persistedSessions],
+  );
+
+  const startNewSession = useCallback(() => {
+    clearTimers();
+    setActiveSessionId(null);
+    setStageId("describe");
+    setMessages([]);
+    setStreamEvents([]);
+    setFileTree([]);
+    setShipReady(false);
+    setShowStreamInThread(false);
+    setIsGenerating(false);
+    setStreamingMessageId(null);
+  }, [clearTimers]);
+
+  const runBuildPipeline = useCallback(
+    (userText: string, onAssistantReady: (msg: BuildMessage) => void) => {
+      clearTimers();
+      const sessionId = `run_${Date.now()}`;
+      const userMsg: BuildMessage = {
+        id: `u_${Date.now()}`,
+        role: "user",
+        content: userText,
+        timestamp: nowTime(),
+      };
+
+      setActiveSessionId(sessionId);
+      setStageId("describe");
+      setMessages([userMsg]);
+      setIsGenerating(true);
+      setShowStreamInThread(true);
+      setShipReady(false);
+
+      const initial = defaultStreamTemplate.map((e) => ({ ...e }));
+      setStreamEvents(initial);
+      setFileTree([]);
+
+      const stages: BuildStreamEvent["stage"][] = [
+        "plan",
+        "generate",
+        "validate",
+        "ready",
+      ];
+
+      let finalMessages: BuildMessage[] = [userMsg];
+      let finalStreamEvents = initial;
+      let finalFileTree: BuildFileNode[] = [];
+      let finalStageId: JourneyStageId = "describe";
+
+      stages.forEach((stage, index) => {
+        const timerId = window.setTimeout(() => {
+          finalStageId = STREAM_TO_JOURNEY[stage];
+          setStageId(finalStageId);
+
+          setStreamEvents((prev) => {
+            const next = prev.map((e) => {
+              if (e.stage === stage) {
+                return {
+                  ...e,
+                  status: "active" as const,
+                  time: nowStamp(),
+                  message: stageMessages[stage],
+                };
+              }
+              if (stages.indexOf(e.stage) < index && e.status !== "done") {
+                return {
+                  ...e,
+                  status: "done" as const,
+                  time: e.time || nowStamp(),
+                };
+              }
+              return e;
+            });
+            finalStreamEvents = next;
+            return next;
+          });
+
+          if (stage === "generate") {
+            setFileTree(generatedFileTree);
+            finalFileTree = generatedFileTree;
+          }
+
+          if (stage === "ready") {
+            setStreamEvents((prev) => {
+              finalStreamEvents = prev.map((e) => ({
+                ...e,
+                status: "done" as const,
+              }));
+              return finalStreamEvents;
+            });
+            setShipReady(true);
+            setStageId("ship");
+            finalStageId = "ship";
+
+            const assistantMsg: BuildMessage = {
+              id: `a_${Date.now()}`,
+              role: "assistant",
+              content: mockBuildResponse,
+              timestamp: nowTime(),
+              model: "Local mock",
+            };
+            finalMessages = [...finalMessages, assistantMsg];
+            setMessages(finalMessages);
+            onAssistantReady(assistantMsg);
+
+            const title =
+              userText.length > 48
+                ? `${userText.slice(0, 48).trim()}…`
+                : userText.trim();
+
+            const session: BuildSession = {
+              id: sessionId,
+              title: title || "New build",
+              status: "healthy",
+              model: "Local mock",
+              updatedAt: "just now",
+              runtime: "local mock",
+              stageId: finalStageId,
+              messages: finalMessages,
+              streamEvents: finalStreamEvents,
+              fileTree: finalFileTree.length ? finalFileTree : generatedFileTree,
+            };
+
+            savePersistedSession(session);
+          }
+        }, (index + 1) * 700);
+        timersRef.current.push(timerId);
+      });
+    },
+    [clearTimers],
+  );
+
+  const handleStreamComplete = useCallback(() => {
+    setIsGenerating(false);
+    setStreamingMessageId(null);
+    setShowStreamInThread(false);
+  }, []);
+
+  return {
+    activeSessionId,
+    stageId,
+    messages,
+    streamEvents,
+    fileTree,
+    isGenerating,
+    streamingMessageId,
+    setStreamingMessageId,
+    shipReady,
+    showStreamInThread,
+    loadSession,
+    startNewSession,
+    runBuildPipeline,
+    handleStreamComplete,
+    recentSessions,
+  };
+}

--- a/apps/aomi-build/src/features/build/hooks/use-streaming-text.ts
+++ b/apps/aomi-build/src/features/build/hooks/use-streaming-text.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export function useStreamingText(fullText: string, enabled: boolean) {
+  const [displayed, setDisplayed] = useState("");
+  const [isStreaming, setIsStreaming] = useState(false);
+  const indexRef = useRef(0);
+  const rafRef = useRef<number | null>(null);
+  const lastTimeRef = useRef(0);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const start = (time: number) => {
+      indexRef.current = 0;
+      lastTimeRef.current = time;
+      setDisplayed("");
+      setIsStreaming(true);
+
+      const stream = (t: number) => {
+        if (indexRef.current >= fullText.length) {
+          setIsStreaming(false);
+          return;
+        }
+
+        if (t - lastTimeRef.current > 12) {
+          const charsToAdd = Math.min(
+            3,
+            fullText.length - indexRef.current,
+          );
+          indexRef.current += charsToAdd;
+          setDisplayed(fullText.slice(0, indexRef.current));
+          lastTimeRef.current = t;
+        }
+
+        rafRef.current = requestAnimationFrame(stream);
+      };
+
+      rafRef.current = requestAnimationFrame(stream);
+    };
+
+    rafRef.current = requestAnimationFrame(start);
+
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, [fullText, enabled]);
+
+  const skipToEnd = useCallback(() => {
+    if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    setDisplayed(fullText);
+    setIsStreaming(false);
+    indexRef.current = fullText.length;
+  }, [fullText]);
+
+  return { displayed, isStreaming, skipToEnd };
+}

--- a/apps/aomi-build/src/features/build/storage/build-session-storage.ts
+++ b/apps/aomi-build/src/features/build/storage/build-session-storage.ts
@@ -1,0 +1,74 @@
+import {
+  seedBuildSessions,
+  type BuildSession,
+} from "@build/features/build/contracts";
+
+const STORAGE_KEY = "aomi-build-sessions-v1";
+const sessionListeners = new Set<() => void>();
+
+function emitBuildSessionsChange() {
+  sessionListeners.forEach((listener) => listener());
+}
+
+export function subscribeBuildSessions(onStoreChange: () => void) {
+  sessionListeners.add(onStoreChange);
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === STORAGE_KEY) onStoreChange();
+  };
+  if (typeof window !== "undefined") {
+    window.addEventListener("storage", onStorage);
+  }
+  return () => {
+    sessionListeners.delete(onStoreChange);
+    if (typeof window !== "undefined") {
+      window.removeEventListener("storage", onStorage);
+    }
+  };
+}
+
+export const emptySessions: BuildSession[] = [];
+
+// getSnapshot must return a stable reference between store changes,
+// so cache the parsed sessions keyed on the raw localStorage string.
+let sessionsCache: { raw: string | null; value: BuildSession[] } | null = null;
+
+export function loadPersistedSessions(): BuildSession[] {
+  if (typeof window === "undefined") return emptySessions;
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (sessionsCache && sessionsCache.raw === raw) return sessionsCache.value;
+
+  let value = emptySessions;
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as BuildSession[];
+      value = Array.isArray(parsed) ? parsed : emptySessions;
+    } catch {
+      value = emptySessions;
+    }
+  }
+  sessionsCache = { raw, value };
+  return value;
+}
+
+export function savePersistedSession(session: BuildSession) {
+  const existing = loadPersistedSessions().filter((s) => s.id !== session.id);
+  const next = [session, ...existing].slice(0, 20);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  emitBuildSessionsChange();
+}
+
+export function mergeSessions(persisted: BuildSession[]): BuildSession[] {
+  const persistedIds = new Set(persisted.map((s) => s.id));
+  const seeded = seedBuildSessions.filter((s) => !persistedIds.has(s.id));
+  return [...persisted, ...seeded];
+}
+
+export function findSessionById(
+  id: string,
+  persisted: BuildSession[],
+): BuildSession | undefined {
+  return (
+    persisted.find((s) => s.id === id) ??
+    seedBuildSessions.find((s) => s.id === id)
+  );
+}

--- a/apps/aomi-build/src/features/build/templates.ts
+++ b/apps/aomi-build/src/features/build/templates.ts
@@ -1,0 +1,65 @@
+import type { BuildTemplate } from "@build/features/build/contracts";
+
+export const BUILD_TEMPLATES: BuildTemplate[] = [
+  {
+    id: "tpl_arbitrage_bot",
+    name: "Arbitrage Bot",
+    description: "Multi-venue arbitrage with execution and risk guardrails.",
+    category: "trading",
+    prompt:
+      "I wanna build a hyperliquid & binance arb bot with risk limits and paper-trade first.",
+  },
+  {
+    id: "tpl_trading_agent",
+    name: "Trading Agent",
+    description: "Cross-exchange strategy runner with risk controls and wallet ops.",
+    category: "trading",
+    prompt:
+      "Build a trading agent that can quote, simulate, and stage swaps across venues.",
+  },
+  {
+    id: "tpl_telegram_bot",
+    name: "Telegram Bot",
+    description: "Auto-responding command bot with deployment and alert hooks.",
+    category: "social",
+    prompt:
+      "Build a Telegram bot that answers portfolio questions and alerts on fills.",
+  },
+  {
+    id: "tpl_openapi_agent",
+    name: "OpenAPI Agent",
+    description: "Wrap REST APIs as agent-callable tools from OpenAPI specs.",
+    category: "infra",
+    prompt:
+      "Scaffold an Aomi app from OpenAPI specs for Hyperliquid and Binance.",
+  },
+  {
+    id: "tpl_mcp_server",
+    name: "MCP Server",
+    description: "Tool interface with secure command rules and middleware.",
+    category: "infra",
+    prompt: "Create an MCP server that exposes read-only market and account tools.",
+  },
+  {
+    id: "tpl_wallet_agent",
+    name: "Wallet Agent",
+    description: "Non-custodial wallet ops with simulation and batch signing.",
+    category: "trading",
+    prompt:
+      "Build a wallet agent for simulation-first signing and batch operations.",
+  },
+  {
+    id: "tpl_rag_agent",
+    name: "RAG Agent",
+    description: "Retrieval pipeline for docs, embeddings, and grounded chat.",
+    category: "research",
+    prompt: "Build a RAG agent over our protocol docs with citations.",
+  },
+  {
+    id: "tpl_discord_bot",
+    name: "Discord Bot",
+    description: "Moderation and command bot with webhook integrations.",
+    category: "social",
+    prompt: "Build a Discord bot for alerts and slash commands into our agent.",
+  },
+];

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,11 @@
 
 ## Last Updated
 
+2026-07-14 — AI Builder P1 craft port: mock layout feel in ControlPlaneShell
+  (composer, stream, files, ship→Projects, in-page history; local mock timers);
+2026-07-14 — AI Builder P1: intent composer + templates + local session;
+2026-07-14 — AI-BUILDER-EXPERIENCE.md (Create / chat-mock port plan);
+2026-07-14 — Build AI Builder: enable sidebar Build + `/build` scaffold;
 2026-07-13 — Build P2 usage peek (Home meter → Operate Usage);
 2026-07-13 — Build P2 Deployments timeline (history that reads as history);
 2026-07-13 — Build Live status consistency (one story across list/Home/Deployments);
@@ -11,6 +16,39 @@
 2026-07-13 — Build UI copy polish (em dashes / hedging essays);
 2026-07-13 — Billing option A: methods live on Chat (no fake Build fetch);
 2026-07-13 — BILLING-EXPERIENCE.md: backend ↔ UI map (code-checked)
+
+## AI Builder P1 craft port (2026-07-14)
+
+Branch `feat/build-enable-route`:
+
+- Ported mock portal craft into `features/build/` inside ControlPlaneShell
+  (no BuildLayout, no Customize marketplace, no `/deploy/[id]`).
+- Empty: centered composer + templates; active: thread + stream, lg context
+  (files/stream), sticky compact composer, xl session list.
+- LocalStorage mock pipeline plan→generate→validate→ready mapped to journey
+  stages; ship banner → `/projects`; honest “Local mock” copy.
+
+## AI Builder P1 intent empty state (2026-07-14)
+
+Branch `feat/build-enable-route`:
+
+- Working intent composer + 8 templates (seed prompts).
+- Submit creates a local Create session + journey chrome.
+- Superseded visually by craft port (stream/files landed).
+
+## AI Builder experience plan (2026-07-14)
+
+- Added `apps/aomi-build/AI-BUILDER-EXPERIENCE.md`: Cecilia decode, platform
+  map, mock-vs-target, import policy, P0–P5 implementation phases.
+- Direction: adapt mock craft into live `features/build/` (not wholesale port).
+
+## Build AI Builder route (2026-07-14)
+
+Branch `feat/build-enable-route`:
+
+- Sidebar Build `enabled: true` (no Soon).
+- Real `/build` page scaffold: journey map + disabled “Start” (no Smithers
+  network yet). Manage path still Projects / Operate.
 
 ## Build P2 usage peek (2026-07-13)
 


### PR DESCRIPTION
## Summary
- Enable sidebar **Build** (no Soon) and ship real `/build` nested in `ControlPlaneShell`
- Port mock Create craft: composer, templates, thread, stream timeline, file tree, session history
- Local mock pipeline only (honest labeling); ship banner → **Projects** (not `/deploy/[id]`)
- Docs: `AI-BUILDER-EXPERIENCE.md` with phase board + PR track (P3 next)

## Test plan
- [ ] `pnpm run dev:aomi-build` → open `/build` (or click Build)
- [ ] Empty state: composer + templates; enter arb-bot prompt
- [ ] Active: stream advances, files appear, Open Projects handoff
- [ ] Global nav still works (Overview / Projects / Operate)
- [ ] **Do not merge until Gordian has clicked through locally / preview**

## PR track
- **This PR = PR-A** (P0–P2 + partial P4)
- Next: **PR-B** P3 Smithers nodes + compile/aomi-run
- Then PR-C (ship polish), PR-D (Han SSE seams)