### PR TITLE
Portal MCP: describe skills and activate them explicitly

### DIFF
--- a/apps/portal/src/server/mcp/backend.ts
+++ b/apps/portal/src/server/mcp/backend.ts
@@ -38,7 +38,12 @@ export async function resourceGet(
 export async function toolCall(
   canonicalUserId: string,
   threadId: string,
-  body: { tool_id: string; arguments: Record<string, unknown>; app?: string },
+  body: {
+    tool_id: string;
+    arguments: Record<string, unknown>;
+    app?: string;
+    skills?: string[];
+  },
 ): Promise<BackendResult> {
   const { bearer } = await mintAccountBearer(canonicalUserId);
   return backendJson(new URL(`${configuredBackendUrl()}/api/exec/tool-call`), {
@@ -55,7 +60,7 @@ export async function toolCall(
 export async function execRun(
   canonicalUserId: string,
   threadId: string,
-  body: { program: string; app?: string },
+  body: { program: string; app?: string; skills?: string[] },
 ): Promise<BackendResult> {
   const { bearer } = await mintAccountBearer(canonicalUserId);
   return backendJson(new URL(`${configuredBackendUrl()}/api/exec/run`), {

--- a/apps/portal/src/server/mcp/tools.test.ts
+++ b/apps/portal/src/server/mcp/tools.test.ts
@@ -53,6 +53,7 @@ describe("MCP tool inventory", () => {
         "aomi_list_tools",
         "aomi_search_tools",
         "aomi_describe_tool",
+        "aomi_describe_skill",
         "aomi_call_tool",
         "aomi_run",
       ]),
@@ -112,6 +113,45 @@ describe("dispatchTool routing", () => {
       arguments: { chain: "1" },
       app: "default",
     });
+  });
+
+  it("aomi_describe_skill -> GET /api/resource/skills/{skill_id}", async () => {
+    await dispatchTool(USER, "aomi_describe_skill", { skill_id: "aave" });
+    expect(resourceGetMock).toHaveBeenCalledWith(
+      USER,
+      "/api/resource/skills/aave",
+    );
+  });
+
+  it("aomi_describe_skill requires skill_id", async () => {
+    const out = await dispatchTool(USER, "aomi_describe_skill", {});
+    expect(out.isError).toBe(true);
+    expect(resourceGetMock).not.toHaveBeenCalled();
+  });
+
+  it("aomi_call_tool forwards explicit skills for instruction-pack guards", async () => {
+    await dispatchTool(USER, "aomi_call_tool", {
+      tool_id: "encode_and_call",
+      arguments: {},
+      skills: ["aave"],
+    });
+    expect(toolCallMock).toHaveBeenCalledWith(
+      USER,
+      "thread-deterministic",
+      expect.objectContaining({ tool_id: "encode_and_call", skills: ["aave"] }),
+    );
+  });
+
+  it("aomi_run forwards explicit skills for instruction-pack guards", async () => {
+    await dispatchTool(USER, "aomi_run", {
+      program: "quote a=1",
+      skills: ["aave", "lido"],
+    });
+    expect(execRunMock).toHaveBeenCalledWith(
+      USER,
+      "thread-deterministic",
+      expect.objectContaining({ skills: ["aave", "lido"] }),
+    );
   });
 
   it("aomi_run -> POST /api/exec/run with program + app + deterministic thread", async () => {

--- a/apps/portal/src/server/mcp/tools.ts
+++ b/apps/portal/src/server/mcp/tools.ts
@@ -64,7 +64,7 @@ export const MCP_TOOLS: McpToolDef[] = [
   {
     name: "aomi_search_tools",
     description:
-      "Ranked search for tools — the fast narrow pass. Scoped to one app when app is given, global when omitted. Prefer this over aomi_list_tools + aomi_describe_tool when you know the capability you want. Returns scored candidates with match reasons; call aomi_describe_tool for the exact schema before aomi_call_tool.",
+      "Ranked search for tools and protocol skills — the fast narrow pass. Scoped to one app when app is given, global when omitted. Prefer this over aomi_list_tools + aomi_describe_tool when you know the capability you want. Returns scored candidates with match reasons. A hit with kind 'skill' is a protocol instruction pack (aave, compound, pendle, …) driven through the generic evm/svm tools: follow it with aomi_describe_skill. For tool hits, call aomi_describe_tool for the exact schema before aomi_call_tool.",
     inputSchema: {
       type: "object",
       properties: {
@@ -140,6 +140,22 @@ export const MCP_TOOLS: McpToolDef[] = [
     },
   },
   {
+    name: "aomi_describe_skill",
+    description:
+      "Return one protocol skill's full instruction pack: the procedure, contract addresses, ABI signatures, and rules the Aomi runtime injects on activation. Most protocols (aave, compound, morpho, pendle, …) have no tools of their own — their skill drives the generic evm tools (encode_and_call, evm_stage_tx). Read the pack, then execute its steps via aomi_call_tool or aomi_run, passing skills=[\"<id>\"] so the skill's server-side guards stay active.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        skill_id: {
+          type: "string",
+          description:
+            "Skill id from aomi_search_tools (kind 'skill') or the list_skills tool, such as aave.",
+        },
+      },
+      required: ["skill_id"],
+    },
+  },
+  {
     name: "aomi_run",
     description: [
       "Run a multi-step orchestration program inside this user's Aomi thread: many tool calls in one request, with intermediate results staying server-side.",
@@ -166,6 +182,12 @@ export const MCP_TOOLS: McpToolDef[] = [
             "The orchestration program in the bash-like subset described above.",
         },
         app: { ...APP_PROPERTY },
+        skills: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Skill ids to activate for the whole plan (e.g. [\"aave\"]). Required when following an instruction-only skill's procedure so its server-side guards run; skill-owned tools named in the plan activate automatically.",
+        },
         thread_id: {
           type: "string",
           description:
@@ -178,7 +200,7 @@ export const MCP_TOOLS: McpToolDef[] = [
   {
     name: "aomi_call_tool",
     description:
-      "Execute a single Aomi tool inside this user's MCP thread on the Aomi backend. Skill-owned tools activate their skill automatically. For multi-step flows where results feed each other, prefer aomi_run.",
+      "Execute a single Aomi tool inside this user's MCP thread on the Aomi backend. Skill-owned tools activate their skill automatically; when following an instruction-only skill's procedure, pass its id in skills. For multi-step flows where results feed each other, prefer aomi_run.",
     inputSchema: {
       type: "object",
       properties: {
@@ -192,6 +214,12 @@ export const MCP_TOOLS: McpToolDef[] = [
             "JSON arguments matching the schema from aomi_describe_tool.",
         },
         app: { ...APP_PROPERTY },
+        skills: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Skill ids to activate for this call (e.g. [\"aave\"]). Required when following an instruction-only skill's procedure so its server-side guards run; redundant for skill-owned tools.",
+        },
         thread_id: {
           type: "string",
           description:
@@ -219,7 +247,7 @@ export async function dispatchTool(
         thread: { id: mcpThreadId(canonicalUserId), resolution: "deterministic" },
         catalog: apps.body,
         next_step:
-          "Use aomi_list_apps for discovery, then aomi_select_app, aomi_list_tools, aomi_describe_tool, and aomi_call_tool. Pass app explicitly on every call.",
+          "Use aomi_search_tools (or aomi_list_apps → aomi_select_app → aomi_list_tools) for discovery, aomi_describe_tool / aomi_describe_skill for schemas and protocol procedures, then aomi_call_tool or aomi_run. Pass app explicitly on every call.",
       });
     }
     case "aomi_list_apps": {
@@ -279,13 +307,24 @@ export async function dispatchTool(
       );
       return wrap(out, out.body);
     }
+    case "aomi_describe_skill": {
+      const skillId = text(args.skill_id);
+      if (!skillId) return invalid("skill_id is required");
+      const out = await resourceGet(
+        canonicalUserId,
+        `/api/resource/skills/${encodeURIComponent(skillId)}`,
+      );
+      return wrap(out, out.body);
+    }
     case "aomi_run": {
       const program = text(args.program);
       if (!program) return invalid("program is required");
       const threadId = text(args.thread_id) ?? mcpThreadId(canonicalUserId);
+      const skills = stringList(args.skills);
       const out = await execRun(canonicalUserId, threadId, {
         program,
         app: text(args.app),
+        ...(skills.length ? { skills } : {}),
       });
       return wrap(out, out.body);
     }
@@ -293,10 +332,12 @@ export async function dispatchTool(
       const toolId = text(args.tool_id);
       if (!toolId) return invalid("tool_id is required");
       const threadId = text(args.thread_id) ?? mcpThreadId(canonicalUserId);
+      const skills = stringList(args.skills);
       const out = await toolCall(canonicalUserId, threadId, {
         tool_id: toolId,
         arguments: objectArgs(args.arguments),
         app: text(args.app),
+        ...(skills.length ? { skills } : {}),
       });
       return wrap(out, out.body);
     }
@@ -325,6 +366,13 @@ function text(value: unknown): string | undefined {
 
 function numeric(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function stringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (item): item is string => typeof item === "string" && item.trim().length > 0,
+  );
 }
 
 function objectArgs(value: unknown): Record<string, unknown> {

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,8 @@
 
 ## Last Updated
 
+2026-07-14 — MCP skill reachability: aomi_describe_skill + skills param (FE) with
+  matching BE resource-plane/skills work in product-mono working tree (uncommitted);
 2026-07-14 — Account menu: Docs (aomi.dev/docs) + Home page links (Vercel-style);
 2026-07-14 — Build P2 deep-link polish (⌘K / Billing / Overview → right tab);
 2026-07-14 — Create stack #343–#349 merged to main (left #340);
@@ -30,6 +32,30 @@
 2026-07-13 — Build UI copy polish (em dashes / hedging essays);
 2026-07-13 — Billing option A: methods live on Chat (no fake Build fetch);
 2026-07-13 — BILLING-EXPERIENCE.md: backend ↔ UI map (code-checked)
+
+## MCP skill reachability (2026-07-14)
+
+Working tree on `main` (uncommitted), paired with backend changes in the
+product-mono checkout at `/private/tmp/product-mono-main-deploy-debug`
+(also uncommitted; diff backed up at `.mcp-opt-backend.patch` repo-root):
+
+- Portal MCP: new `aomi_describe_skill` tool → `GET /api/resource/skills/{id}`
+  (protocol instruction packs; 26 of 31 skills have no tools of their own).
+- `aomi_call_tool` / `aomi_run` accept `skills: []` — activates instruction-only
+  skills so their server-side guard hooks run; omitted from body when empty.
+- `aomi_search_tools` description now covers `kind: "skill"` hits.
+- Backend (product-mono): catalog serves honest (non-strict) schemas, skills
+  indexed in `Catalog` + `/api/resource/skills[/​:id]`, search ranks skill cards,
+  exec surface takes explicit `skills`, `encode_and_call` + `lifi_get_quote`
+  accept explicit `from` for wallet-less simulate/quote, serde arg errors
+  stripped of position noise.
+- Source analysis + plan: `/Users/cecilia/Code/aomi-skill/mcp-opt-plan.md`.
+
+Pending:
+- Backend changes live in a shared /tmp checkout that another agent switched to
+  branch `codex/retry-new-platform-branch-ref` mid-session — decide where they
+  should land (branch off main) before anyone resets that tree.
+- Staging deploy predates these features (aomi_run 404 etc. observed in eval).
 
 ## Build P2 deep-link polish (2026-07-14)
 


### PR DESCRIPTION
## Why

The portal MCP server exposed the tool funnel but not protocol skills — and 26 of 31 Aomi protocols (aave, compound, morpho, pendle, …) are instruction packs with no tools of their own. An MCP agent could see them in `list_skills` but had no path to their procedure, and their server-side guard hooks never ran for exec calls. Companion backend PR: aomi-labs/product-mono#807 (must land/deploy first; until then the new tool returns a clean backend 404).

## What

- New `aomi_describe_skill` tool → `GET /api/resource/skills/:skill_id`, returning the skill's full instruction pack (procedure, contract addresses, ABI signatures, rules)
- `aomi_call_tool` / `aomi_run` accept and forward `skills: []` so instruction-pack guards are activated server-side; the field is omitted from the request body when empty
- `aomi_search_tools` / `aomi_get_agent_context` descriptions teach the funnel: search hit with `kind: "skill"` → `aomi_describe_skill` → drive the generic evm tools via `aomi_call_tool`/`aomi_run` with `skills: ["<id>"]`

## Testing

- `pnpm vitest run apps/portal/src/server/mcp/`: 21/21 (4 new: describe_skill routing, required skill_id, skills passthrough on call_tool and run)
- `tsc --noEmit` clean on apps/portal

🤖 Generated with [Claude Code](https://claude.com/claude-code)