### PR TITLE
feat(aomi-build): UI-only model picker mock

### DIFF
--- a/apps/aomi-build/src/features/build/components/composer-model-picker.tsx
+++ b/apps/aomi-build/src/features/build/components/composer-model-picker.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { Check, ChevronDown } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+
+import { cn } from "@build/lib/utils";
+
+/**
+ * UI-only Create composer model list.
+ * Hardcoded — does not fetch models or invent a live backend catalog.
+ */
+const MODEL_OPTIONS = [
+  {
+    id: "aomi",
+    label: "Aomi",
+    available: true,
+    hint: "Current",
+  },
+  {
+    id: "auto",
+    label: "Auto",
+    available: false,
+    hint: "Soon",
+  },
+  {
+    id: "custom",
+    label: "Custom",
+    available: false,
+    hint: "Soon",
+  },
+] as const;
+
+const CURRENT_MODEL_ID = "aomi";
+
+type ComposerModelPickerProps = {
+  className?: string;
+  disabled?: boolean;
+};
+
+/**
+ * Cursor-like model control for Create. Selection stays on Aomi;
+ * other rows are honest Soon stubs until remote models exist.
+ */
+export function ComposerModelPicker({
+  className,
+  disabled = false,
+}: ComposerModelPickerProps) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const menuId = useId();
+  const current = MODEL_OPTIONS.find((m) => m.id === CURRENT_MODEL_ID)!;
+
+  useEffect(() => {
+    if (!open) return;
+
+    function onPointerDown(event: PointerEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className={cn("relative", className)}>
+      <button
+        type="button"
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={menuId}
+        onClick={() => setOpen((value) => !value)}
+        className={cn(
+          "context-chip gap-1 pr-1.5",
+          open && "bg-accent-selected text-foreground",
+          disabled && "pointer-events-none opacity-50",
+        )}
+        title="Model for Create (Preview)"
+      >
+        <span className="font-medium text-foreground">{current.label}</span>
+        <ChevronDown
+          className={cn(
+            "size-3.5 opacity-60 transition-transform duration-150",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+
+      {open ? (
+        <div
+          id={menuId}
+          role="listbox"
+          aria-label="Models"
+          className="border-border bg-popover text-popover-foreground absolute bottom-full left-0 z-50 mb-2 w-[220px] overflow-hidden rounded-xl border shadow-lg"
+        >
+          <div className="border-border/60 border-b px-3 py-2">
+            <p className="text-foreground text-[12px] font-medium">Model</p>
+            <p className="text-dim text-[11px] leading-snug">
+              Preview — remote models not connected yet
+            </p>
+          </div>
+
+          <ul className="p-1">
+            {MODEL_OPTIONS.map((option) => {
+              const selected = option.id === CURRENT_MODEL_ID;
+              return (
+                <li key={option.id} role="option" aria-selected={selected}>
+                  <button
+                    type="button"
+                    disabled={!option.available}
+                    onClick={() => {
+                      if (!option.available) return;
+                      setOpen(false);
+                    }}
+                    className={cn(
+                      "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-[13px] transition-colors duration-150",
+                      option.available
+                        ? "text-foreground hover:bg-accent-hover"
+                        : "text-dim cursor-not-allowed opacity-70",
+                      selected && "bg-accent-selected",
+                    )}
+                  >
+                    <span className="flex size-4 shrink-0 items-center justify-center">
+                      {selected ? (
+                        <Check className="text-foreground size-3.5" />
+                      ) : null}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate font-medium">
+                      {option.label}
+                    </span>
+                    <span
+                      className={cn(
+                        "shrink-0 text-[11px]",
+                        option.available ? "text-dim" : "text-hint",
+                      )}
+                    >
+                      {option.hint}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/aomi-build/src/features/build/components/intent-composer.tsx
+++ b/apps/aomi-build/src/features/build/components/intent-composer.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
 } from "react";
 
+import { ComposerModelPicker } from "@build/features/build/components/composer-model-picker";
 import { cn } from "@build/lib/utils";
 
 type ActionPill = {
@@ -38,8 +39,8 @@ type IntentComposerProps = {
 };
 
 /**
- * Intent composer — Preview honesty chip + send.
- * No stacked Aomi branding (shell already brands); no model picker yet.
+ * Intent composer — UI-only model picker + Preview honesty + send.
+ * Shell already brands Aomi; picker shows Aomi once as the current model.
  */
 export const IntentComposer = forwardRef<
   IntentComposerHandle,
@@ -133,13 +134,16 @@ export const IntentComposer = forwardRef<
         />
 
         <div className="mt-2.5 flex items-center justify-between gap-2">
-          <span
-            className="context-chip cursor-default"
-            title="Preview build — timers until remote generate is connected"
-          >
-            <Laptop className="size-3.5 opacity-70" />
-            Preview
-          </span>
+          <div className="flex min-w-0 items-center gap-1.5">
+            <ComposerModelPicker disabled={isLoading} />
+            <span
+              className="context-chip pointer-events-none cursor-default opacity-80"
+              title="Preview build — timers until remote generate is connected"
+            >
+              <Laptop className="size-3.5 opacity-70" />
+              Preview
+            </span>
+          </div>
 
           {isLoading && onStop ? (
             <button

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,7 @@
 
 ## Last Updated
 
+2026-07-14 — Create composer: UI-only model picker mock (Aomi + Soon);
 2026-07-14 — Create craft polish tranche (rail/empty/chat/stage/composer);
 2026-07-14 — Create craft review: jargon migrate + canvas;
 2026-07-14 — Create UI: builder language (no eng keywords in chat/sidebar);
@@ -22,6 +23,16 @@
 2026-07-13 — Billing option A: methods live on Chat (no fake Build fetch);
 2026-07-13 — BILLING-EXPERIENCE.md: backend ↔ UI map (code-checked)
 
+## Create composer model picker mock (2026-07-14)
+
+Branch `feat/build-model-picker-mock` (stack on #344):
+
+- Cursor-like model control on Create composer (`ComposerModelPicker`).
+- Current selection: **Aomi** only; Auto / Custom rows disabled with Soon.
+- Hardcoded mock — no Han API, no fake live model list fetch.
+- Keeps quiet **Preview** honesty chip beside the picker (no Aomi branding spam).
+- Product language only (no Smithers / eng jargon in UI).
+
 ## Create craft polish tranche (2026-07-14)
 
 Shipped the review next-tranche on Create (`/build`):
@@ -31,7 +42,8 @@ Shipped the review next-tranche on Create (`/build`):
 - Chat density: tighter message/banner spacing; less mid-thread void.
 - Stage strip: `resolveDisplayJourneyStage` + verify-gate stream honesty
   (Compile & test stays active until smoke test; Ship only when shipReady).
-- Composer: Preview chip only (no stacked Aomi / model chip).
+- Composer: Preview chip only (no stacked Aomi / model chip) — superseded by
+  model picker mock above for the picker PR.
 
 ## Create craft review + jargon migrate (2026-07-14)
 


### PR DESCRIPTION
## Summary
- Adds a Cursor-like **UI-only** model picker to the Create composer (`ComposerModelPicker`).
- Current selection stays **Aomi**; Auto / Custom rows are disabled with **Soon**.
- Keeps the quiet **Preview** honesty chip beside the picker (no stacked Aomi branding spam).
- Hardcoded mock only — no Han API, no fake live model catalog fetch.
- Light `specs/STATE.md` note.

**Merge after #344.** Separate from #345–#347 craft follow-ups.

## Test plan
- [ ] Open `/build` empty Create — composer shows `Aomi ▾` + `Preview` + send
- [ ] Open picker: Aomi checked/Current; Auto & Custom disabled with Soon
- [ ] Menu footer says Preview / remote models not connected (honest)
- [ ] No network calls for models in DevTools when opening the menu
- [ ] Active session compact composer still shows the same control
- [ ] Esc / click-outside closes the menu; no Smithers/eng jargon in UI labels