### PR TITLE
fix(aomi-build): dedupe Recent sidebar session titles

### DIFF
--- a/apps/aomi-build/src/features/build/components/session-history.tsx
+++ b/apps/aomi-build/src/features/build/components/session-history.tsx
@@ -4,6 +4,7 @@ import { History } from "lucide-react";
 
 import type { BuildSession } from "@build/features/build/contracts";
 import { JOURNEY_STAGES } from "@build/features/build/contracts";
+import { disambiguateSessionTitles } from "@build/features/build/storage/session-title";
 import { cn } from "@build/lib/utils";
 
 type SessionHistoryProps = {
@@ -42,6 +43,8 @@ export function SessionHistory({
   onNewSession,
   className,
 }: SessionHistoryProps) {
+  const visible = disambiguateSessionTitles(sessions.slice(0, 12));
+
   return (
     <div className={cn("flex h-full flex-col gap-2", className)}>
       <div className="flex items-center justify-between gap-2 px-1">
@@ -63,7 +66,7 @@ export function SessionHistory({
             No builds yet. Describe an app to start.
           </p>
         ) : null}
-        {sessions.slice(0, 12).map((session) => (
+        {visible.map((session) => (
           <button
             key={session.id}
             type="button"

--- a/apps/aomi-build/src/features/build/hooks/use-build-session.ts
+++ b/apps/aomi-build/src/features/build/hooks/use-build-session.ts
@@ -24,6 +24,10 @@ import {
   subscribeBuildSessions,
 } from "@build/features/build/storage/build-session-storage";
 import { sanitizeBuildSession } from "@build/features/build/storage/sanitize-session-copy";
+import {
+  deriveSessionTitle,
+  uniqueSessionTitle,
+} from "@build/features/build/storage/session-title";
 
 function nowTime() {
   const d = new Date();
@@ -198,10 +202,10 @@ export function useBuildSession() {
     (userText: string, onAssistantReady: (msg: BuildMessage) => void) => {
       clearTimers();
       const sessionId = `run_${Date.now()}`;
-      const title =
-        userText.length > 48
-          ? `${userText.slice(0, 48).trim()}…`
-          : userText.trim();
+      const title = uniqueSessionTitle(
+        deriveSessionTitle(userText),
+        recentSessions.map((s) => s.title),
+      );
       const userMsg: BuildMessage = {
         id: `u_${Date.now()}`,
         role: "user",
@@ -367,7 +371,7 @@ export function useBuildSession() {
         timersRef.current.push(timerId);
       });
     },
-    [clearTimers],
+    [clearTimers, recentSessions],
   );
 
   const handleStreamComplete = useCallback(() => {

--- a/apps/aomi-build/src/features/build/storage/session-title.ts
+++ b/apps/aomi-build/src/features/build/storage/session-title.ts
@@ -1,0 +1,49 @@
+const GREETING_PREFIX =
+  /^(hey|hi|hello|yo|sup|hola|howdy)([,!.\s]+)/i;
+
+/**
+ * Build a sidebar title from the user prompt: drop greeting fluff,
+ * take the first clause, truncate cleanly.
+ */
+export function deriveSessionTitle(prompt: string, maxLen = 48): string {
+  let text = prompt.trim().replace(/\s+/g, " ");
+  text = text.replace(GREETING_PREFIX, "").trim();
+  const clause =
+    text.split(/[.!?\n]/).find((part) => part.trim().length > 0)?.trim() ??
+    text;
+  const cleaned = clause || "New build";
+  if (cleaned.length <= maxLen) return cleaned;
+  const cut = cleaned.slice(0, maxLen - 1);
+  const soft = cut.replace(/\s+\S*$/, "").trim();
+  return `${soft.length >= 12 ? soft : cut.trim()}…`;
+}
+
+/** Ensure titles stay unique in Recent (hello, hello (2), …). */
+export function uniqueSessionTitle(
+  base: string,
+  existingTitles: ReadonlyArray<string>,
+): string {
+  const normalized = base.trim() || "New build";
+  const taken = new Set(
+    existingTitles.map((t) => t.trim().toLowerCase()).filter(Boolean),
+  );
+  if (!taken.has(normalized.toLowerCase())) return normalized;
+
+  let n = 2;
+  while (taken.has(`${normalized.toLowerCase()} (${n})`)) n += 1;
+  return `${normalized} (${n})`;
+}
+
+/** Remaster list display so already-persisted dupes don't collide. */
+export function disambiguateSessionTitles<T extends { id: string; title: string }>(
+  sessions: T[],
+): T[] {
+  const seen = new Map<string, number>();
+  return sessions.map((session) => {
+    const key = session.title.trim().toLowerCase() || "new build";
+    const count = (seen.get(key) ?? 0) + 1;
+    seen.set(key, count);
+    if (count === 1) return session;
+    return { ...session, title: `${session.title.trim() || "New build"} (${count})` };
+  });
+}

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,7 @@
 
 ## Last Updated
 
+2026-07-14 — Create Recent titles: derive + dedupe (hello → unique);
 2026-07-14 — Create craft polish tranche (rail/empty/chat/stage/composer);
 2026-07-14 — Create craft review: jargon migrate + canvas;
 2026-07-14 — Create UI: builder language (no eng keywords in chat/sidebar);
@@ -21,6 +22,11 @@
 2026-07-13 — Build UI copy polish (em dashes / hedging essays);
 2026-07-13 — Billing option A: methods live on Chat (no fake Build fetch);
 2026-07-13 — BILLING-EXPERIENCE.md: backend ↔ UI map (code-checked)
+
+## Create Recent title dedupe (2026-07-14)
+
+- `deriveSessionTitle` strips greeting fluff + soft-truncates; `uniqueSessionTitle`
+  avoids colliding sidebar labels; list remasters persisted dupes for display.
 
 ## Create craft polish tranche (2026-07-14)
 


### PR DESCRIPTION
## Summary
- Derive Create session titles from the prompt (strip greeting fluff, soft truncate) instead of raw first-48 chars.
- Enforce unique titles on save and remaster already-persisted duplicates in the Recent list for display.

## Merge order
Merge **#343 → #344** first, then this PR (independent of the other Create leftover PRs after #344).

## Test plan
- [ ] Open `/build`, start a session with `hello` → Recent shows a useful title (or New build), not a raw greeting-only pile-up without distinction
- [ ] Start a second session with the same prompt → titles differ (`… (2)`)
- [ ] Start with `hello, build an arb bot` → title prefers the meaningful clause
- [ ] Existing localStorage dupes still look distinct in Recent