### PR TITLE
feat(aomi-build): AI Builder P3 Smithers nodes + compile/aomi-run

### DIFF
--- a/apps/aomi-build/AI-BUILDER-EXPERIENCE.md
+++ b/apps/aomi-build/AI-BUILDER-EXPERIENCE.md
@@ -1,12 +1,12 @@
 # Aomi Build — AI Builder (Create / “Chat Mock”) Plan
 
-> **Status:** P0–P2 + partial P4 landed (craft port). **Next = P3** (nodes + compile/test) — biggest gap vs Cecilia sketches.  
+> **Status:** P0–P3 on branch + **UX polish pass** (stop/⌘N/autofocus/collapsible files/prompt-aware tree). Review local before merge.  
 > **App:** `aomi/apps/aomi-build` → [build.aomi.dev](https://build.aomi.dev)  
 > **Reference mock:** `aomi-build` repo → `apps/portal` `/build`  
 > **Owner:** Gordian (`0xgordian`) — experience + mock UI  
 > **Backend / Smithers stream:** Han (`POST /api/build` + SSE — **not in product-mono yet**)  
-> **Branch:** `feat/build-enable-route`  
-> **Last updated:** 2026-07-14 (post-craft review)
+> **Branch:** `feat/build-p3-smithers-nodes` (stacks on #343 / #344)  
+> **Last updated:** 2026-07-14 (UX/DX polish)
 
 Local source of truth for bringing the **AI Builder** onto the live control plane.  
 Pair with a Scrum Board issue so Cecilia/Han can see status. This file alone is not team sync.
@@ -15,6 +15,24 @@ Related:
 
 - [BUILDERS-EXPERIENCE.md](./BUILDERS-EXPERIENCE.md) — manage/deploy/operate polish (**mostly done**; do not reopen for chrome)
 - [BILLING-EXPERIENCE.md](./BILLING-EXPERIENCE.md) — pay on Chat, not fake Build billing
+
+---
+
+## UX / DX polish (Cursor-agent bar)
+
+Even as a local mock, every control must work. Landed on `feat/build-p3-smithers-nodes`:
+
+- [x] **Stop** mid-run (header + composer square + Esc) cancels timers, leaves a system note
+- [x] **⌘N / New** starts a clean session and focuses composer
+- [x] **Autofocus** empty + after template / session select
+- [x] Working pills: Arb bot / OpenAPI agent seed prompts; Plan from idea (⇧Tab)
+- [x] Composer gate while verify: clear copy; don’t silently eat Enter
+- [x] **Collapsible** file tree folders; prompt-aware arb file tree
+- [x] Download lists flattened paths; toast confirms
+- [x] De-dupe: templates dropped from right rail; nodes compact in context
+- [x] Stream stays visible while generating; skip-to-end on assistant stream
+
+**Still later (don’t block demo):** real SSE, real GitHub init, mobile session drawer, edit-last-user-message.
 
 ---
 

--- a/apps/aomi-build/AI-BUILDER-EXPERIENCE.md
+++ b/apps/aomi-build/AI-BUILDER-EXPERIENCE.md
@@ -273,10 +273,10 @@ You view **locally** (`pnpm run dev:aomi-build` → `/build`) and/or on the **Ve
 
 | PR | Phase(s) | Branch | Status |
 |----|----------|--------|--------|
-| **PR-A** | P0 + P1 + P2 + partial P4 (craft in shell) | `feat/build-enable-route` | Open next — click through locally first |
-| **PR-B** | P3 Smithers nodes + compile / aomi-run | `feat/build-p3-smithers-nodes` | After PR-A exists; implement next |
-| **PR-C** | P4 finish (download + GitHub-init copy) | `feat/build-p4-ship-polish` | After P3 / Cecilia gate |
-| **PR-D** | P5 Han SSE seams (no fake live) | `feat/build-p5-sse-seams` | After Han has API or accepted stubs |
+| **PR-A** | P0 + P1 + P2 + partial P4 (craft in shell) | `feat/build-enable-route` | **[#343](https://github.com/aomi-labs/aomi/pull/343)** — review local/preview; merge when you OK |
+| **PR-B** | P3 Smithers nodes + compile / aomi-run | `feat/build-p3-smithers-nodes` | Implement locally → PR after you OK |
+| **PR-C** | P4 leftovers / polish only if needed | `feat/build-p4-ship-polish` | Likely skip — folded into P3 |
+| **PR-D** | P5 Han SSE seams (no fake live) | `feat/build-p5-sse-seams` | After Han API or accepted stubs |
 
 ```mermaid
 flowchart LR
@@ -364,30 +364,28 @@ Nested in `ControlPlaneShell` (not BuildLayout). Ported mock craft:
 
 **Done when:** One click-through shows stream completing and a file tree appearing.
 
-### P3 — Smithers nodes + compile / test affordances ⬅️ NEXT
+### P3 — Smithers nodes + compile / test affordances ✅ (branch `feat/build-p3-smithers-nodes`)
 
-**Goal:** Closer to Cecilia wireframe than Cursor thread. **This closes the biggest product gap.**
+**Goal:** Closer to Cecilia wireframe than Cursor thread.
 
-- [ ] Add `components/smithers-nodes.tsx` — plan step shows **node cards** (e.g. `aomi-openapi-gen` hype / binance) — mock data OK
-- [ ] Show nodes during / after `plan` (not only progress list)
-- [ ] Explicit **Compile** and **Test with aomi-run** controls after generate (mock success / fail)
-- [ ] Copy: “smither writes smither” / agent nodes — honest that stream is local
-- [ ] Soften Cursor residue: remove or hide **Multitask**; keep one local-mock affordance
-- [ ] Optional with P3: mock **Download your code** on ship banner
+- [x] `components/smithers-nodes.tsx` — plan step shows **node cards**
+- [x] Nodes derive from prompt (hype/binance openapi-gen, aomi-run, compose)
+- [x] Explicit **Compile** and **Test with aomi-run** after generate (mock)
+- [x] Ship unlocked only after both verify steps
+- [x] Soften Cursor residue: drop Multitask pill
+- [x] Mock **Download code** on ship banner; GitHub init copy = needs API
 
-**Done when:** Cecilia can point at nodes + compile/test and say “that’s the product.”
+**Done when:** Local click-through: prompt → nodes → files → compile → aomi-run → download / Projects.
 
-**Stop gate:** Loom/GIF click-through → Cecilia/Han before more chrome.
+**Stop gate:** You review locally → open **PR-B** → merge only after OK. Cecilia Loom optional.
 
-### P4 — Ship handoff + light history ✅ (partial with craft port)
+### P4 — Ship handoff + light history ✅ (mostly; leftovers folded into P3)
 
-- [x] Banner: **Open Projects** (+ GitHub init Soon)
-- [x] In-page session history (not second global sidebar)
+- [x] Banner: **Open Projects**
+- [x] In-page session history
 - [x] Never deep-link to mock portal `/deploy/[id]`
-- [ ] Download (mock) button — fold into P3 pass
-- [ ] GitHub init copy: disabled with clear “needs Han API” (not ambiguous Soon forever)
-
-**Done when:** End of flow lands on manage path without confusion.
+- [x] Download (mock)
+- [x] GitHub init copy: “needs API”
 
 ### P5 — Han seams (no fake live)
 
@@ -462,7 +460,7 @@ If anything feels more like Cursor than Aomi Create → cut chrome, keep journey
 
 ## Next action
 
-1. Click through current craft: `/build` empty → run → stream/files → Open Projects.  
-2. Implement **P3** (nodes + compile/test + soft Cursor trim + optional download).  
-3. Stop gate for Cecilia — then PR (P0–P3) for preview/staging.  
-4. Only after that: P5 Han SSE seams.
+1. **PR-A** [#343](https://github.com/aomi-labs/aomi/pull/343) — view locally / Vercel preview; merge only when you OK (not auto).  
+2. On `feat/build-p3-smithers-nodes`: `pnpm run dev:aomi-build` → `/build` → arb prompt → nodes → compile → aomi-run → download.  
+3. When P3 feels right → push + **PR-B** (still no merge until you say).  
+4. **PR-D** later for Han SSE seams only.

--- a/apps/aomi-build/src/features/build/build-view.tsx
+++ b/apps/aomi-build/src/features/build/build-view.tsx
@@ -8,20 +8,22 @@ import {
   ChatMessage,
   TypingIndicator,
 } from "@build/features/build/components/chat-message";
+import { CompileTestPanel } from "@build/features/build/components/compile-test-panel";
 import { FileTreePreview } from "@build/features/build/components/file-tree-preview";
 import { IntentComposer } from "@build/features/build/components/intent-composer";
 import { SessionHistory } from "@build/features/build/components/session-history";
 import { ShipHandoffBanner } from "@build/features/build/components/ship-handoff-banner";
+import { SmithersNodes } from "@build/features/build/components/smithers-nodes";
 import { TemplateGallery } from "@build/features/build/components/template-gallery";
 import { JOURNEY_STAGES } from "@build/features/build/contracts";
 import { useBuildSession } from "@build/features/build/hooks/use-build-session";
 import { useStreamingText } from "@build/features/build/hooks/use-streaming-text";
 import { BUILD_TEMPLATES } from "@build/features/build/templates";
 import { cn } from "@build/lib/utils";
+import { useToast } from "@build/components/control-plane/toast";
 
 const actionPills = [
-  { label: "Plan New Idea", hint: "⇧Tab", action: "plan" },
-  { label: "Multitask", action: "multitask" },
+  { label: "Plan from idea", hint: "⇧Tab", action: "plan" },
 ];
 
 function StreamingMessage({
@@ -76,6 +78,7 @@ function ContextPanelSection({
 export function BuildView() {
   const [input, setInput] = useState("");
   const scrollRef = useRef<HTMLDivElement>(null);
+  const { toast } = useToast();
 
   const {
     activeSessionId,
@@ -83,15 +86,22 @@ export function BuildView() {
     messages,
     streamEvents,
     fileTree,
+    nodes,
     isGenerating,
     streamingMessageId,
     setStreamingMessageId,
+    awaitingVerify,
+    compileDone,
+    testDone,
+    verifyBusy,
     shipReady,
     showStreamInThread,
     loadSession,
     startNewSession,
     runBuildPipeline,
     handleStreamComplete,
+    runCompile,
+    runTest,
     recentSessions,
   } = useBuildSession();
 
@@ -129,10 +139,30 @@ export function BuildView() {
   const handleActionPill = useCallback((action: string) => {
     if (action === "plan") {
       setInput("Help me plan a new agent idea: ");
-    } else if (action === "multitask") {
-      setInput("Run these build tasks in parallel: ");
     }
   }, []);
+
+  const handleDownload = useCallback(() => {
+    const blob = new Blob(
+      [
+        "# Aomi Build — local mock export\n",
+        "# Real archive lands when Smithers / codegen is wired.\n",
+        fileTree.map((n) => n.path).join("\n"),
+        "\n",
+      ],
+      { type: "text/plain" },
+    );
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "aomi-build-mock-export.txt";
+    a.click();
+    URL.revokeObjectURL(url);
+    toast({
+      title: "Downloaded mock export",
+      description: "Placeholder file list — not a real repo archive.",
+    });
+  }, [fileTree, toast]);
 
   const handleTemplateSelect = useCallback(
     (template: (typeof BUILD_TEMPLATES)[0]) => {
@@ -257,7 +287,21 @@ export function BuildView() {
                     </div>
                   ) : null}
 
-                  {shipReady ? <ShipHandoffBanner /> : null}
+                  {nodes.length > 0 ? <SmithersNodes nodes={nodes} /> : null}
+
+                  {awaitingVerify ? (
+                    <CompileTestPanel
+                      compileDone={compileDone}
+                      testDone={testDone}
+                      busy={verifyBusy}
+                      onCompile={runCompile}
+                      onTest={runTest}
+                    />
+                  ) : null}
+
+                  {shipReady ? (
+                    <ShipHandoffBanner onDownload={handleDownload} />
+                  ) : null}
 
                   {isGenerating && !streamingMessageId ? (
                     <TypingIndicator />
@@ -291,6 +335,15 @@ export function BuildView() {
               <ContextPanelSection title="Build stream" icon={History}>
                 <BuildStreamTimeline events={streamEvents} compact />
               </ContextPanelSection>
+
+              {nodes.length > 0 ? (
+                <ContextPanelSection title="Smithers nodes" icon={History}>
+                  <SmithersNodes
+                    nodes={nodes}
+                    caption="Plan graph (local mock)"
+                  />
+                </ContextPanelSection>
+              ) : null}
 
               <ContextPanelSection title="Files" icon={Files}>
                 <FileTreePreview tree={fileTree} />

--- a/apps/aomi-build/src/features/build/build-view.tsx
+++ b/apps/aomi-build/src/features/build/build-view.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { Files, History, LayoutTemplate } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Files, ListChecks, Plus, Square } from "lucide-react";
 
+import { useToast } from "@build/components/control-plane/toast";
 import { BuildStreamTimeline } from "@build/features/build/components/build-stream-timeline";
 import {
   ChatMessage,
@@ -10,21 +11,37 @@ import {
 } from "@build/features/build/components/chat-message";
 import { CompileTestPanel } from "@build/features/build/components/compile-test-panel";
 import { FileTreePreview } from "@build/features/build/components/file-tree-preview";
-import { IntentComposer } from "@build/features/build/components/intent-composer";
+import {
+  IntentComposer,
+  type IntentComposerHandle,
+} from "@build/features/build/components/intent-composer";
 import { SessionHistory } from "@build/features/build/components/session-history";
 import { ShipHandoffBanner } from "@build/features/build/components/ship-handoff-banner";
 import { SmithersNodes } from "@build/features/build/components/smithers-nodes";
 import { TemplateGallery } from "@build/features/build/components/template-gallery";
-import { JOURNEY_STAGES } from "@build/features/build/contracts";
+import {
+  JOURNEY_STAGES,
+  resolveDisplayJourneyStage,
+  type BuildFileNode,
+} from "@build/features/build/contracts";
 import { useBuildSession } from "@build/features/build/hooks/use-build-session";
 import { useStreamingText } from "@build/features/build/hooks/use-streaming-text";
 import { BUILD_TEMPLATES } from "@build/features/build/templates";
 import { cn } from "@build/lib/utils";
-import { useToast } from "@build/components/control-plane/toast";
 
 const actionPills = [
+  { label: "Arb bot", action: "tpl_arbitrage_bot" },
+  { label: "OpenAPI agent", action: "tpl_openapi_agent" },
   { label: "Plan from idea", hint: "⇧Tab", action: "plan" },
 ];
+
+function flattenPaths(nodes: BuildFileNode[], out: string[] = []): string[] {
+  for (const node of nodes) {
+    out.push(node.path);
+    if (node.children) flattenPaths(node.children, out);
+  }
+  return out;
+}
 
 function StreamingMessage({
   content,
@@ -58,11 +75,11 @@ function ContextPanelSection({
   children,
 }: {
   title: string;
-  icon: typeof History;
+  icon: typeof Files;
   children: React.ReactNode;
 }) {
   return (
-    <section className="space-y-2">
+    <section className="space-y-1.5">
       <div className="text-subtle flex items-center gap-1.5 px-1 text-[12px] font-medium">
         <Icon className="text-dim size-3.5" />
         {title}
@@ -78,6 +95,7 @@ function ContextPanelSection({
 export function BuildView() {
   const [input, setInput] = useState("");
   const scrollRef = useRef<HTMLDivElement>(null);
+  const composerRef = useRef<IntentComposerHandle>(null);
   const { toast } = useToast();
 
   const {
@@ -98,12 +116,39 @@ export function BuildView() {
     showStreamInThread,
     loadSession,
     startNewSession,
+    cancelPipeline,
     runBuildPipeline,
     handleStreamComplete,
     runCompile,
     runTest,
     recentSessions,
   } = useBuildSession();
+
+  const displayStageId = useMemo(
+    () =>
+      resolveDisplayJourneyStage({
+        stageId,
+        isGenerating,
+        awaitingVerify,
+        shipReady,
+        compileDone,
+        testDone,
+        verifyBusy,
+        streamEvents,
+        messageCount: messages.length,
+      }),
+    [
+      stageId,
+      isGenerating,
+      awaitingVerify,
+      shipReady,
+      compileDone,
+      testDone,
+      verifyBusy,
+      streamEvents,
+      messages.length,
+    ],
+  );
 
   const scrollToBottom = useCallback(() => {
     const el = scrollRef.current;
@@ -119,9 +164,25 @@ export function BuildView() {
     messages,
     streamingMessageId,
     showStreamInThread,
+    nodes,
+    awaitingVerify,
     shipReady,
+    fileTree,
     scrollToBottom,
   ]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "n") {
+        e.preventDefault();
+        startNewSession();
+        setInput("");
+        requestAnimationFrame(() => composerRef.current?.focus());
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [startNewSession]);
 
   const handleSend = useCallback(() => {
     const text = input.trim();
@@ -132,6 +193,16 @@ export function BuildView() {
     });
   }, [input, isGenerating, runBuildPipeline, setStreamingMessageId]);
 
+  const handleStop = useCallback(() => {
+    cancelPipeline();
+    toast({
+      title: "Stopped",
+      description: "Build cancelled.",
+      tone: "info",
+    });
+    requestAnimationFrame(() => composerRef.current?.focus());
+  }, [cancelPipeline, toast]);
+
   const handleStreamDone = useCallback(() => {
     handleStreamComplete();
   }, [handleStreamComplete]);
@@ -139,15 +210,24 @@ export function BuildView() {
   const handleActionPill = useCallback((action: string) => {
     if (action === "plan") {
       setInput("Help me plan a new agent idea: ");
+      requestAnimationFrame(() => composerRef.current?.focus());
+      return;
+    }
+    const template = BUILD_TEMPLATES.find((t) => t.id === action);
+    if (template) {
+      setInput(template.prompt);
+      requestAnimationFrame(() => composerRef.current?.focus());
     }
   }, []);
 
   const handleDownload = useCallback(() => {
+    const paths = flattenPaths(fileTree);
     const blob = new Blob(
       [
-        "# Aomi Build — local mock export\n",
-        "# Real archive lands when Smithers / codegen is wired.\n",
-        fileTree.map((n) => n.path).join("\n"),
+        "# Aomi Build — file list\n",
+        `# Session ${activeSessionId ?? "unknown"}\n`,
+        "# Full archive download comes when generate is connected.\n\n",
+        paths.join("\n"),
         "\n",
       ],
       { type: "text/plain" },
@@ -155,18 +235,20 @@ export function BuildView() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "aomi-build-mock-export.txt";
+    a.download = "aomi-build-files.txt";
     a.click();
     URL.revokeObjectURL(url);
     toast({
-      title: "Downloaded mock export",
-      description: "Placeholder file list — not a real repo archive.",
+      title: "Downloaded file list",
+      description: `${paths.length} paths listed — archive download comes later.`,
+      tone: "success",
     });
-  }, [fileTree, toast]);
+  }, [activeSessionId, fileTree, toast]);
 
   const handleTemplateSelect = useCallback(
     (template: (typeof BUILD_TEMPLATES)[0]) => {
       setInput(template.prompt);
+      requestAnimationFrame(() => composerRef.current?.focus());
     },
     [],
   );
