### PR TITLE
feat(aomi-build): Docs + Home page links in account menu

### DIFF
--- a/apps/aomi-build/src/components/control-plane/control-plane-shell.tsx
+++ b/apps/aomi-build/src/components/control-plane/control-plane-shell.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
   Activity,
+  BookOpen,
   CircleUserRound,
   Github,
   FolderKanban,
@@ -507,6 +508,25 @@ function AccountMenu({
           <Settings className="size-3.5" />
           Settings
         </Link>
+        <div className="bg-border -mx-1 my-1 h-px" />
+        <a
+          href="https://aomi.dev/docs"
+          target="_blank"
+          rel="noreferrer"
+          className="hover:bg-accent-hover hover:text-foreground flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs transition"
+        >
+          <BookOpen className="size-3.5" />
+          Docs
+        </a>
+        <a
+          href="https://aomi.dev"
+          target="_blank"
+          rel="noreferrer"
+          className="hover:bg-accent-hover hover:text-foreground flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs transition"
+        >
+          <Home className="size-3.5" />
+          Home page
+        </a>
         <div className="bg-border -mx-1 my-1 h-px" />
         <button
           type="button"

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,7 @@
 
 ## Last Updated
 
+2026-07-14 — Account menu: Docs (aomi.dev/docs) + Home page links (Vercel-style);
 2026-07-14 — Build P2 deep-link polish (⌘K / Billing / Overview → right tab);
 2026-07-14 — Create stack #343–#349 merged to main (left #340);
 2026-07-14 — Create Recent rail UX: one Create-header toggle (no double collapse);


### PR DESCRIPTION
## Summary
- Account menu now links to **Docs** (https://aomi.dev/docs) and **Home page** (https://aomi.dev), grouped above Sign out — Vercel-style
- Deferred (no real destinations yet): Feedback, Theme toggle (dark-only today), Changelog, status line

## Test plan
- [ ] `pnpm run dev:aomi-build` → avatar menu (top right)
- [ ] Docs opens aomi.dev/docs in new tab; Home page opens aomi.dev
- [ ] Sign in/out rows unaffected