### PR TITLE
feat(aomi-build): Cursor-like Recent rail open/collapse

### DIFF
--- a/apps/aomi-build/src/features/build/build-view.tsx
+++ b/apps/aomi-build/src/features/build/build-view.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Files,
-  History,
   ListChecks,
   PanelLeftClose,
   PanelLeftOpen,
@@ -106,14 +105,14 @@ function ContextPanelSection({
  */
 export function BuildView() {
   const [input, setInput] = useState("");
-  const [recentOpen, setRecentOpen] = useState(getInitialRecentRailOpen);
+  // SSR-safe false; restore preference after mount to avoid hydration mismatch.
+  const [recentOpen, setRecentOpen] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const composerRef = useRef<IntentComposerHandle>(null);
   const { toast } = useToast();
 
-  const setRecentRailOpen = useCallback((open: boolean) => {
-    setRecentOpen(open);
-    writeRecentRailPreference(open);
+  useEffect(() => {
+    setRecentOpen(getInitialRecentRailOpen());
   }, []);
 
   const toggleRecentRail = useCallback(() => {
@@ -323,22 +322,9 @@ export function BuildView() {
             activeSessionId={activeSessionId}
             onSelect={handleSelectSession}
             onNewSession={handleNewSession}
-            onCollapse={() => setRecentRailOpen(false)}
           />
         </aside>
-      ) : (
-        <aside className="border-border flex w-10 shrink-0 flex-col items-center gap-2 border-r py-2">
-          <button
-            type="button"
-            onClick={() => setRecentRailOpen(true)}
-            className="text-dim hover:bg-accent/40 hover:text-foreground inline-flex size-7 items-center justify-center rounded-md transition-colors"
-            title="Show Recent (⌘B)"
-            aria-label="Show Recent"
-          >
-            <History className="size-3.5" />
-          </button>
-        </aside>
-      )}
+      ) : null}
 
       <section className="bg-background flex min-w-0 flex-1 flex-col">
         <div className="border-border flex h-10 shrink-0 items-center justify-between gap-2 border-b px-3 sm:px-4">

--- a/apps/aomi-build/src/features/build/build-view.tsx
+++ b/apps/aomi-build/src/features/build/build-view.tsx
@@ -1,7 +1,15 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Files, ListChecks, Plus, Square } from "lucide-react";
+import {
+  Files,
+  History,
+  ListChecks,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Plus,
+  Square,
+} from "lucide-react";
 
 import { useToast } from "@build/components/control-plane/toast";
 import { BuildStreamTimeline } from "@build/features/build/components/build-stream-timeline";
@@ -26,6 +34,10 @@ import {
 } from "@build/features/build/contracts";
 import { useBuildSession } from "@build/features/build/hooks/use-build-session";
 import { useStreamingText } from "@build/features/build/hooks/use-streaming-text";
+import {
+  getInitialRecentRailOpen,
+  writeRecentRailPreference,
+} from "@build/features/build/storage/recent-rail-preference";
 import { BUILD_TEMPLATES } from "@build/features/build/templates";
 import { cn } from "@build/lib/utils";
 
@@ -94,9 +106,23 @@ function ContextPanelSection({
  */
 export function BuildView() {
   const [input, setInput] = useState("");
+  const [recentOpen, setRecentOpen] = useState(getInitialRecentRailOpen);
   const scrollRef = useRef<HTMLDivElement>(null);
   const composerRef = useRef<IntentComposerHandle>(null);
   const { toast } = useToast();
+
+  const setRecentRailOpen = useCallback((open: boolean) => {
+    setRecentOpen(open);
+    writeRecentRailPreference(open);
+  }, []);
+
+  const toggleRecentRail = useCallback(() => {
+    setRecentOpen((prev) => {
+      const next = !prev;
+      writeRecentRailPreference(next);
+      return next;
+    });
+  }, []);
 
   const {
     activeSessionId,
@@ -173,16 +199,24 @@ export function BuildView() {
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "n") {
+      if (!(e.metaKey || e.ctrlKey) || e.altKey) return;
+      const key = e.key.toLowerCase();
+      if (key === "n") {
         e.preventDefault();
         startNewSession();
         setInput("");
         requestAnimationFrame(() => composerRef.current?.focus());
+        return;
+      }
+      // Shell sidebar is click-only; ⌘B toggles Create Recent rail.
+      if (key === "b") {
+        e.preventDefault();
+        toggleRecentRail();
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [startNewSession]);
+  }, [startNewSession, toggleRecentRail]);
 
   const handleSend = useCallback(() => {
     const text = input.trim();
@@ -282,42 +316,73 @@ export function BuildView() {
 
   return (
     <div className="flex h-[calc(100dvh-2.75rem)] min-h-0 w-full">
-      <aside className="border-border hidden w-[220px] shrink-0 flex-col gap-3 overflow-y-auto border-r p-3 xl:flex">
-        <SessionHistory
-          sessions={recentSessions}
-          activeSessionId={activeSessionId}
-          onSelect={handleSelectSession}
-          onNewSession={handleNewSession}
-        />
-      </aside>
+      {recentOpen ? (
+        <aside className="border-border flex w-[220px] shrink-0 flex-col gap-3 overflow-y-auto border-r p-3">
+          <SessionHistory
+            sessions={recentSessions}
+            activeSessionId={activeSessionId}
+            onSelect={handleSelectSession}
+            onNewSession={handleNewSession}
+            onCollapse={() => setRecentRailOpen(false)}
+          />
+        </aside>
+      ) : (
+        <aside className="border-border flex w-10 shrink-0 flex-col items-center gap-2 border-r py-2">
+          <button
+            type="button"
+            onClick={() => setRecentRailOpen(true)}
+            className="text-dim hover:bg-accent/40 hover:text-foreground inline-flex size-7 items-center justify-center rounded-md transition-colors"
+            title="Show Recent (⌘B)"
+            aria-label="Show Recent"
+          >
+            <History className="size-3.5" />
+          </button>
+        </aside>
+      )}
 
       <section className="bg-background flex min-w-0 flex-1 flex-col">
         <div className="border-border flex h-10 shrink-0 items-center justify-between gap-2 border-b px-3 sm:px-4">
-          {!isEmpty ? (
-            <ol className="hidden min-w-0 flex-1 flex-wrap items-center gap-1.5 sm:flex">
-              {JOURNEY_STAGES.map((stage, index) => {
-                const active = index === stageIndex;
-                const done = index < stageIndex;
-                return (
-                  <li
-                    key={stage.id}
-                    className={cn(
-                      "rounded-full border px-2 py-0.5 text-[10px]",
-                      active
-                        ? "border-foreground/30 text-foreground bg-surface-1"
-                        : done
-                          ? "border-border text-dim"
-                          : "border-border/60 text-dim/70",
-                    )}
-                  >
-                    {stage.title}
-                  </li>
-                );
-              })}
-            </ol>
-          ) : (
-            <p className="text-dim text-[12px]">Create</p>
-          )}
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <button
+              type="button"
+              onClick={toggleRecentRail}
+              className="text-dim hover:bg-accent/40 hover:text-foreground inline-flex size-7 shrink-0 items-center justify-center rounded-md transition-colors"
+              title={recentOpen ? "Hide Recent (⌘B)" : "Show Recent (⌘B)"}
+              aria-label={recentOpen ? "Hide Recent" : "Show Recent"}
+              aria-pressed={recentOpen}
+            >
+              {recentOpen ? (
+                <PanelLeftClose className="size-3.5" />
+              ) : (
+                <PanelLeftOpen className="size-3.5" />
+              )}
+            </button>
+            {!isEmpty ? (
+              <ol className="hidden min-w-0 flex-1 flex-wrap items-center gap-1.5 sm:flex">
+                {JOURNEY_STAGES.map((stage, index) => {
+                  const active = index === stageIndex;
+                  const done = index < stageIndex;
+                  return (
+                    <li
+                      key={stage.id}
+                      className={cn(
+                        "rounded-full border px-2 py-0.5 text-[10px]",
+                        active
+                          ? "border-foreground/30 text-foreground bg-surface-1"
+                          : done
+                            ? "border-border text-dim"
+                            : "border-border/60 text-dim/70",
+                      )}
+                    >
+                      {stage.title}
+                    </li>
+                  );
+                })}
+              </ol>
+            ) : (
+              <p className="text-dim text-[12px]">Create</p>
+            )}
+          </div>
 
           <div className="ml-auto flex shrink-0 items-center gap-1.5">
             {isGenerating ? (

--- a/apps/aomi-build/src/features/build/components/session-history.tsx
+++ b/apps/aomi-build/src/features/build/components/session-history.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { History } from "lucide-react";
+import { History, PanelLeftClose } from "lucide-react";
 
 import type { BuildSession } from "@build/features/build/contracts";
 import { JOURNEY_STAGES } from "@build/features/build/contracts";
@@ -11,6 +11,8 @@ type SessionHistoryProps = {
   activeSessionId: string | null;
   onSelect: (id: string) => void;
   onNewSession: () => void;
+  /** Hide Recent rail (Cursor-style collapse). */
+  onCollapse?: () => void;
   className?: string;
 };
 
@@ -40,6 +42,7 @@ export function SessionHistory({
   activeSessionId,
   onSelect,
   onNewSession,
+  onCollapse,
   className,
 }: SessionHistoryProps) {
   return (
@@ -49,13 +52,26 @@ export function SessionHistory({
           <History className="text-dim size-3.5" />
           Recent
         </div>
-        <button
-          type="button"
-          onClick={onNewSession}
-          className="text-dim hover:text-foreground text-[11px] transition-colors"
-        >
-          New
-        </button>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={onNewSession}
+            className="text-dim hover:text-foreground text-[11px] transition-colors"
+          >
+            New
+          </button>
+          {onCollapse ? (
+            <button
+              type="button"
+              onClick={onCollapse}
+              className="text-dim hover:bg-accent/40 hover:text-foreground inline-flex size-6 items-center justify-center rounded-md transition-colors"
+              title="Hide Recent (⌘B)"
+              aria-label="Hide Recent"
+            >
+              <PanelLeftClose className="size-3.5" />
+            </button>
+          ) : null}
+        </div>
       </div>
       <div className="min-h-0 flex-1 space-y-1 overflow-y-auto">
         {sessions.length === 0 ? (

--- a/apps/aomi-build/src/features/build/components/session-history.tsx
+++ b/apps/aomi-build/src/features/build/components/session-history.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { History, PanelLeftClose } from "lucide-react";
+import { History } from "lucide-react";
 
 import type { BuildSession } from "@build/features/build/contracts";
 import { JOURNEY_STAGES } from "@build/features/build/contracts";
@@ -11,8 +11,6 @@ type SessionHistoryProps = {
   activeSessionId: string | null;
   onSelect: (id: string) => void;
   onNewSession: () => void;
-  /** Hide Recent rail (Cursor-style collapse). */
-  onCollapse?: () => void;
   className?: string;
 };
 
@@ -42,7 +40,6 @@ export function SessionHistory({
   activeSessionId,
   onSelect,
   onNewSession,
-  onCollapse,
   className,
 }: SessionHistoryProps) {
   return (
@@ -52,26 +49,13 @@ export function SessionHistory({
           <History className="text-dim size-3.5" />
           Recent
         </div>
-        <div className="flex items-center gap-1">
-          <button
-            type="button"
-            onClick={onNewSession}
-            className="text-dim hover:text-foreground text-[11px] transition-colors"
-          >
-            New
-          </button>
-          {onCollapse ? (
-            <button
-              type="button"
-              onClick={onCollapse}
-              className="text-dim hover:bg-accent/40 hover:text-foreground inline-flex size-6 items-center justify-center rounded-md transition-colors"
-              title="Hide Recent (⌘B)"
-              aria-label="Hide Recent"
-            >
-              <PanelLeftClose className="size-3.5" />
-            </button>
-          ) : null}
-        </div>
+        <button
+          type="button"
+          onClick={onNewSession}
+          className="text-dim hover:text-foreground text-[11px] transition-colors"
+        >
+          New
+        </button>
       </div>
       <div className="min-h-0 flex-1 space-y-1 overflow-y-auto">
         {sessions.length === 0 ? (

--- a/apps/aomi-build/src/features/build/storage/recent-rail-preference.ts
+++ b/apps/aomi-build/src/features/build/storage/recent-rail-preference.ts
@@ -1,0 +1,41 @@
+const STORAGE_KEY = "aomi-build-recent-rail-open";
+
+/** xl breakpoint — matches Tailwind `xl:` used elsewhere on Create. */
+const XL_MEDIA = "(min-width: 1280px)";
+
+/**
+ * Read persisted Recent-rail preference.
+ * `null` = never toggled; caller should use viewport default.
+ */
+export function readRecentRailPreference(): boolean | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === "1") return true;
+    if (raw === "0") return false;
+  } catch {
+    // ignore quota / private mode
+  }
+  return null;
+}
+
+export function writeRecentRailPreference(open: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, open ? "1" : "0");
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
+/** First-visit default: open on xl+, closed below. */
+export function defaultRecentRailOpen(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia(XL_MEDIA).matches;
+}
+
+export function getInitialRecentRailOpen(): boolean {
+  const stored = readRecentRailPreference();
+  if (stored !== null) return stored;
+  return defaultRecentRailOpen();
+}

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,7 @@
 
 ## Last Updated
 
+2026-07-14 — Create Recent rail UX: one Create-header toggle (no double collapse);
 2026-07-14 — Create Recent rail: user open/collapse + localStorage (⌘B);
 2026-07-14 — Create craft polish tranche (rail/empty/chat/stage/composer);
 2026-07-14 — Create craft review: jargon migrate + canvas;
@@ -27,10 +28,11 @@
 
 Branch `feat/build-recent-sidebar-toggle` (stack on #344 / p3):
 
-- Recent session rail is user-collapsible (not only `xl:flex`).
-- Header toggle + narrow History rail when closed; collapse in Recent header.
-- Preference persisted in localStorage; first visit defaults open on xl+.
-- ⌘/Ctrl+B toggles Recent (shell nav remains click-only).
+- Single mental model: Recent open OR closed.
+- Primary control: Create header panel icon (always visible); ⌘/Ctrl+B same state.
+- Closed = no left rail (header toggle reopens); removed in-Recent collapse + narrow History rail.
+- Preference persisted in localStorage; first visit defaults open on xl+ (after mount; SSR-safe).
+- Shell nav remains click-only.
 
 ## Create craft polish tranche (2026-07-14)
 

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,7 @@
 
 ## Last Updated
 
+2026-07-14 — Create Recent rail: user open/collapse + localStorage (⌘B);
 2026-07-14 — Create craft polish tranche (rail/empty/chat/stage/composer);
 2026-07-14 — Create craft review: jargon migrate + canvas;
 2026-07-14 — Create UI: builder language (no eng keywords in chat/sidebar);
@@ -21,6 +22,15 @@
 2026-07-13 — Build UI copy polish (em dashes / hedging essays);
 2026-07-13 — Billing option A: methods live on Chat (no fake Build fetch);
 2026-07-13 — BILLING-EXPERIENCE.md: backend ↔ UI map (code-checked)
+
+## Create Recent sidebar toggle (2026-07-14)
+
+Branch `feat/build-recent-sidebar-toggle` (stack on #344 / p3):
+
+- Recent session rail is user-collapsible (not only `xl:flex`).
+- Header toggle + narrow History rail when closed; collapse in Recent header.
+- Preference persisted in localStorage; first visit defaults open on xl+.
+- ⌘/Ctrl+B toggles Recent (shell nav remains click-only).
 
 ## Create craft polish tranche (2026-07-14)
 


### PR DESCRIPTION
## Summary
- Replace viewport-only (`xl:flex`) Create Recent rail with a user-controlled open/collapse (header toggle, narrow History rail when closed, collapse in Recent header).
- Persist preference in `localStorage`; first visit defaults open on xl+ / closed below.
- ⌘/Ctrl+B toggles Recent (control-plane shell sidebar stays click-only).

Stacked on [#344](https://github.com/aomi-labs/aomi/pull/344) (`feat/build-p3-smithers-nodes`). Merge after #344.

## Test plan
- [ ] On `/build` below xl: Recent starts closed; open via History rail or header Panel icon; list is usable.
- [ ] On xl+: Recent starts open; collapse via header, Recent header control, or ⌘B.
- [ ] Refresh remembers last open/closed choice.
- [ ] ⌘N still starts a new session; shell nav expand/collapse still click-only.
- [ ] Copy stays product language (Recent / Show Recent / Hide Recent).