@@ -174,6 +256,7 @@ export function BuildView() {
   const handleSelectSession = useCallback(
     (id: string) => {
       loadSession(id);
+      requestAnimationFrame(() => composerRef.current?.focus());
     },
     [loadSession],
   );
@@ -181,14 +264,24 @@ export function BuildView() {
   const handleNewSession = useCallback(() => {
     startNewSession();
     setInput("");
+    requestAnimationFrame(() => composerRef.current?.focus());
   }, [startNewSession]);
 
   const isEmpty = messages.length === 0;
-  const stageIndex = JOURNEY_STAGES.findIndex((s) => s.id === stageId);
+  const stageIndex = JOURNEY_STAGES.findIndex((s) => s.id === displayStageId);
+  const composerBlocked =
+    awaitingVerify && !shipReady
+      ? "Finish Compile → smoke test below, or start a new build (⌘N)."
+      : undefined;
+
+  /** Unique plan steps only during plan/generate — not a second progress list. */
+  const showPlanNodes =
+    nodes.length > 0 &&
+    isGenerating &&
+    (displayStageId === "plan" || displayStageId === "generate");
 
   return (
     <div className="flex h-[calc(100dvh-2.75rem)] min-h-0 w-full">
-      {/* Optional thin session column — in-page, not BuildLayout rail */}
       <aside className="border-border hidden w-[220px] shrink-0 flex-col gap-3 overflow-y-auto border-r p-3 xl:flex">
         <SessionHistory
           sessions={recentSessions}
@@ -199,9 +292,9 @@ export function BuildView() {
       </aside>
 
       <section className="bg-background flex min-w-0 flex-1 flex-col">
-        {!isEmpty ? (
-          <div className="border-border hidden h-10 items-center justify-between border-b px-4 sm:flex">
-            <ol className="flex flex-wrap items-center gap-1.5">
+        <div className="border-border flex h-10 shrink-0 items-center justify-between gap-2 border-b px-3 sm:px-4">
+          {!isEmpty ? (
+            <ol className="hidden min-w-0 flex-1 flex-wrap items-center gap-1.5 sm:flex">
               {JOURNEY_STAGES.map((stage, index) => {
                 const active = index === stageIndex;
                 const done = index < stageIndex;
@@ -222,34 +315,60 @@ export function BuildView() {
                 );
               })}
             </ol>
-            <span className="text-dim text-[11px]">Local mock · timers</span>
+          ) : (
+            <p className="text-dim text-[12px]">Create</p>
+          )}
+
+          <div className="ml-auto flex shrink-0 items-center gap-1.5">
+            {isGenerating ? (
+              <button
+                type="button"
+                onClick={handleStop}
+                className="border-border text-foreground hover:bg-accent/40 inline-flex h-7 items-center gap-1 rounded-md border px-2 text-[11px]"
+              >
+                <Square className="size-2.5 fill-current" />
+                Stop
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={handleNewSession}
+              className="border-border text-foreground hover:bg-accent/40 inline-flex h-7 items-center gap-1 rounded-md border px-2 text-[11px]"
+              title="New session (⌘N)"
+            >
+              <Plus className="size-3" />
+              New
+            </button>
           </div>
-        ) : null}
+        </div>
 
         <div className="flex min-h-0 flex-1">
           <div className="flex min-w-0 flex-1 flex-col">
             <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
               {isEmpty ? (
-                <div className="flex h-full items-center justify-center px-4 py-10">
+                <div className="flex justify-center px-4 pt-8 pb-8 sm:pt-10">
                   <div className="w-full max-w-[640px]">
-                    <div className="mb-6 space-y-1 text-center sm:text-left">
+                    <div className="mb-4 space-y-1 text-center sm:text-left">
                       <h1 className="text-foreground text-base font-medium">
-                        Build
+                        What do you want to build?
                       </h1>
-                      <p className="text-dim text-sm leading-6">
-                        Describe what you want — local mock plans and generates
-                        — then ship to Projects. Real Smithers SSE comes later.
+                      <p className="text-dim text-[13px] leading-5">
+                        Describe an agent, review the plan and files, compile,
+                        smoke-test, then ship to Projects.
                       </p>
                     </div>
                     <IntentComposer
+                      ref={composerRef}
                       value={input}
                       onChange={setInput}
                       onSubmit={handleSend}
+                      onStop={handleStop}
                       disabled={isGenerating}
                       isLoading={isGenerating}
                       actionPills={actionPills}
                       onActionPillClick={handleActionPill}
-                      placeholder="What do you want to build?"
+                      placeholder="Describe an agent — e.g. hyperliquid & binance arb bot"
+                      autoFocus
                     />
                     <TemplateGallery
                       templates={BUILD_TEMPLATES}
@@ -258,7 +377,7 @@ export function BuildView() {
                   </div>
                 </div>
               ) : (
-                <div className="px-4">
+                <div className="mx-auto w-full max-w-3xl space-y-1 px-4 pt-3 pb-3">
                   {messages.map((msg) => {
                     if (streamingMessageId === msg.id) {
                       return (
@@ -281,13 +400,17 @@ export function BuildView() {
                     );
                   })}
 
-                  {showStreamInThread ? (
-                    <div className="mx-auto my-4 max-w-3xl">
+                  {/* Progress in-thread when right rail is hidden */}
+                  {(showStreamInThread || isGenerating || awaitingVerify) &&
+                  streamEvents.length > 0 ? (
+                    <div className="my-2 lg:hidden">
                       <BuildStreamTimeline events={streamEvents} />
                     </div>
                   ) : null}
 
-                  {nodes.length > 0 ? <SmithersNodes nodes={nodes} /> : null}
+                  {showPlanNodes ? (
+                    <SmithersNodes nodes={nodes} caption="Plan steps" />
+                  ) : null}
 
                   {awaitingVerify ? (
                     <CompileTestPanel
@@ -311,19 +434,32 @@ export function BuildView() {
             </div>
 
             {!isEmpty ? (
-              <div className="border-border border-t p-4">
-                <div className="mx-auto max-w-3xl">
+              <div className="border-border border-t px-4 py-3">
+                <div className="mx-auto max-w-3xl space-y-1.5">
+                  {composerBlocked ? (
+                    <p className="text-dim text-center text-[11px]">
+                      {composerBlocked}
+                    </p>
+                  ) : null}
                   <IntentComposer
+                    ref={composerRef}
                     value={input}
                     onChange={setInput}
                     onSubmit={handleSend}
-                    disabled={isGenerating}
+                    onStop={handleStop}
+                    disabled={isGenerating || (awaitingVerify && !shipReady)}
                     isLoading={isGenerating}
                     compact
-                    showContextStrip={false}
                     footerHint=""
-                    actionPills={actionPills}
+                    actionPills={
+                      awaitingVerify && !shipReady ? undefined : actionPills
+                    }
                     onActionPillClick={handleActionPill}
+                    placeholder={
+                      awaitingVerify && !shipReady
+                        ? "Verify below, or ⌘N for a new build…"
+                        : "Refine or start another build…"
+                    }
                   />
                 </div>
               </div>
@@ -331,42 +467,13 @@ export function BuildView() {
           </div>
 
           {!isEmpty ? (
-            <aside className="border-border bg-surface-1/40 hidden w-[300px] shrink-0 flex-col gap-4 overflow-y-auto border-l p-3 lg:flex">
-              <ContextPanelSection title="Build stream" icon={History}>
+            <aside className="border-border bg-surface-1/40 hidden w-[280px] shrink-0 flex-col gap-3 overflow-y-auto border-l p-3 lg:flex">
+              <ContextPanelSection title="Progress" icon={ListChecks}>
                 <BuildStreamTimeline events={streamEvents} compact />
               </ContextPanelSection>
 
-              {nodes.length > 0 ? (
-                <ContextPanelSection title="Smithers nodes" icon={History}>
-                  <SmithersNodes
-                    nodes={nodes}
-                    caption="Plan graph (local mock)"
-                  />
-                </ContextPanelSection>
-              ) : null}
-
               <ContextPanelSection title="Files" icon={Files}>
                 <FileTreePreview tree={fileTree} />
-              </ContextPanelSection>
-
-              <ContextPanelSection title="Templates" icon={LayoutTemplate}>
-                <div className="space-y-1">
-                  {BUILD_TEMPLATES.slice(0, 4).map((template) => (
-                    <button
-                      key={template.id}
-                      type="button"
-                      onClick={() => handleTemplateSelect(template)}
-                      className="panel-row w-full text-left"
-                    >
-                      <p className="text-foreground text-[13px]">
-                        {template.name}
-                      </p>
-                      <p className="text-subtle mt-0.5 text-[12px]">
-                        {template.description}
-                      </p>
-                    </button>
-                  ))}
-                </div>
               </ContextPanelSection>
             </aside>
           ) : null}

--- a/apps/aomi-build/src/features/build/components/build-stream-timeline.tsx
+++ b/apps/aomi-build/src/features/build/components/build-stream-timeline.tsx
@@ -24,11 +24,12 @@ export function BuildStreamTimeline({
         compact ? "p-3" : "p-4",
       )}
     >
-      <div className="mb-3 flex items-center justify-between gap-2">
-        <p className="text-subtle text-[12px] font-medium">Build progress</p>
-        <span className="text-dim text-[10px]">Local mock</span>
-      </div>
-      <ol className="space-y-3">
+      {!compact ? (
+        <div className="mb-3 flex items-center justify-between gap-2">
+          <p className="text-subtle text-[12px] font-medium">Progress</p>
+        </div>
+      ) : null}
+      <ol className={cn("space-y-3", compact && "space-y-2.5")}>
         {events.map((event) => (
           <li key={event.stage} className="flex gap-3">
             <div className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center">

--- a/apps/aomi-build/src/features/build/components/chat-message.tsx
+++ b/apps/aomi-build/src/features/build/components/chat-message.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Bot, Square } from "lucide-react";
+import { Square } from "lucide-react";
 
 import { MarkdownContent } from "@build/features/build/components/markdown-content";
+import { cn } from "@build/lib/utils";
 
 export type ChatMessageProps = {
   role: "user" | "assistant" | "system";
@@ -13,6 +14,10 @@ export type ChatMessageProps = {
   model?: string;
 };
 
+/**
+ * Thread rendering — product language only (You / Aomi).
+ * Dense stack: tight padding so messages don't float in voids.
+ */
 export function ChatMessage({
   role,
   content,
@@ -21,18 +26,28 @@ export function ChatMessage({
   timestamp,
   model,
 }: ChatMessageProps) {
-  const isUser = role === "user";
-
-  if (isUser) {
+  if (role === "system") {
     return (
-      <div className="group w-full py-4">
-        <div className="mx-auto max-w-3xl">
-          <div className="text-dim mb-1.5 flex items-center gap-2 text-[11px]">
-            <span>You</span>
-            {timestamp ? <span>{timestamp}</span> : null}
-          </div>
-          <div className="text-foreground text-[13px] leading-relaxed">
-            {content}
+      <div className="mx-auto max-w-3xl px-1 py-1.5">
+        <div className="border-border bg-surface-1 text-dim rounded-md border px-3 py-1.5 text-center text-[12px] leading-5">
+          {content}
+        </div>
+      </div>
+    );
+  }
+
+  if (role === "user") {
+    return (
+      <div className="w-full py-1.5">
+        <div className="mx-auto flex max-w-3xl justify-end">
+          <div className="max-w-[85%] sm:max-w-[75%]">
+            <div className="text-dim mb-0.5 flex items-center justify-end gap-2 text-[11px]">
+              {timestamp ? <span>{timestamp}</span> : null}
+              <span>You</span>
+            </div>
+            <div className="bg-surface-2 text-foreground rounded-2xl rounded-br-md px-3.5 py-2 text-[13px] leading-relaxed whitespace-pre-wrap">
+              {content}
+            </div>
           </div>
         </div>
       </div>
@@ -40,30 +55,36 @@ export function ChatMessage({
   }
 
   return (
-    <div className="border-border/60 group w-full border-b py-5">
+    <div className="w-full py-2">
       <div className="mx-auto max-w-3xl">
-        <div className="text-muted-foreground mb-2 flex items-center gap-1.5 text-[11px]">
-          <Bot className="size-3" />
-          <span className="text-subtle font-medium">
-            {role === "system" ? "Aomi" : "Agent"}
-          </span>
-          {model ? <span>{model}</span> : null}
-          {timestamp ? <span>{timestamp}</span> : null}
+        <div className="text-dim mb-1 flex items-center gap-2 text-[11px]">
+          <span className="text-subtle font-medium">Aomi</span>
+          {model &&
+          model.toLowerCase() !== "aomi" &&
+          !model.toLowerCase().includes("local mock") ? (
+            <span className="text-dim">· {model}</span>
+          ) : null}
+          {timestamp ? <span>· {timestamp}</span> : null}
         </div>
 
         <MarkdownContent content={content} />
         {isStreaming ? (
-          <span className="bg-foreground/60 mt-1 inline-block h-4 w-[2px] animate-pulse" />
+          <span
+            className="bg-foreground/70 mt-1 inline-block h-4 w-[2px] animate-pulse"
+            aria-hidden
+          />
         ) : null}
 
         {isStreaming && onStop ? (
           <button
             type="button"
             onClick={onStop}
-            className="border-border bg-surface-1 text-muted-foreground hover:text-foreground mt-3 flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-[11px] transition-colors"
+            className={cn(
+              "border-border bg-surface-1 text-dim hover:text-foreground mt-2 inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-[11px] transition-colors",
+            )}
           >
             <Square className="size-2.5 fill-current" />
-            Skip
+            Skip to end
           </button>
         ) : null}
       </div>
@@ -73,16 +94,15 @@ export function ChatMessage({
 
 export function TypingIndicator() {
   return (
-    <div className="border-border/60 w-full border-b py-5">
+    <div className="w-full py-2">
       <div className="mx-auto max-w-3xl">
-        <div className="text-muted-foreground mb-2 flex items-center gap-1.5 text-[11px]">
-          <Bot className="size-3" />
-          <span>Agent</span>
+        <div className="text-dim mb-1 text-[11px]">
+          <span className="text-subtle font-medium">Aomi</span>
         </div>
-        <div className="flex items-center gap-1">
-          <span className="bg-muted-foreground h-1.5 w-1.5 animate-bounce rounded-full [animation-delay:0ms]" />
-          <span className="bg-muted-foreground h-1.5 w-1.5 animate-bounce rounded-full [animation-delay:150ms]" />
-          <span className="bg-muted-foreground h-1.5 w-1.5 animate-bounce rounded-full [animation-delay:300ms]" />
+        <div className="flex items-center gap-1.5" aria-label="Thinking">
+          <span className="bg-dim h-1.5 w-1.5 animate-bounce rounded-full [animation-delay:0ms]" />
+          <span className="bg-dim h-1.5 w-1.5 animate-bounce rounded-full [animation-delay:150ms]" />
+          <span className="bg-dim h-1.5 w-1.5 animate-bounce rounded-full [animation-delay:300ms]" />
         </div>
       </div>
     </div>

--- a/apps/aomi-build/src/features/build/components/compile-test-panel.tsx
+++ b/apps/aomi-build/src/features/build/components/compile-test-panel.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { Check, Play, Terminal } from "lucide-react";
+
+import { cn } from "@build/lib/utils";
+
+type CompileTestPanelProps = {
+  compileDone: boolean;
+  testDone: boolean;
+  busy: "compile" | "test" | null;
+  onCompile: () => void;
+  onTest: () => void;
+};
+
+/**
+ * Explicit Compile + aomi-run steps (Cecilia wireframe). Local mock only.
+ */
+export function CompileTestPanel({
+  compileDone,
+  testDone,
+  busy,
+  onCompile,
+  onTest,
+}: CompileTestPanelProps) {
+  return (
+    <div className="border-border bg-surface-1 mx-auto my-4 max-w-3xl space-y-3 rounded-lg border p-4">
+      <div>
+        <p className="text-foreground text-[13px] font-medium">
+          How do you want to verify?
+        </p>
+        <p className="text-dim mt-0.5 text-[12px] leading-5">
+          Tool layer is done — compile, then test with aomi-run (local mock).
+        </p>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={onCompile}
+          disabled={compileDone || busy !== null}
+          className={cn(
+            "inline-flex h-8 items-center gap-1.5 rounded-md px-3 text-[12px] font-medium transition-colors",
+            compileDone
+              ? "border-positive/40 text-positive border bg-transparent"
+              : "bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50",
+          )}
+        >
+          {compileDone ? (
+            <Check className="size-3.5" />
+          ) : (
+            <Terminal className="size-3.5" />
+          )}
+          {busy === "compile"
+            ? "Compiling…"
+            : compileDone
+              ? "Compile · done"
+              : "Compile"}
+        </button>
+        <button
+          type="button"
+          onClick={onTest}
+          disabled={!compileDone || testDone || busy !== null}
+          className={cn(
+            "inline-flex h-8 items-center gap-1.5 rounded-md border px-3 text-[12px] font-medium transition-colors",
+            testDone
+              ? "border-positive/40 text-positive"
+              : "border-border text-foreground hover:bg-accent/40 disabled:opacity-40",
+          )}
+        >
+          {testDone ? (
+            <Check className="size-3.5" />
+          ) : (
+            <Play className="size-3.5" />
+          )}
+          {busy === "test"
+            ? "aomi-run…"
+            : testDone
+              ? "aomi-run · done"
+              : "Test with aomi-run"}
+        </button>
+      </div>
+      {compileDone && testDone ? (
+        <p className="text-positive text-[12px]">
+          Compile + aomi-run passed (mock). Ship when you’re ready.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/aomi-build/src/features/build/components/compile-test-panel.tsx
+++ b/apps/aomi-build/src/features/build/components/compile-test-panel.tsx
@@ -12,9 +12,7 @@ type CompileTestPanelProps = {
   onTest: () => void;
 };
 
-/**
- * Explicit Compile + aomi-run steps (Cecilia wireframe). Local mock only.
- */
+/** Explicit Compile + smoke test — builder language (no CLI codenames). */
 export function CompileTestPanel({
   compileDone,
   testDone,
@@ -23,13 +21,13 @@ export function CompileTestPanel({
   onTest,
 }: CompileTestPanelProps) {
   return (
-    <div className="border-border bg-surface-1 mx-auto my-4 max-w-3xl space-y-3 rounded-lg border p-4">
+    <div className="border-border bg-surface-1 mx-auto my-2 max-w-3xl space-y-3 rounded-lg border p-4">
       <div>
         <p className="text-foreground text-[13px] font-medium">
-          How do you want to verify?
+          Verify before you ship
         </p>
         <p className="text-dim mt-0.5 text-[12px] leading-5">
-          Tool layer is done — compile, then test with aomi-run (local mock).
+          Compile the generated app, then run a quick smoke test.
         </p>
       </div>
       <div className="flex flex-wrap gap-2">
@@ -52,7 +50,7 @@ export function CompileTestPanel({
           {busy === "compile"
             ? "Compiling…"
             : compileDone
-              ? "Compile · done"
+              ? "Compiled"
               : "Compile"}
         </button>
         <button
@@ -72,15 +70,15 @@ export function CompileTestPanel({
             <Play className="size-3.5" />
           )}
           {busy === "test"
-            ? "aomi-run…"
+            ? "Testing…"
             : testDone
-              ? "aomi-run · done"
-              : "Test with aomi-run"}
+              ? "Smoke test passed"
+              : "Smoke test"}
         </button>
       </div>
       {compileDone && testDone ? (
         <p className="text-positive text-[12px]">
-          Compile + aomi-run passed (mock). Ship when you’re ready.
+          Looking good — ship when you’re ready.
         </p>
       ) : null}
     </div>

--- a/apps/aomi-build/src/features/build/components/file-tree-preview.tsx
+++ b/apps/aomi-build/src/features/build/components/file-tree-preview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { ChevronRight, File, Folder } from "lucide-react";
+import { ChevronDown, ChevronRight, File, Folder } from "lucide-react";
+import { useState } from "react";
 
 import type { BuildFileNode } from "@build/features/build/contracts";
 import { cn } from "@build/lib/utils";
@@ -13,32 +14,50 @@ function FileTreeNode({
   depth?: number;
 }) {
   const isFolder = node.type === "folder";
+  const [open, setOpen] = useState(depth < 2);
   const name = node.path.split("/").pop() ?? node.path;
 
   return (
     <div>
-      <div
+      <button
+        type="button"
+        disabled={!isFolder}
+        onClick={() => isFolder && setOpen((v) => !v)}
         className={cn(
-          "flex items-center gap-1.5 rounded px-1.5 py-1 text-[12px]",
-          depth > 0 && "ml-3",
+          "flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-left text-[12px] transition-colors",
+          isFolder ? "hover:bg-accent/40 cursor-pointer" : "cursor-default",
         )}
         style={{ paddingLeft: depth * 12 + 6 }}
+        title={node.path}
       >
+        {isFolder ? (
+          open ? (
+            <ChevronDown className="text-dim size-3 shrink-0" />
+          ) : (
+            <ChevronRight className="text-dim size-3 shrink-0" />
+          )
+        ) : (
+          <span className="inline-block w-3 shrink-0" />
+        )}
         {isFolder ? (
           <Folder className="text-warning size-3.5 shrink-0" />
         ) : (
           <File className="text-link size-3.5 shrink-0" />
         )}
-        <span className={cn(isFolder ? "text-foreground" : "text-subtle")}>
+        <span
+          className={cn(
+            "truncate",
+            isFolder ? "text-foreground" : "text-subtle",
+          )}
+        >
           {name}
         </span>
-        {isFolder ? (
-          <ChevronRight className="text-dim ml-auto size-3" />
-        ) : null}
-      </div>
-      {node.children?.map((child) => (
-        <FileTreeNode key={child.path} node={child} depth={depth + 1} />
-      ))}
+      </button>
+      {isFolder && open
+        ? node.children?.map((child) => (
+            <FileTreeNode key={child.path} node={child} depth={depth + 1} />
+          ))
+        : null}
     </div>
   );
 }
@@ -53,7 +72,7 @@ export function FileTreePreview({ tree, className }: FileTreePreviewProps) {
     return (
       <div className={cn("panel-inset p-4 text-center", className)}>
         <p className="text-dim text-[12px]">
-          Files appear as the local mock generates.
+          Files appear when generate runs.
         </p>
       </div>
     );

--- a/apps/aomi-build/src/features/build/components/intent-composer.tsx
+++ b/apps/aomi-build/src/features/build/components/intent-composer.tsx
@@ -1,7 +1,13 @@
 "use client";
 
-import { ArrowUp, Laptop, Loader2 } from "lucide-react";
-import { useCallback, useEffect, useRef } from "react";
+import { ArrowUp, Laptop, Loader2, Square } from "lucide-react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from "react";
 
 import { cn } from "@build/lib/utils";
 
@@ -11,37 +17,55 @@ type ActionPill = {
   action?: string;
 };
 
+export type IntentComposerHandle = {
+  focus: () => void;
+};
+
 type IntentComposerProps = {
   value: string;
   onChange: (value: string) => void;
   onSubmit: () => void;
+  /** Cursor-style: while generating, primary action stops the run. */
+  onStop?: () => void;
   disabled?: boolean;
   isLoading?: boolean;
   placeholder?: string;
   actionPills?: ActionPill[];
   onActionPillClick?: (action: string) => void;
-  /** Visual-only model chip — no picker (DropdownMenu not in live app). */
-  modelLabel?: string;
   compact?: boolean;
-  showContextStrip?: boolean;
   footerHint?: string;
+  autoFocus?: boolean;
 };
 
-export function IntentComposer({
-  value,
-  onChange,
-  onSubmit,
-  disabled,
-  isLoading,
-  placeholder = "What do you want to build?",
-  actionPills,
-  onActionPillClick,
-  modelLabel = "Local mock",
-  compact = false,
-  showContextStrip = true,
-  footerHint = "Local mock for now — Smithers streaming is not wired yet.",
-}: IntentComposerProps) {
+/**
+ * Intent composer — Preview honesty chip + send.
+ * No stacked Aomi branding (shell already brands); no model picker yet.
+ */
+export const IntentComposer = forwardRef<
+  IntentComposerHandle,
+  IntentComposerProps
+>(function IntentComposer(
+  {
+    value,
+    onChange,
+    onSubmit,
+    onStop,
+    disabled,
+    isLoading,
+    placeholder = "What do you want to build?",
+    actionPills,
+    onActionPillClick,
+    compact = false,
+    footerHint = "Enter to send · Shift+Enter newline · Esc stop · ⌘N new",
+    autoFocus = false,
+  },
+  ref,
+) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useImperativeHandle(ref, () => ({
+    focus: () => textareaRef.current?.focus(),
+  }));
 
   const adjustHeight = useCallback(() => {
     const el = textareaRef.current;
@@ -55,21 +79,30 @@ export function IntentComposer({
   }, [value, adjustHeight]);
 
   useEffect(() => {
+    if (autoFocus) textareaRef.current?.focus();
+  }, [autoFocus]);
+
+  useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Tab" && e.shiftKey) {
         e.preventDefault();
         onActionPillClick?.("plan");
       }
+      if (e.key === "Escape" && isLoading) {
+        e.preventDefault();
+        onStop?.();
+      }
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [onActionPillClick]);
+  }, [onActionPillClick, isLoading, onStop]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
-        if (!disabled && !isLoading && value.trim()) onSubmit();
+        if (isLoading) return;
+        if (!disabled && value.trim()) onSubmit();
       }
     },
     [disabled, isLoading, value, onSubmit],
@@ -79,21 +112,6 @@ export function IntentComposer({
 
   return (
     <div className="w-full">
-      {showContextStrip ? (
-        <div className="mb-2.5 flex items-center gap-1">
-          <span className="context-chip cursor-default" title="Local mock workspace">
-            aomi
-          </span>
-          <span
-            className="context-chip cursor-default"
-            title="Timers only until SSE"
-          >
-            <Laptop className="size-3.5 opacity-70" />
-            Local mock
-          </span>
-        </div>
-      ) : null}
-
       <div
         className={cn(
           "composer-surface",
@@ -105,46 +123,59 @@ export function IntentComposer({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           onKeyDown={handleKeyDown}
-          disabled={disabled || isLoading}
-          placeholder={placeholder}
+          disabled={disabled && !isLoading}
+          placeholder={isLoading ? "Building… Esc to stop" : placeholder}
           rows={compact ? 2 : 3}
           className={cn(
             "text-foreground placeholder:text-dim w-full resize-none bg-transparent text-[14px] leading-relaxed outline-none disabled:opacity-50",
-            compact ? "min-h-[48px]" : "min-h-[80px]",
+            compact ? "min-h-[48px]" : "min-h-[72px]",
           )}
         />
 
-        <div className="mt-3 flex items-center justify-between">
+        <div className="mt-2.5 flex items-center justify-between gap-2">
           <span
-            className="context-chip cursor-default rounded-full border border-transparent px-2.5 py-1"
-            title="Model selection arrives with Smithers SSE"
+            className="context-chip cursor-default"
+            title="Preview build — timers until remote generate is connected"
           >
-            {modelLabel}
+            <Laptop className="size-3.5 opacity-70" />
+            Preview
           </span>
 
-          <button
-            type="button"
-            onClick={onSubmit}
-            disabled={!canSend}
-            className={cn(
-              "flex h-9 w-9 items-center justify-center rounded-full transition-all duration-150",
-              canSend
-                ? "bg-primary text-primary-foreground hover:bg-brand-hover shadow-sm hover:scale-[1.03]"
-                : "bg-surface-3 text-dim",
-            )}
-            aria-label="Send message"
-          >
-            {isLoading ? (
-              <Loader2 className="size-4 animate-spin" />
-            ) : (
-              <ArrowUp className="size-4" />
-            )}
-          </button>
+          {isLoading && onStop ? (
+            <button
+              type="button"
+              onClick={onStop}
+              className="border-border bg-surface-2 text-foreground hover:bg-accent/50 flex h-9 w-9 shrink-0 items-center justify-center rounded-full border transition-all duration-150"
+              aria-label="Stop generation"
+              title="Stop (Esc)"
+            >
+              <Square className="size-3.5 fill-current" />
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={onSubmit}
+              disabled={!canSend}
+              className={cn(
+                "flex h-9 w-9 shrink-0 items-center justify-center rounded-full transition-all duration-150",
+                canSend
+                  ? "bg-primary text-primary-foreground hover:bg-brand-hover shadow-sm hover:scale-[1.03]"
+                  : "bg-surface-3 text-dim",
+              )}
+              aria-label="Send message"
+            >
+              {isLoading ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <ArrowUp className="size-4" />
+              )}
+            </button>
+          )}
         </div>
       </div>
 
-      {actionPills && actionPills.length > 0 ? (
-        <div className="mt-3 flex flex-wrap items-center justify-center gap-2">
+      {actionPills && actionPills.length > 0 && !isLoading ? (
+        <div className="mt-2.5 flex flex-wrap items-center justify-center gap-2">
           {actionPills.map((pill) => (
             <button
               key={pill.label}
@@ -162,10 +193,10 @@ export function IntentComposer({
       ) : null}
 
       {footerHint ? (
-        <p className="text-dim mt-4 text-center text-[12px] leading-relaxed">
+        <p className="text-dim mt-2.5 text-center text-[11px] leading-relaxed">
           {footerHint}
         </p>
       ) : null}
     </div>
   );
-}
+});

--- a/apps/aomi-build/src/features/build/components/session-history.tsx
+++ b/apps/aomi-build/src/features/build/components/session-history.tsx
@@ -14,6 +14,13 @@ type SessionHistoryProps = {
   className?: string;
 };
 
+function statusLabel(status: BuildSession["status"]) {
+  if (status === "healthy") return "Ready";
+  if (status === "failed") return "Failed";
+  if (status === "running") return "In progress";
+  return "Queued";
+}
+
 function statusTone(status: BuildSession["status"]) {
   if (status === "healthy") return "bg-positive/10 text-positive";
   if (status === "failed") return "bg-destructive/10 text-destructive";
@@ -26,7 +33,7 @@ function stageLabel(stageId: BuildSession["stageId"]) {
 }
 
 /**
- * Thin in-page session list — not an immersive BuildLayout rail.
+ * Thin in-page session list — product labels, not API enums.
  */
 export function SessionHistory({
   sessions,
@@ -36,11 +43,11 @@ export function SessionHistory({
   className,
 }: SessionHistoryProps) {
   return (
-    <div className={cn("flex flex-col gap-2", className)}>
+    <div className={cn("flex h-full flex-col gap-2", className)}>
       <div className="flex items-center justify-between gap-2 px-1">
         <div className="text-subtle flex items-center gap-1.5 text-[12px] font-medium">
           <History className="text-dim size-3.5" />
-          Sessions
+          Recent
         </div>
         <button
           type="button"
@@ -50,15 +57,21 @@ export function SessionHistory({
           New
         </button>
       </div>
-      <div className="space-y-1">
-        {sessions.slice(0, 8).map((session) => (
+      <div className="min-h-0 flex-1 space-y-1 overflow-y-auto">
+        {sessions.length === 0 ? (
+          <p className="text-dim px-1 py-3 text-[11px] leading-4">
+            No builds yet. Describe an app to start.
+          </p>
+        ) : null}
+        {sessions.slice(0, 12).map((session) => (
           <button
             key={session.id}
             type="button"
             onClick={() => onSelect(session.id)}
             className={cn(
               "panel-row w-full text-left",
-              activeSessionId === session.id && "border-border-hover bg-accent-selected",
+              activeSessionId === session.id &&
+                "border-border-hover bg-accent-selected",
             )}
           >
             <div className="flex items-center justify-between gap-2">
@@ -67,11 +80,11 @@ export function SessionHistory({
               </p>
               <span
                 className={cn(
-                  "shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium capitalize",
+                  "shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium",
                   statusTone(session.status),
                 )}
               >
-                {session.status}
+                {statusLabel(session.status)}
               </span>
             </div>
             <p className="text-dim mt-0.5 text-[11px]">

--- a/apps/aomi-build/src/features/build/components/ship-handoff-banner.tsx
+++ b/apps/aomi-build/src/features/build/components/ship-handoff-banner.tsx
@@ -10,14 +10,11 @@ type ShipHandoffBannerProps = {
  */
 export function ShipHandoffBanner({ onDownload }: ShipHandoffBannerProps) {
   return (
-    <div className="border-positive/30 bg-positive/5 mx-auto my-4 flex max-w-3xl flex-col gap-3 rounded-lg border px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+    <div className="border-positive/30 bg-positive/5 mx-auto my-2 flex max-w-3xl flex-col gap-3 rounded-lg border px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
       <div>
-        <p className="text-foreground text-[13px] font-medium">
-          Verified (local mock) — ship toward Projects
-        </p>
+        <p className="text-foreground text-[13px] font-medium">Ready to ship</p>
         <p className="text-subtle text-[12px]">
-          Download a placeholder archive, or manage deploy from Projects. GitHub
-          init needs a Han API.
+          Download your files, or open Projects to manage deploy.
         </p>
       </div>
       <div className="flex shrink-0 flex-wrap items-center gap-2">
@@ -38,10 +35,10 @@ export function ShipHandoffBanner({ onDownload }: ShipHandoffBannerProps) {
         </Link>
         <span
           className="text-dim inline-flex h-8 items-center gap-1.5 rounded-md border border-dashed px-3 text-[11px]"
-          title="Needs Han GitHub create-repo API"
+          title="Coming when GitHub create-repo is connected"
         >
           <Rocket className="size-3.5" />
-          GitHub init · needs API
+          GitHub init · soon
         </span>
       </div>
     </div>

--- a/apps/aomi-build/src/features/build/components/ship-handoff-banner.tsx
+++ b/apps/aomi-build/src/features/build/components/ship-handoff-banner.tsx
@@ -1,22 +1,34 @@
 import Link from "next/link";
-import { FolderKanban, Rocket } from "lucide-react";
+import { Download, FolderKanban, Rocket } from "lucide-react";
+
+type ShipHandoffBannerProps = {
+  onDownload?: () => void;
+};
 
 /**
  * End-of-run handoff → manage path (Projects), never /deploy/[id].
  */
-export function ShipHandoffBanner() {
+export function ShipHandoffBanner({ onDownload }: ShipHandoffBannerProps) {
   return (
     <div className="border-positive/30 bg-positive/5 mx-auto my-4 flex max-w-3xl flex-col gap-3 rounded-lg border px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
       <div>
         <p className="text-foreground text-[13px] font-medium">
-          Local mock ready — ship toward Projects
+          Verified (local mock) — ship toward Projects
         </p>
         <p className="text-subtle text-[12px]">
-          Review the generated files, then manage deploy from Projects. Real
-          Smithers SSE is not wired yet.
+          Download a placeholder archive, or manage deploy from Projects. GitHub
+          init needs a Han API.
         </p>
       </div>
       <div className="flex shrink-0 flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={onDownload}
+          className="border-border text-foreground hover:bg-accent/40 inline-flex h-8 items-center gap-1.5 rounded-md border px-3 text-[12px] font-medium"
+        >
+          <Download className="size-3.5" />
+          Download code
+        </button>
         <Link
           href="/projects"
           className="bg-primary text-primary-foreground hover:bg-brand-hover inline-flex h-8 items-center gap-1.5 rounded-md px-3 text-[12px] font-medium transition-colors"
@@ -24,9 +36,12 @@ export function ShipHandoffBanner() {
           <FolderKanban className="size-3.5" />
           Open Projects
         </Link>
-        <span className="text-dim inline-flex h-8 items-center gap-1.5 rounded-md border border-dashed px-3 text-[11px]">
+        <span
+          className="text-dim inline-flex h-8 items-center gap-1.5 rounded-md border border-dashed px-3 text-[11px]"
+          title="Needs Han GitHub create-repo API"
+        >
           <Rocket className="size-3.5" />
-          GitHub init · Soon
+          GitHub init · needs API
         </span>
       </div>
     </div>

--- a/apps/aomi-build/src/features/build/components/smithers-nodes.tsx
+++ b/apps/aomi-build/src/features/build/components/smithers-nodes.tsx
@@ -1,25 +1,36 @@
 "use client";
 
-import { Bot, Check, Circle, Loader2 } from "lucide-react";
+import { Check, Circle, Loader2 } from "lucide-react";
 
 import type { SmithersNode } from "@build/features/build/contracts";
 import { cn } from "@build/lib/utils";
 
-type SmithersNodesProps = {
+type PlanNodesProps = {
   nodes: SmithersNode[];
+  /** Pass empty string to hide (parent section already titles the block). */
   caption?: string;
+  compact?: boolean;
 };
 
+/** Build plan steps — product labels only (no engine/codenames). */
 export function SmithersNodes({
   nodes,
-  caption = "Smithers nodes (local mock) — smither writes smither",
-}: SmithersNodesProps) {
+  caption = "Build plan",
+  compact = false,
+}: PlanNodesProps) {
   if (!nodes.length) return null;
 
   return (
-    <div className="border-border bg-surface-1 mx-auto my-4 max-w-3xl rounded-lg border p-4">
-      <p className="text-subtle mb-3 text-[12px] font-medium">{caption}</p>
-      <ul className="space-y-2">
+    <div
+      className={cn(
+        "border-border bg-surface-1 rounded-lg border",
+        compact ? "p-3" : "mx-auto my-2 max-w-3xl p-4",
+      )}
+    >
+      {caption ? (
+        <p className="text-subtle mb-3 text-[12px] font-medium">{caption}</p>
+      ) : null}
+      <ul className={cn("space-y-2", compact && "space-y-1.5")}>
         {nodes.map((node) => (
           <li
             key={node.id}
@@ -39,18 +50,19 @@ export function SmithersNodes({
                 <span className="text-foreground text-[13px] font-medium">
                   {node.label}
                 </span>
-                <span className="text-dim inline-flex items-center gap-1 text-[10px] uppercase tracking-wide">
-                  <Bot className="size-3" />
-                  {node.agent}
+                <span className="text-dim text-[10px] uppercase tracking-wide">
+                  {node.role}
                 </span>
               </div>
-              <p className="text-dim mt-0.5 text-[12px] leading-4">
-                {node.detail}
-              </p>
+              {!compact ? (
+                <p className="text-dim mt-0.5 text-[12px] leading-4">
+                  {node.detail}
+                </p>
+              ) : null}
             </div>
             <span
               className={cn(
-                "shrink-0 self-start text-[10px]",
+                "shrink-0 self-start text-[10px] capitalize",
                 node.status === "active"
                   ? "text-warning"
                   : node.status === "done"
@@ -58,7 +70,11 @@ export function SmithersNodes({
                     : "text-dim",
               )}
             >
-              {node.status}
+              {node.status === "done"
+                ? "Done"
+                : node.status === "active"
+                  ? "Running"
+                  : "Queued"}
             </span>
           </li>
         ))}

--- a/apps/aomi-build/src/features/build/components/smithers-nodes.tsx
+++ b/apps/aomi-build/src/features/build/components/smithers-nodes.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Bot, Check, Circle, Loader2 } from "lucide-react";
+
+import type { SmithersNode } from "@build/features/build/contracts";
+import { cn } from "@build/lib/utils";
+
+type SmithersNodesProps = {
+  nodes: SmithersNode[];
+  caption?: string;
+};
+
+export function SmithersNodes({
+  nodes,
+  caption = "Smithers nodes (local mock) — smither writes smither",
+}: SmithersNodesProps) {
+  if (!nodes.length) return null;
+
+  return (
+    <div className="border-border bg-surface-1 mx-auto my-4 max-w-3xl rounded-lg border p-4">
+      <p className="text-subtle mb-3 text-[12px] font-medium">{caption}</p>
+      <ul className="space-y-2">
+        {nodes.map((node) => (
+          <li
+            key={node.id}
+            className="border-border/80 bg-background flex gap-3 rounded-md border px-3 py-2.5"
+          >
+            <div className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center">
+              {node.status === "done" ? (
+                <Check className="text-positive size-3.5" />
+              ) : node.status === "active" ? (
+                <Loader2 className="text-warning size-3.5 animate-spin" />
+              ) : (
+                <Circle className="text-dim size-3" />
+              )}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-foreground text-[13px] font-medium">
+                  {node.label}
+                </span>
+                <span className="text-dim inline-flex items-center gap-1 text-[10px] uppercase tracking-wide">
+                  <Bot className="size-3" />
+                  {node.agent}
+                </span>
+              </div>
+              <p className="text-dim mt-0.5 text-[12px] leading-4">
+                {node.detail}
+              </p>
+            </div>
+            <span
+              className={cn(
+                "shrink-0 self-start text-[10px]",
+                node.status === "active"
+                  ? "text-warning"
+                  : node.status === "done"
+                    ? "text-positive"
+                    : "text-dim",
+              )}
+            >
+              {node.status}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/aomi-build/src/features/build/components/template-gallery.tsx
+++ b/apps/aomi-build/src/features/build/components/template-gallery.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { LayoutTemplate } from "lucide-react";
+import { useMemo, useState } from "react";
+import { ChevronDown, LayoutTemplate } from "lucide-react";
 
 import type { BuildTemplate } from "@build/features/build/contracts";
+import { FEATURED_TEMPLATE_IDS } from "@build/features/build/templates";
+import { cn } from "@build/lib/utils";
 
 type TemplateGalleryProps = {
   templates: BuildTemplate[];
@@ -10,14 +13,35 @@ type TemplateGalleryProps = {
 };
 
 export function TemplateGallery({ templates, onSelect }: TemplateGalleryProps) {
+  const [showAll, setShowAll] = useState(false);
+
+  const { featured, rest } = useMemo(() => {
+    const featuredList: BuildTemplate[] = [];
+    for (const id of FEATURED_TEMPLATE_IDS) {
+      const match = templates.find((t) => t.id === id);
+      if (match) featuredList.push(match);
+    }
+    while (featuredList.length < 3 && featuredList.length < templates.length) {
+      const next = templates.find((t) => !featuredList.includes(t));
+      if (!next) break;
+      featuredList.push(next);
+    }
+    const featuredIds = new Set(featuredList.map((t) => t.id));
+    return {
+      featured: featuredList,
+      rest: templates.filter((t) => !featuredIds.has(t.id)),
+    };
+  }, [templates]);
+
   return (
-    <div className="mt-8 w-full">
-      <div className="text-subtle mb-3 flex items-center gap-2 text-[12px] font-medium">
+    <div className="mt-5 w-full">
+      <div className="text-subtle mb-2.5 flex items-center gap-2 text-[12px] font-medium">
         <LayoutTemplate className="text-dim size-3.5" />
         Start from a template
       </div>
-      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-        {templates.map((template) => (
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+        {featured.map((template) => (
           <button
             key={template.id}
             type="button"
@@ -27,12 +51,49 @@ export function TemplateGallery({ templates, onSelect }: TemplateGalleryProps) {
             <p className="text-foreground text-[13px] font-medium">
               {template.name}
             </p>
-            <p className="text-subtle mt-0.5 line-clamp-2 text-[11px]">
+            <p className="text-subtle mt-0.5 line-clamp-2 text-[11px] leading-4">
               {template.description}
             </p>
           </button>
         ))}
       </div>
+
+      {rest.length > 0 ? (
+        <div className="mt-2">
+          <button
+            type="button"
+            onClick={() => setShowAll((v) => !v)}
+            className="text-dim hover:text-foreground inline-flex items-center gap-1 px-1 text-[11px] transition-colors"
+          >
+            <ChevronDown
+              className={cn(
+                "size-3 transition-transform",
+                showAll && "rotate-180",
+              )}
+            />
+            {showAll ? "Hide templates" : `Browse all (${rest.length})`}
+          </button>
+          {showAll ? (
+            <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-4">
+              {rest.map((template) => (
+                <button
+                  key={template.id}
+                  type="button"
+                  onClick={() => onSelect(template)}
+                  className="panel-row hover:border-border-hover hover:bg-accent-hover/40 text-left transition-colors"
+                >
+                  <p className="text-foreground text-[12px] font-medium">
+                    {template.name}
+                  </p>
+                  <p className="text-subtle mt-0.5 line-clamp-2 text-[10px] leading-4">
+                    {template.description}
+                  </p>
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/aomi-build/src/features/build/contracts.ts
+++ b/apps/aomi-build/src/features/build/contracts.ts
@@ -77,6 +77,17 @@ export type BuildSession = {
   messages: BuildMessage[];
   streamEvents: BuildStreamEvent[];
   fileTree: BuildFileNode[];
+  nodes?: SmithersNode[];
+};
+
+export type SmithersNodeStatus = "pending" | "active" | "done";
+
+export type SmithersNode = {
+  id: string;
+  label: string;
+  agent: "codex" | "claude" | "local";
+  detail: string;
+  status: SmithersNodeStatus;
 };
 
 export type BuildTemplate = {
@@ -146,14 +157,71 @@ export const generatedFileTree: BuildFileNode[] = [
   },
 ];
 
-export const mockBuildResponse = `Done. Here's what the local mock generated:
+export const mockBuildResponse = `Tool layer is done (local mock). Here's what was generated:
 
 - \`src/agent.ts\` — Main agent loop with retry logic
 - \`src/config.ts\` — Configuration management
 - \`src/handlers.ts\` — Event handlers for on-chain actions
 - \`tests/agent.test.ts\` — Unit tests
 
-Checks passed in the local mock. Next: ship to Projects / GitHub — real Smithers SSE is not wired yet.`;
+Next: **Compile**, then **test with aomi-run**, then ship to Projects / GitHub.
+Real Smithers SSE is not wired yet.`;
+
+/** Derive mock Smithers plan nodes from the user prompt (Cecilia wireframe). */
+export function deriveSmithersNodes(prompt: string): SmithersNode[] {
+  const lower = prompt.toLowerCase();
+  const nodes: SmithersNode[] = [
+    {
+      id: "node_compose",
+      label: "smithers compose",
+      agent: "local",
+      detail: "smither writes smither — compose the workflow graph",
+      status: "pending",
+    },
+  ];
+
+  if (lower.includes("hyperliquid") || lower.includes("hype")) {
+    nodes.push({
+      id: "node_hype",
+      label: "aomi-openapi-gen hype",
+      agent: "codex",
+      detail: "Generate Hyperliquid OpenAPI tools / client",
+      status: "pending",
+    });
+  }
+  if (lower.includes("binance")) {
+    nodes.push({
+      id: "node_binance",
+      label: "aomi-openapi-gen binance",
+      agent: "codex",
+      detail: "Generate Binance OpenAPI tools / client",
+      status: "pending",
+    });
+  }
+  if (
+    !lower.includes("hyperliquid") &&
+    !lower.includes("hype") &&
+    !lower.includes("binance")
+  ) {
+    nodes.push({
+      id: "node_openapi",
+      label: "aomi-openapi-gen",
+      agent: "codex",
+      detail: "Generate tools from API surface in the prompt",
+      status: "pending",
+    });
+  }
+
+  nodes.push({
+    id: "node_run",
+    label: "arb-bot aomi-run",
+    agent: "claude",
+    detail: "Smoke / exercise the agent with aomi-run (after compile)",
+    status: "pending",
+  });
+
+  return nodes;
+}
 
 export const seedBuildSessions: BuildSession[] = [
   {

--- a/apps/aomi-build/src/features/build/contracts.ts
+++ b/apps/aomi-build/src/features/build/contracts.ts
@@ -20,22 +20,22 @@ export const JOURNEY_STAGES: JourneyStage[] = [
   {
     id: "plan",
     title: "Plan",
-    detail: "Smithers nodes compose the work (codegen, tooling, APIs).",
+    detail: "Break the work into generate / compile / test steps.",
   },
   {
     id: "generate",
     title: "Generate",
-    detail: "Review the tool layer and source as it lands.",
+    detail: "Review tools and source as they land.",
   },
   {
     id: "compile_test",
     title: "Compile & test",
-    detail: "Compile, then exercise with aomi-run before you commit.",
+    detail: "Compile, then run a smoke test before you ship.",
   },
   {
     id: "ship",
     title: "Ship",
-    detail: "Download, init a GitHub repo, then deploy from Projects.",
+    detail: "Download, connect GitHub, then deploy from Projects.",
   },
 ];
 
@@ -80,15 +80,20 @@ export type BuildSession = {
   nodes?: SmithersNode[];
 };
 
-export type SmithersNodeStatus = "pending" | "active" | "done";
+export type PlanNodeStatus = "pending" | "active" | "done";
 
+/** Internal plan step — never show engine names (Smithers/codex) in UI labels. */
 export type SmithersNode = {
   id: string;
   label: string;
-  agent: "codex" | "claude" | "local";
+  /** Product-facing role chip, e.g. Planner / Generator / Tester */
+  role: string;
   detail: string;
-  status: SmithersNodeStatus;
+  status: PlanNodeStatus;
 };
+
+/** @deprecated use PlanNodeStatus */
+export type SmithersNodeStatus = PlanNodeStatus;
 
 export type BuildTemplate = {
   id: string;
@@ -114,29 +119,72 @@ export const STREAM_STAGE_LABELS: Record<BuildStreamStage, string> = {
   ready: "Ship",
 };
 
+/**
+ * Stage strip source of truth — gates beat optimistic stageId / stream "ready".
+ * Never highlight Ship while compile/smoke test are still open.
+ */
+export function resolveDisplayJourneyStage(input: {
+  stageId: JourneyStageId;
+  isGenerating: boolean;
+  awaitingVerify: boolean;
+  shipReady: boolean;
+  compileDone: boolean;
+  testDone: boolean;
+  verifyBusy: "compile" | "test" | null;
+  streamEvents: BuildStreamEvent[];
+  messageCount: number;
+}): JourneyStageId {
+  if (input.messageCount === 0) return "describe";
+  if (input.shipReady || (input.compileDone && input.testDone)) return "ship";
+  if (
+    input.awaitingVerify ||
+    input.verifyBusy !== null ||
+    (input.compileDone && !input.testDone)
+  ) {
+    return "compile_test";
+  }
+  if (input.isGenerating) {
+    const active = input.streamEvents.find((e) => e.status === "active");
+    if (active) {
+      if (active.stage === "ready" || active.stage === "validate") {
+        return "compile_test";
+      }
+      return STREAM_TO_JOURNEY[active.stage];
+    }
+    const lastDone = [...input.streamEvents]
+      .reverse()
+      .find((e) => e.status === "done");
+    if (lastDone?.stage === "plan") return "generate";
+    if (lastDone?.stage === "generate") return "compile_test";
+    return "plan";
+  }
+  if (input.stageId === "ship" && !input.shipReady) return "compile_test";
+  return input.stageId;
+}
+
 export const defaultStreamTemplate: BuildStreamEvent[] = [
   {
     time: "",
     stage: "plan",
-    message: "Analyzing prompt and composing Smithers plan.",
+    message: "Reading your intent and drafting a build plan.",
     status: "pending",
   },
   {
     time: "",
     stage: "generate",
-    message: "Generating project files and configuration.",
+    message: "Generating project files and tool wiring.",
     status: "pending",
   },
   {
     time: "",
     stage: "validate",
-    message: "Running compile and lint checks (local mock).",
+    message: "Ready for compile and smoke test.",
     status: "pending",
   },
   {
     time: "",
     stage: "ready",
-    message: "Artifacts ready — ship toward Projects / GitHub.",
+    message: "Waiting for compile + smoke test before ship.",
     status: "pending",
   },
 ];
@@ -157,25 +205,68 @@ export const generatedFileTree: BuildFileNode[] = [
   },
 ];
 
-export const mockBuildResponse = `Tool layer is done (local mock). Here's what was generated:
+/** Prompt-aware mock file tree so arb bots look different from generic agents. */
+export function deriveGeneratedFileTree(prompt: string): BuildFileNode[] {
+  const lower = prompt.toLowerCase();
+  const isArb =
+    lower.includes("arb") ||
+    lower.includes("hyperliquid") ||
+    lower.includes("binance");
+
+  if (!isArb) return generatedFileTree;
+
+  const exchanges: BuildFileNode[] = [];
+  if (lower.includes("hyperliquid") || lower.includes("hype") || !lower.includes("binance")) {
+    exchanges.push({
+      path: "arb-bot/src/exchanges/hyperliquid.ts",
+      type: "file",
+    });
+  }
+  if (lower.includes("binance") || !lower.includes("hyperliquid")) {
+    exchanges.push({
+      path: "arb-bot/src/exchanges/binance.ts",
+      type: "file",
+    });
+  }
+
+  return [
+    {
+      path: "arb-bot",
+      type: "folder",
+      children: [
+        { path: "arb-bot/src/agent.ts", type: "file" },
+        { path: "arb-bot/src/config.ts", type: "file" },
+        {
+          path: "arb-bot/src/exchanges",
+          type: "folder",
+          children: exchanges,
+        },
+        { path: "arb-bot/src/risk/limits.ts", type: "file" },
+        { path: "arb-bot/tests/agent.test.ts", type: "file" },
+        { path: "arb-bot/aomi.toml", type: "file" },
+      ],
+    },
+  ];
+}
+
+export const mockBuildResponse = `Tool layer is ready. Here's what was generated:
 
 - \`src/agent.ts\` — Main agent loop with retry logic
-- \`src/config.ts\` — Configuration management
-- \`src/handlers.ts\` — Event handlers for on-chain actions
+- \`src/config.ts\` — Configuration
+- \`src/handlers.ts\` — Event handlers
 - \`tests/agent.test.ts\` — Unit tests
 
-Next: **Compile**, then **test with aomi-run**, then ship to Projects / GitHub.
-Real Smithers SSE is not wired yet.`;
+Next: **Compile**, then run a **smoke test**, then ship to Projects.`;
 
-/** Derive mock Smithers plan nodes from the user prompt (Cecilia wireframe). */
+/** Derive mock plan nodes from the user prompt (product labels only). */
 export function deriveSmithersNodes(prompt: string): SmithersNode[] {
   const lower = prompt.toLowerCase();
   const nodes: SmithersNode[] = [
     {
       id: "node_compose",
-      label: "smithers compose",
-      agent: "local",
-      detail: "smither writes smither — compose the workflow graph",
+      label: "Compose plan",
+      role: "Planner",
+      detail: "Turn your intent into ordered build steps",
       status: "pending",
     },
   ];
@@ -183,18 +274,18 @@ export function deriveSmithersNodes(prompt: string): SmithersNode[] {
   if (lower.includes("hyperliquid") || lower.includes("hype")) {
     nodes.push({
       id: "node_hype",
-      label: "aomi-openapi-gen hype",
-      agent: "codex",
-      detail: "Generate Hyperliquid OpenAPI tools / client",
+      label: "Hyperliquid tools",
+      role: "Generator",
+      detail: "Scaffold exchange client and agent tools",
       status: "pending",
     });
   }
   if (lower.includes("binance")) {
     nodes.push({
       id: "node_binance",
-      label: "aomi-openapi-gen binance",
-      agent: "codex",
-      detail: "Generate Binance OpenAPI tools / client",
+      label: "Binance tools",
+      role: "Generator",
+      detail: "Scaffold exchange client and agent tools",
       status: "pending",
     });
   }
@@ -205,18 +296,18 @@ export function deriveSmithersNodes(prompt: string): SmithersNode[] {
   ) {
     nodes.push({
       id: "node_openapi",
-      label: "aomi-openapi-gen",
-      agent: "codex",
-      detail: "Generate tools from API surface in the prompt",
+      label: "API tools",
+      role: "Generator",
+      detail: "Scaffold tools from the APIs in your prompt",
       status: "pending",
     });
   }
 
   nodes.push({
     id: "node_run",
-    label: "arb-bot aomi-run",
-    agent: "claude",
-    detail: "Smoke / exercise the agent with aomi-run (after compile)",
+    label: "Smoke test",
+    role: "Tester",
+    detail: "Exercise the agent after compile",
     status: "pending",
   });
 
@@ -228,7 +319,7 @@ export const seedBuildSessions: BuildSession[] = [
     id: "run_1203_arb_bot",
     title: "Hyperliquid and Binance arb bot",
     status: "healthy",
-    model: "Local mock",
+    model: "Aomi",
     updatedAt: "2m ago",
     runtime: "5m 12s",
     stageId: "ship",
@@ -254,7 +345,7 @@ export const seedBuildSessions: BuildSession[] = [
 
 All checks passed. Ready to ship toward Projects.`,
         timestamp: "12:03",
-        model: "Local mock",
+        model: "Aomi",
       },
     ],
     streamEvents: [
@@ -279,7 +370,7 @@ All checks passed. Ready to ship toward Projects.`,
       {
         time: "12:03:02",
         stage: "ready",
-        message: "Artifacts ready. Ship toward Projects / GitHub.",
+        message: "Ready to ship — open Projects or download files.",
         status: "done",
       },
     ],

--- a/apps/aomi-build/src/features/build/hooks/use-build-session.ts
+++ b/apps/aomi-build/src/features/build/hooks/use-build-session.ts
@@ -5,6 +5,7 @@ import { useCallback, useRef, useState, useSyncExternalStore } from "react";
 import {
   STREAM_TO_JOURNEY,
   defaultStreamTemplate,
+  deriveSmithersNodes,
   generatedFileTree,
   mockBuildResponse,
   type BuildFileNode,
@@ -12,6 +13,7 @@ import {
   type BuildSession,
   type BuildStreamEvent,
   type JourneyStageId,
+  type SmithersNode,
 } from "@build/features/build/contracts";
 import {
   emptySessions,
@@ -33,15 +35,14 @@ function nowStamp() {
 }
 
 const stageMessages: Record<BuildStreamEvent["stage"], string> = {
-  plan: "Analyzing prompt and composing Smithers plan (local mock).",
+  plan: "Composing Smithers nodes from your intent (local mock).",
   generate: "Generating project files and configuration (local mock).",
-  validate: "Running compile, lint, and type checks (local mock).",
-  ready: "Artifacts ready. Ship toward Projects / GitHub.",
+  validate: "Tool layer ready — compile & aomi-run are next (local mock).",
+  ready: "Waiting for compile + aomi-run before ship.",
 };
 
 /**
- * Local Create-session driver with timer pipeline.
- * Honest mock until Han SSE — copy labels this as local mock.
+ * Local Create-session driver with timer pipeline + P3 verify gates.
  */
 export function useBuildSession() {
   const persistedSessions = useSyncExternalStore(
@@ -54,13 +55,26 @@ export function useBuildSession() {
   const [messages, setMessages] = useState<BuildMessage[]>([]);
   const [streamEvents, setStreamEvents] = useState<BuildStreamEvent[]>([]);
   const [fileTree, setFileTree] = useState<BuildFileNode[]>([]);
+  const [nodes, setNodes] = useState<SmithersNode[]>([]);
   const [isGenerating, setIsGenerating] = useState(false);
   const [streamingMessageId, setStreamingMessageId] = useState<string | null>(
     null,
   );
+  const [awaitingVerify, setAwaitingVerify] = useState(false);
+  const [compileDone, setCompileDone] = useState(false);
+  const [testDone, setTestDone] = useState(false);
+  const [verifyBusy, setVerifyBusy] = useState<"compile" | "test" | null>(null);
   const [shipReady, setShipReady] = useState(false);
   const [showStreamInThread, setShowStreamInThread] = useState(false);
   const timersRef = useRef<number[]>([]);
+  const sessionDraftRef = useRef<{
+    id: string;
+    title: string;
+    messages: BuildMessage[];
+    streamEvents: BuildStreamEvent[];
+    fileTree: BuildFileNode[];
+    nodes: SmithersNode[];
+  } | null>(null);
 
   const recentSessions = mergeSessions(persistedSessions);
 
@@ -79,22 +93,42 @@ export function useBuildSession() {
       setMessages(session.messages);
       setStreamEvents(session.streamEvents);
       setFileTree(session.fileTree);
-      setShipReady(session.status === "healthy");
+      setNodes(session.nodes ?? []);
+      const healthy = session.status === "healthy" && session.stageId === "ship";
+      setShipReady(healthy);
+      setAwaitingVerify(session.stageId === "compile_test" && !healthy);
+      setCompileDone(healthy || session.stageId === "ship");
+      setTestDone(healthy);
+      setVerifyBusy(null);
       setShowStreamInThread(false);
       setIsGenerating(false);
       setStreamingMessageId(null);
+      sessionDraftRef.current = {
+        id: session.id,
+        title: session.title,
+        messages: session.messages,
+        streamEvents: session.streamEvents,
+        fileTree: session.fileTree,
+        nodes: session.nodes ?? [],
+      };
     },
     [clearTimers, persistedSessions],
   );
 
   const startNewSession = useCallback(() => {
     clearTimers();
+    sessionDraftRef.current = null;
     setActiveSessionId(null);
     setStageId("describe");
     setMessages([]);
     setStreamEvents([]);
     setFileTree([]);
+    setNodes([]);
     setShipReady(false);
+    setAwaitingVerify(false);
+    setCompileDone(false);
+    setTestDone(false);
+    setVerifyBusy(null);
     setShowStreamInThread(false);
     setIsGenerating(false);
     setStreamingMessageId(null);
@@ -104,12 +138,17 @@ export function useBuildSession() {
     (userText: string, onAssistantReady: (msg: BuildMessage) => void) => {
       clearTimers();
       const sessionId = `run_${Date.now()}`;
+      const title =
+        userText.length > 48
+          ? `${userText.slice(0, 48).trim()}…`
+          : userText.trim();
       const userMsg: BuildMessage = {
         id: `u_${Date.now()}`,
         role: "user",
         content: userText,
         timestamp: nowTime(),
       };
+      const plannedNodes = deriveSmithersNodes(userText);
 
       setActiveSessionId(sessionId);
       setStageId("describe");
@@ -117,10 +156,24 @@ export function useBuildSession() {
       setIsGenerating(true);
       setShowStreamInThread(true);
       setShipReady(false);
+      setAwaitingVerify(false);
+      setCompileDone(false);
+      setTestDone(false);
+      setVerifyBusy(null);
+      setNodes(plannedNodes.map((n) => ({ ...n, status: "pending" })));
 
       const initial = defaultStreamTemplate.map((e) => ({ ...e }));
       setStreamEvents(initial);
       setFileTree([]);
+
+      sessionDraftRef.current = {
+        id: sessionId,
+        title: title || "New build",
+        messages: [userMsg],
+        streamEvents: initial,
+        fileTree: [],
+        nodes: plannedNodes,
+      };
 
       const stages: BuildStreamEvent["stage"][] = [
         "plan",
@@ -132,12 +185,12 @@ export function useBuildSession() {
       let finalMessages: BuildMessage[] = [userMsg];
       let finalStreamEvents = initial;
       let finalFileTree: BuildFileNode[] = [];
-      let finalStageId: JourneyStageId = "describe";
+      let finalNodes = plannedNodes;
 
       stages.forEach((stage, index) => {
         const timerId = window.setTimeout(() => {
-          finalStageId = STREAM_TO_JOURNEY[stage];
-          setStageId(finalStageId);
+          const journey = STREAM_TO_JOURNEY[stage];
+          setStageId(journey);
 
           setStreamEvents((prev) => {
             const next = prev.map((e) => {
@@ -159,12 +212,37 @@ export function useBuildSession() {
               return e;
             });
             finalStreamEvents = next;
+            if (sessionDraftRef.current) {
+              sessionDraftRef.current.streamEvents = next;
+            }
             return next;
           });
+
+          if (stage === "plan") {
+            finalNodes = plannedNodes.map((n, i) => ({
+              ...n,
+              status: i === 0 ? "active" : "pending",
+            }));
+            setNodes(finalNodes);
+            const activateRest = window.setTimeout(() => {
+              finalNodes = plannedNodes.map((n) => ({
+                ...n,
+                status: n.id === "node_run" ? "pending" : "done",
+              }));
+              setNodes(finalNodes);
+              if (sessionDraftRef.current) {
+                sessionDraftRef.current.nodes = finalNodes;
+              }
+            }, 500);
+            timersRef.current.push(activateRest);
+          }
 
           if (stage === "generate") {
             setFileTree(generatedFileTree);
             finalFileTree = generatedFileTree;
+            if (sessionDraftRef.current) {
+              sessionDraftRef.current.fileTree = finalFileTree;
+            }
           }
 
           if (stage === "ready") {
@@ -173,11 +251,13 @@ export function useBuildSession() {
                 ...e,
                 status: "done" as const,
               }));
+              if (sessionDraftRef.current) {
+                sessionDraftRef.current.streamEvents = finalStreamEvents;
+              }
               return finalStreamEvents;
             });
-            setShipReady(true);
-            setStageId("ship");
-            finalStageId = "ship";
+            setStageId("compile_test");
+            setAwaitingVerify(true);
 
             const assistantMsg: BuildMessage = {
               id: `a_${Date.now()}`,
@@ -188,27 +268,24 @@ export function useBuildSession() {
             };
             finalMessages = [...finalMessages, assistantMsg];
             setMessages(finalMessages);
+            if (sessionDraftRef.current) {
+              sessionDraftRef.current.messages = finalMessages;
+            }
             onAssistantReady(assistantMsg);
 
-            const title =
-              userText.length > 48
-                ? `${userText.slice(0, 48).trim()}…`
-                : userText.trim();
-
-            const session: BuildSession = {
+            savePersistedSession({
               id: sessionId,
               title: title || "New build",
-              status: "healthy",
+              status: "running",
               model: "Local mock",
               updatedAt: "just now",
               runtime: "local mock",
-              stageId: finalStageId,
+              stageId: "compile_test",
               messages: finalMessages,
               streamEvents: finalStreamEvents,
               fileTree: finalFileTree.length ? finalFileTree : generatedFileTree,
-            };
-
-            savePersistedSession(session);
+              nodes: finalNodes,
+            });
           }
         }, (index + 1) * 700);
         timersRef.current.push(timerId);
@@ -223,21 +300,80 @@ export function useBuildSession() {
     setShowStreamInThread(false);
   }, []);
 
+  const runCompile = useCallback(() => {
+    if (compileDone || verifyBusy) return;
+    setVerifyBusy("compile");
+    const id = window.setTimeout(() => {
+      setCompileDone(true);
+      setVerifyBusy(null);
+      setNodes((prev) =>
+        prev.map((n) =>
+          n.id === "node_run" ? n : { ...n, status: "done" as const },
+        ),
+      );
+    }, 600);
+    timersRef.current.push(id);
+  }, [compileDone, verifyBusy]);
+
+  const runTest = useCallback(() => {
+    if (!compileDone || testDone || verifyBusy) return;
+    setVerifyBusy("test");
+    setNodes((prev) =>
+      prev.map((n) =>
+        n.id === "node_run" ? { ...n, status: "active" as const } : n,
+      ),
+    );
+    const id = window.setTimeout(() => {
+      setTestDone(true);
+      setVerifyBusy(null);
+      setNodes((prev) =>
+        prev.map((n) => ({ ...n, status: "done" as const })),
+      );
+      setAwaitingVerify(false);
+      setShipReady(true);
+      setStageId("ship");
+      const draft = sessionDraftRef.current;
+      if (draft) {
+        savePersistedSession({
+          id: draft.id,
+          title: draft.title,
+          status: "healthy",
+          model: "Local mock",
+          updatedAt: "just now",
+          runtime: "local mock",
+          stageId: "ship",
+          messages: draft.messages,
+          streamEvents: draft.streamEvents,
+          fileTree: draft.fileTree,
+          nodes: draft.nodes.map((n) => ({ ...n, status: "done" })),
+        });
+      }
+    }, 700);
+    timersRef.current.push(id);
+  }, [compileDone, testDone, verifyBusy]);
+
   return {
     activeSessionId,
     stageId,
     messages,
     streamEvents,
     fileTree,
+    nodes,
     isGenerating,
     streamingMessageId,
     setStreamingMessageId,
+    awaitingVerify,
+    compileDone,
+    testDone,
+    verifyBusy,
     shipReady,
     showStreamInThread,
     loadSession,
     startNewSession,
     runBuildPipeline,
     handleStreamComplete,
+    runCompile,
+    runTest,
     recentSessions,
   };
 }

--- a/apps/aomi-build/src/features/build/hooks/use-build-session.ts
+++ b/apps/aomi-build/src/features/build/hooks/use-build-session.ts
@@ -5,8 +5,8 @@ import { useCallback, useRef, useState, useSyncExternalStore } from "react";
 import {
   STREAM_TO_JOURNEY,
   defaultStreamTemplate,
+  deriveGeneratedFileTree,
   deriveSmithersNodes,
-  generatedFileTree,
   mockBuildResponse,
   type BuildFileNode,
   type BuildMessage,
@@ -23,6 +23,7 @@ import {
   savePersistedSession,
   subscribeBuildSessions,
 } from "@build/features/build/storage/build-session-storage";
+import { sanitizeBuildSession } from "@build/features/build/storage/sanitize-session-copy";
 
 function nowTime() {
   const d = new Date();
@@ -35,10 +36,10 @@ function nowStamp() {
 }
 
 const stageMessages: Record<BuildStreamEvent["stage"], string> = {
-  plan: "Composing Smithers nodes from your intent (local mock).",
-  generate: "Generating project files and configuration (local mock).",
-  validate: "Tool layer ready — compile & aomi-run are next (local mock).",
-  ready: "Waiting for compile + aomi-run before ship.",
+  plan: "Reading your intent and drafting a build plan.",
+  generate: "Generating project files and tool wiring.",
+  validate: "Ready for compile and smoke test.",
+  ready: "Waiting for compile + smoke test before ship.",
 };
 
 /**
@@ -88,28 +89,54 @@ export function useBuildSession() {
       clearTimers();
       const session = findSessionById(sessionId, persistedSessions);
       if (!session) return;
+      const clean = sanitizeBuildSession(session);
+      const healthy = clean.status === "healthy" && clean.stageId === "ship";
+      const needsVerify =
+        !healthy &&
+        (clean.stageId === "compile_test" ||
+          clean.status === "running");
+      let streamEvents = clean.streamEvents;
+      if (needsVerify && streamEvents.length > 0) {
+        // Persisted mid-verify runs may wrongly mark Ship done — coerce.
+        streamEvents = streamEvents.map((e) => {
+          if (e.stage === "plan" || e.stage === "generate") {
+            return { ...e, status: "done" as const };
+          }
+          if (e.stage === "validate") {
+            return {
+              ...e,
+              status: "active" as const,
+              message: e.message || "Ready for compile and smoke test.",
+            };
+          }
+          return {
+            ...e,
+            status: "pending" as const,
+            message: e.message || "Waiting for compile + smoke test before ship.",
+          };
+        });
+      }
       setActiveSessionId(sessionId);
-      setStageId(session.stageId);
-      setMessages(session.messages);
-      setStreamEvents(session.streamEvents);
-      setFileTree(session.fileTree);
-      setNodes(session.nodes ?? []);
-      const healthy = session.status === "healthy" && session.stageId === "ship";
+      setStageId(healthy ? "ship" : needsVerify ? "compile_test" : clean.stageId);
+      setMessages(clean.messages);
+      setStreamEvents(streamEvents);
+      setFileTree(clean.fileTree);
+      setNodes(clean.nodes ?? []);
       setShipReady(healthy);
-      setAwaitingVerify(session.stageId === "compile_test" && !healthy);
-      setCompileDone(healthy || session.stageId === "ship");
+      setAwaitingVerify(needsVerify);
+      setCompileDone(healthy);
       setTestDone(healthy);
       setVerifyBusy(null);
       setShowStreamInThread(false);
       setIsGenerating(false);
       setStreamingMessageId(null);
       sessionDraftRef.current = {
-        id: session.id,
-        title: session.title,
-        messages: session.messages,
-        streamEvents: session.streamEvents,
-        fileTree: session.fileTree,
-        nodes: session.nodes ?? [],
+        id: clean.id,
+        title: clean.title,
+        messages: clean.messages,
+        streamEvents,
+        fileTree: clean.fileTree,
+        nodes: clean.nodes ?? [],
       };
     },
     [clearTimers, persistedSessions],
@@ -133,6 +160,39 @@ export function useBuildSession() {
     setIsGenerating(false);
     setStreamingMessageId(null);
   }, [clearTimers]);
+
+  const cancelPipeline = useCallback(() => {
+    clearTimers();
+    setIsGenerating(false);
+    setStreamingMessageId(null);
+    setVerifyBusy(null);
+    setShowStreamInThread(true);
+    setStreamEvents((prev) =>
+      prev.map((e) =>
+        e.status === "active" ? { ...e, status: "pending" as const } : e,
+      ),
+    );
+    setMessages((prev) => {
+      const next: BuildMessage[] = [
+        ...prev,
+        {
+          id: `sys_cancel_${Date.now()}`,
+          role: "system",
+          content:
+            "Stopped. Edit your prompt and run again, or continue compile / smoke test if files already exist.",
+          timestamp: nowTime(),
+        },
+      ];
+      if (sessionDraftRef.current) {
+        sessionDraftRef.current.messages = next;
+      }
+      return next;
+    });
+    if (fileTree.length > 0) {
+      setAwaitingVerify(true);
+      setStageId("compile_test");
+    }
+  }, [clearTimers, fileTree.length]);
 
   const runBuildPipeline = useCallback(
     (userText: string, onAssistantReady: (msg: BuildMessage) => void) => {
@@ -175,12 +235,7 @@ export function useBuildSession() {
         nodes: plannedNodes,
       };
 
-      const stages: BuildStreamEvent["stage"][] = [
-        "plan",
-        "generate",
-        "validate",
-        "ready",
-      ];
+      const stages: BuildStreamEvent["stage"][] = ["plan", "generate"];
 
       let finalMessages: BuildMessage[] = [userMsg];
       let finalStreamEvents = initial;
@@ -189,8 +244,7 @@ export function useBuildSession() {
 
       stages.forEach((stage, index) => {
         const timerId = window.setTimeout(() => {
-          const journey = STREAM_TO_JOURNEY[stage];
-          setStageId(journey);
+          setStageId(STREAM_TO_JOURNEY[stage]);
 
           setStreamEvents((prev) => {
             const next = prev.map((e) => {
@@ -238,19 +292,37 @@ export function useBuildSession() {
           }
 
           if (stage === "generate") {
-            setFileTree(generatedFileTree);
-            finalFileTree = generatedFileTree;
+            const tree = deriveGeneratedFileTree(userText);
+            setFileTree(tree);
+            finalFileTree = tree;
             if (sessionDraftRef.current) {
               sessionDraftRef.current.fileTree = finalFileTree;
             }
-          }
 
-          if (stage === "ready") {
+            // End of generate → enter verify gates (do not mark Ship done).
             setStreamEvents((prev) => {
-              finalStreamEvents = prev.map((e) => ({
-                ...e,
-                status: "done" as const,
-              }));
+              finalStreamEvents = prev.map((e) => {
+                if (e.stage === "plan" || e.stage === "generate") {
+                  return {
+                    ...e,
+                    status: "done" as const,
+                    time: e.time || nowStamp(),
+                  };
+                }
+                if (e.stage === "validate") {
+                  return {
+                    ...e,
+                    status: "active" as const,
+                    time: nowStamp(),
+                    message: stageMessages.validate,
+                  };
+                }
+                return {
+                  ...e,
+                  status: "pending" as const,
+                  message: stageMessages.ready,
+                };
+              });
               if (sessionDraftRef.current) {
                 sessionDraftRef.current.streamEvents = finalStreamEvents;
               }
@@ -258,13 +330,14 @@ export function useBuildSession() {
             });
             setStageId("compile_test");
             setAwaitingVerify(true);
+            setIsGenerating(false);
 
             const assistantMsg: BuildMessage = {
               id: `a_${Date.now()}`,
               role: "assistant",
               content: mockBuildResponse,
               timestamp: nowTime(),
-              model: "Local mock",
+              model: "Aomi",
             };
             finalMessages = [...finalMessages, assistantMsg];
             setMessages(finalMessages);
@@ -277,13 +350,16 @@ export function useBuildSession() {
               id: sessionId,
               title: title || "New build",
               status: "running",
-              model: "Local mock",
+              model: "Aomi",
               updatedAt: "just now",
-              runtime: "local mock",
+              runtime: "local",
               stageId: "compile_test",
               messages: finalMessages,
               streamEvents: finalStreamEvents,
-              fileTree: finalFileTree.length ? finalFileTree : generatedFileTree,
+              fileTree:
+                finalFileTree.length > 0
+                  ? finalFileTree
+                  : deriveGeneratedFileTree(userText),
               nodes: finalNodes,
             });
           }
@@ -303,6 +379,7 @@ export function useBuildSession() {
   const runCompile = useCallback(() => {
     if (compileDone || verifyBusy) return;
     setVerifyBusy("compile");
+    setStageId("compile_test");
     const id = window.setTimeout(() => {
       setCompileDone(true);
       setVerifyBusy(null);
@@ -311,6 +388,32 @@ export function useBuildSession() {
           n.id === "node_run" ? n : { ...n, status: "done" as const },
         ),
       );
+      setStreamEvents((prev) => {
+        const next = prev.map((e) => {
+          if (e.stage === "validate") {
+            return {
+              ...e,
+              status: "active" as const,
+              message: "Compile done — smoke test next.",
+              time: e.time || nowStamp(),
+            };
+          }
+          if (e.stage === "ready") {
+            return {
+              ...e,
+              status: "pending" as const,
+              message: "Ship after smoke test passes.",
+            };
+          }
+          return e.stage === "plan" || e.stage === "generate"
+            ? { ...e, status: "done" as const }
+            : e;
+        });
+        if (sessionDraftRef.current) {
+          sessionDraftRef.current.streamEvents = next;
+        }
+        return next;
+      });
     }, 600);
     timersRef.current.push(id);
   }, [compileDone, verifyBusy]);
@@ -318,6 +421,7 @@ export function useBuildSession() {
   const runTest = useCallback(() => {
     if (!compileDone || testDone || verifyBusy) return;
     setVerifyBusy("test");
+    setStageId("compile_test");
     setNodes((prev) =>
       prev.map((n) =>
         n.id === "node_run" ? { ...n, status: "active" as const } : n,
@@ -332,22 +436,45 @@ export function useBuildSession() {
       setAwaitingVerify(false);
       setShipReady(true);
       setStageId("ship");
-      const draft = sessionDraftRef.current;
-      if (draft) {
-        savePersistedSession({
-          id: draft.id,
-          title: draft.title,
-          status: "healthy",
-          model: "Local mock",
-          updatedAt: "just now",
-          runtime: "local mock",
-          stageId: "ship",
-          messages: draft.messages,
-          streamEvents: draft.streamEvents,
-          fileTree: draft.fileTree,
-          nodes: draft.nodes.map((n) => ({ ...n, status: "done" })),
-        });
-      }
+      setStreamEvents((prev) => {
+        const next = prev.map((e) => ({
+          ...e,
+          status: "done" as const,
+          message:
+            e.stage === "ready"
+              ? "Ready to ship — open Projects or download files."
+              : e.stage === "validate"
+                ? "Compile and smoke test passed."
+                : e.message,
+          time: e.time || nowStamp(),
+        }));
+        const draft = sessionDraftRef.current;
+        if (draft) {
+          const doneNodes = draft.nodes.map((n) => ({
+            ...n,
+            status: "done" as const,
+          }));
+          sessionDraftRef.current = {
+            ...draft,
+            streamEvents: next,
+            nodes: doneNodes,
+          };
+          savePersistedSession({
+            id: draft.id,
+            title: draft.title,
+            status: "healthy",
+            model: "Aomi",
+            updatedAt: "just now",
+            runtime: "local",
+            stageId: "ship",
+            messages: draft.messages,
+            streamEvents: next,
+            fileTree: draft.fileTree,
+            nodes: doneNodes,
+          });
+        }
+        return next;
+      });
     }, 700);
     timersRef.current.push(id);
   }, [compileDone, testDone, verifyBusy]);
@@ -370,6 +497,7 @@ export function useBuildSession() {
     showStreamInThread,
     loadSession,
     startNewSession,
+    cancelPipeline,
     runBuildPipeline,
     handleStreamComplete,
     runCompile,

--- a/apps/aomi-build/src/features/build/storage/build-session-storage.ts
+++ b/apps/aomi-build/src/features/build/storage/build-session-storage.ts
@@ -2,9 +2,14 @@ import {
   seedBuildSessions,
   type BuildSession,
 } from "@build/features/build/contracts";
+import {
+  sanitizeBuildSession,
+  sessionsNeedSanitize,
+} from "@build/features/build/storage/sanitize-session-copy";
 
 const STORAGE_KEY = "aomi-build-sessions-v1";
 const sessionListeners = new Set<() => void>();
+let didRewriteSanitized = false;
 
 function emitBuildSessionsChange() {
   sessionListeners.forEach((listener) => listener());
@@ -46,13 +51,31 @@ export function loadPersistedSessions(): BuildSession[] {
       value = emptySessions;
     }
   }
+
+  if (value.length > 0) {
+    const cleaned = value.map(sanitizeBuildSession);
+    if (sessionsNeedSanitize(value)) {
+      value = cleaned;
+      if (!didRewriteSanitized) {
+        didRewriteSanitized = true;
+        const nextRaw = JSON.stringify(cleaned);
+        queueMicrotask(() => {
+          localStorage.setItem(STORAGE_KEY, nextRaw);
+          sessionsCache = { raw: nextRaw, value: cleaned };
+          emitBuildSessionsChange();
+        });
+      }
+    }
+  }
+
   sessionsCache = { raw, value };
   return value;
 }
 
 export function savePersistedSession(session: BuildSession) {
-  const existing = loadPersistedSessions().filter((s) => s.id !== session.id);
-  const next = [session, ...existing].slice(0, 20);
+  const cleaned = sanitizeBuildSession(session);
+  const existing = loadPersistedSessions().filter((s) => s.id !== cleaned.id);
+  const next = [cleaned, ...existing].slice(0, 20);
   localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
   emitBuildSessionsChange();
 }

--- a/apps/aomi-build/src/features/build/storage/sanitize-session-copy.ts
+++ b/apps/aomi-build/src/features/build/storage/sanitize-session-copy.ts
@@ -1,0 +1,135 @@
+import type {
+  BuildMessage,
+  BuildSession,
+  BuildStreamEvent,
+  SmithersNode,
+} from "@build/features/build/contracts";
+
+/**
+ * Rewrite eng/mock jargon that may still live in localStorage from older
+ * Create sessions. Display-time safety net until storage is rewritten.
+ */
+
+const LEGACY_NODE_LABELS: Record<
+  string,
+  Pick<SmithersNode, "label" | "role" | "detail">
+> = {
+  "smithers compose": {
+    label: "Compose plan",
+    role: "Planner",
+    detail: "Turn your intent into ordered build steps",
+  },
+  "aomi-openapi-gen": {
+    label: "API tools",
+    role: "Generator",
+    detail: "Scaffold tools from the APIs in your prompt",
+  },
+  "aomi-openapi-gen hype": {
+    label: "Hyperliquid tools",
+    role: "Generator",
+    detail: "Scaffold exchange client and agent tools",
+  },
+  "aomi-openapi-gen binance": {
+    label: "Binance tools",
+    role: "Generator",
+    detail: "Scaffold exchange client and agent tools",
+  },
+  "arb-bot aomi-run": {
+    label: "Smoke test",
+    role: "Tester",
+    detail: "Exercise the agent after compile",
+  },
+};
+
+function roleFromLegacyAgent(agent: unknown): string {
+  if (agent === "local") return "Planner";
+  if (agent === "claude") return "Tester";
+  return "Generator";
+}
+
+function sanitizePlainText(raw: string): string {
+  return raw
+    .replace(/\bReal\s+Smithers\s+SSE\s+is\s+not\s+wired\s+yet\.?/gi, "")
+    .replace(/\bSmithers\s+SSE\b/gi, "live generate")
+    .replace(/\bComposing\s+Smithers\s+nodes\b/gi, "Drafting plan steps")
+    .replace(/\bSmithers\s+nodes\b/gi, "plan steps")
+    .replace(/\bSmithers\b/gi, "plan")
+    .replace(/\baomi-openapi-gen(?:\s+\w+)?/gi, "API tools")
+    .replace(/\barb-bot\s+aomi-run\b/gi, "Smoke test")
+    .replace(/\btest(?:ing)?\s+with\s+aomi-run\b/gi, "run a smoke test")
+    .replace(/\baomi-run\b/gi, "smoke test")
+    .replace(/\s*\(local\s+mock\)\.?/gi, "")
+    .replace(/\blocal\s+mock\b/gi, "")
+    .replace(/\s{2,}/g, " ")
+    .replace(/\s+([.,;:!])/g, "$1")
+    .replace(/\.\s*\./g, ".")
+    .trim();
+}
+
+function sanitizeModel(model: string | undefined): string | undefined {
+  if (!model) return model;
+  const lower = model.toLowerCase().trim();
+  if (
+    lower === "local mock" ||
+    lower === "aomi · local mock" ||
+    lower.includes("local mock")
+  ) {
+    return "Aomi";
+  }
+  return model;
+}
+
+function sanitizeMessage(message: BuildMessage): BuildMessage {
+  return {
+    ...message,
+    content: sanitizePlainText(message.content),
+    model: sanitizeModel(message.model),
+  };
+}
+
+function sanitizeStreamEvent(event: BuildStreamEvent): BuildStreamEvent {
+  return {
+    ...event,
+    message: sanitizePlainText(event.message),
+  };
+}
+
+function sanitizeNode(node: SmithersNode & { agent?: string }): SmithersNode {
+  const key = (node.label ?? "").toLowerCase().trim();
+  const mapped = LEGACY_NODE_LABELS[key];
+  if (mapped) {
+    return {
+      id: node.id,
+      label: mapped.label,
+      role: mapped.role,
+      detail: mapped.detail,
+      status: node.status,
+    };
+  }
+
+  const legacyAgent = "agent" in node ? node.agent : undefined;
+  return {
+    id: node.id,
+    label: sanitizePlainText(node.label),
+    role: node.role || roleFromLegacyAgent(legacyAgent),
+    detail: sanitizePlainText(node.detail),
+    status: node.status,
+  };
+}
+
+export function sanitizeBuildSession(session: BuildSession): BuildSession {
+  return {
+    ...session,
+    model: sanitizeModel(session.model) ?? "Aomi",
+    messages: session.messages.map(sanitizeMessage),
+    streamEvents: session.streamEvents.map(sanitizeStreamEvent),
+    nodes: session.nodes?.map((n) => sanitizeNode(n as SmithersNode & { agent?: string })),
+  };
+}
+
+export function sessionsNeedSanitize(sessions: BuildSession[]): boolean {
+  return sessions.some((session) => {
+    const cleaned = sanitizeBuildSession(session);
+    return JSON.stringify(cleaned) !== JSON.stringify(session);
+  });
+}

--- a/apps/aomi-build/src/features/build/templates.ts
+++ b/apps/aomi-build/src/features/build/templates.ts
@@ -1,5 +1,12 @@
 import type { BuildTemplate } from "@build/features/build/contracts";
 
+/** First-viewport starters on empty Create (order matters). */
+export const FEATURED_TEMPLATE_IDS = [
+  "tpl_arbitrage_bot",
+  "tpl_openapi_agent",
+  "tpl_trading_agent",
+] as const;
+
 export const BUILD_TEMPLATES: BuildTemplate[] = [
   {
     id: "tpl_arbitrage_bot",

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,8 @@
 
 ## Last Updated
 
+2026-07-14 — AI Builder P3 (#344): nodes + compile/aomi-run (review local first);
+2026-07-14 — AI Builder P0–P2 (#343): Create craft on /build;
 2026-07-14 — AI Builder P1 craft port: mock layout feel in ControlPlaneShell
   (composer, stream, files, ship→Projects, in-page history; local mock timers);
 2026-07-14 — AI Builder P1: intent composer + templates + local session;

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,9 @@
 
 ## Last Updated
 
+2026-07-14 — Create craft polish tranche (rail/empty/chat/stage/composer);
+2026-07-14 — Create craft review: jargon migrate + canvas;
+2026-07-14 — Create UI: builder language (no eng keywords in chat/sidebar);
 2026-07-14 — AI Builder P3 (#344): nodes + compile/aomi-run (review local first);
 2026-07-14 — AI Builder P0–P2 (#343): Create craft on /build;
 2026-07-14 — AI Builder P1 craft port: mock layout feel in ControlPlaneShell
@@ -18,6 +21,39 @@
 2026-07-13 — Build UI copy polish (em dashes / hedging essays);
 2026-07-13 — Billing option A: methods live on Chat (no fake Build fetch);
 2026-07-13 — BILLING-EXPERIENCE.md: backend ↔ UI map (code-checked)
+
+## Create craft polish tranche (2026-07-14)
+
+Shipped the review next-tranche on Create (`/build`):
+
+- Right rail: single Progress timeline + Files (removed duplicate Build plan).
+- Empty Create: top-anchored hero, 3 featured templates + Browse all.
+- Chat density: tighter message/banner spacing; less mid-thread void.
+- Stage strip: `resolveDisplayJourneyStage` + verify-gate stream honesty
+  (Compile & test stays active until smoke test; Ship only when shipReady).
+- Composer: Preview chip only (no stacked Aomi / model chip).
+
+## Create craft review + jargon migrate (2026-07-14)
+
+Screenshot review of empty Create + active session:
+
+- Stale localStorage still showed Local mock / Smithers / aomi-run after the
+  product-language pass — added `sanitize-session-copy` on load/save +
+  display guards; dropped redundant empty-state `aomi` chip and dual rail titles.
+- Craft canvas: `canvases/aomi-build-create-craft-review.canvas.tsx`
+- Follow-up tranche shipped (see above): rail / empty / chat / stage / composer.
+
+## Create product-language polish (2026-07-14)
+
+Branch `feat/build-p3-smithers-nodes`:
+
+- UI copy uses builder language only: Plan / Generator / Smoke test / Aomi /
+  Ready / Preview. Eng names (Smithers, aomi-run, Local mock, Han, etc.) stay
+  in types/comments, not rendered labels.
+- Chat: You (right) / Aomi (assistant) / quiet system; seed model = Aomi.
+- Sidebar sessions: Ready / In progress / Failed + journey stage titles.
+- Ship banner: Ready to ship + Download / Open Projects; GitHub init · soon.
+- Composer chip: Preview; blocked hint says smoke test (not aomi-run).
 
 ## AI Builder P1 craft port (2026-07-14)
 


### PR DESCRIPTION
## Summary
- Smithers **node cards** derived from prompt (openapi-gen hype/binance, compose, aomi-run)
- Explicit **Compile** → **Test with aomi-run** before ship banner
- Mock **Download code**; GitHub init labeled needs API
- Drop Multitask pill

## Depends on
Base = `feat/build-enable-route` ([#343](https://github.com/aomi-labs/aomi/pull/343)). Merge PR-A first (or retarget to main after A merges).

## Test plan
- [ ] On this branch: `pnpm run dev:aomi-build` → `/build`
- [ ] Arb-bot prompt → nodes appear → files → Compile → aomi-run → Download / Projects
- [ ] **Do not merge until Gordian clicks through locally**

## PR track
- PR-A #343 = P0–P2 craft
- **This PR = PR-B** (P3)
- PR-D later = Han SSE seams