### PR TITLE
fix(aomi-build): hide Plan steps beside mobile Progress

### DIFF
--- a/apps/aomi-build/src/features/build/build-view.tsx
+++ b/apps/aomi-build/src/features/build/build-view.tsx
@@ -274,7 +274,7 @@ export function BuildView() {
       ? "Finish Compile → smoke test below, or start a new build (⌘N)."
       : undefined;
 
-  /** Unique plan steps only during plan/generate — not a second progress list. */
+  /** Plan steps in-thread on lg+ only — mobile already shows Progress. */
   const showPlanNodes =
     nodes.length > 0 &&
     isGenerating &&
@@ -409,7 +409,9 @@ export function BuildView() {
                   ) : null}
 
                   {showPlanNodes ? (
-                    <SmithersNodes nodes={nodes} caption="Plan steps" />
+                    <div className="hidden lg:block">
+                      <SmithersNodes nodes={nodes} caption="Plan steps" />
+                    </div>
                   ) : null}
 
                   {awaitingVerify ? (

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,7 @@
 
 ## Last Updated
 
+2026-07-14 — Create mobile: hide Plan steps when Progress is in-thread;
 2026-07-14 — Create craft polish tranche (rail/empty/chat/stage/composer);
 2026-07-14 — Create craft review: jargon migrate + canvas;
 2026-07-14 — Create UI: builder language (no eng keywords in chat/sidebar);
@@ -21,6 +22,11 @@
 2026-07-13 — Build UI copy polish (em dashes / hedging essays);
 2026-07-13 — Billing option A: methods live on Chat (no fake Build fetch);
 2026-07-13 — BILLING-EXPERIENCE.md: backend ↔ UI map (code-checked)
+
+## Create mobile Progress/Plan dedupe (2026-07-14)
+
+- On `<lg`, Plan-steps cards stay hidden during generate so they do not compete
+  with the in-thread Progress timeline (rail Progress is lg+ only).
 
 ## Create craft polish tranche (2026-07-14)
 


### PR DESCRIPTION
## Summary
- Hide in-thread Plan-steps cards below `lg` during generate so they do not compete with the mobile in-thread Progress timeline.
- Desktop (`lg+`) keeps Plan steps in-thread alongside the right-rail Progress.

## Merge order
Merge **#343 → #344** first, then this PR (independent of the other Create leftover PRs after #344).

## Test plan
- [ ] Narrow viewport (`<lg`): start a build → see Progress in-thread, **no** Plan-steps cards
- [ ] Wide viewport (`lg+`): start a build → Plan steps still appear in-thread; rail Progress still present
- [ ] After generate completes, compile/smoke panel still works on mobile