### PR TITLE
Gate required secrets before deployment

### DIFF
--- a/apps/aomi-build/src/features/launch/client.ts
+++ b/apps/aomi-build/src/features/launch/client.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import type { SecretSlot } from "@aomi-labs/deploy";
 import type { SourceSdkUpgradeResult } from "@aomi-labs/deploy";
 import { API_PATHS } from "@build/lib/api-paths";
 import { sessionScopedFetch } from "@build/lib/settings-api";
@@ -21,6 +20,7 @@ import {
   type LaunchSdkStatus,
   type LaunchStatus,
 } from "./contracts";
+import type { RequiredSecretsByApp } from "./required-secrets";
 import { normalizeRepo } from "./state";
 
 export type GithubAppOAuthStartResponse = {
@@ -53,6 +53,18 @@ export async function githubAppInstallUrl(args: {
 
 // Every launch BFF route returns the payload on success or `{ error }` on
 // failure. Centralize that contract so each call site stays a one-liner.
+export class LaunchRequestError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "LaunchRequestError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
 async function launchFetch<T>(
   path: string,
   label: string,
@@ -61,7 +73,11 @@ async function launchFetch<T>(
   const res = await fetch(path, init);
   const json = (await res.json().catch(() => ({}))) as T & { error?: string };
   if (!res.ok) {
-    throw new Error(json.error || `${label} failed (${res.status})`);
+    throw new LaunchRequestError(
+      json.error || `${label} failed (${res.status})`,
+      res.status,
+      json,
+    );
   }
   return json;
 }
@@ -162,7 +178,7 @@ export function deploymentSecrets(input: {
 }
 
 export type RequiredSecretsResult = {
-  byApp: Record<string, { slots: SecretSlot[]; missing: string[] }>;
+  byApp: RequiredSecretsByApp;
 };
 
 export function deploymentRequiredSecrets(input: {

--- a/apps/aomi-build/src/features/launch/components/deploy-step.test.tsx
+++ b/apps/aomi-build/src/features/launch/components/deploy-step.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { DeployStep } from "./deploy-step";
 import type { LaunchDeployPayload } from "@build/features/launch";
 import type { LaunchProgress } from "@build/features/launch";
@@ -149,9 +149,7 @@ describe("DeployStep", () => {
       />,
     );
     expect(detail.loadRequiredSecrets).toHaveBeenCalled();
-    expect(
-      screen.getByText(/1 required secret missing/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/1 required secret missing/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Activate" })).toBeDisabled();
   });
 
@@ -169,5 +167,28 @@ describe("DeployStep", () => {
       />,
     );
     expect(screen.queryByText(/required secret/i)).not.toBeInTheDocument();
+  });
+
+  it("offers an in-place retry when required-secret verification fails", async () => {
+    const refreshRequiredSecrets = vi.fn().mockResolvedValue({});
+    const detail = {
+      hasMissingSecrets: () => false,
+      requiredSecrets: null,
+      requiredSecretsError: "Temporary gateway error",
+      loadRequiredSecrets: vi.fn(),
+      refreshRequiredSecrets,
+    };
+    render(
+      <DeployStep
+        {...defaultProps}
+        progress={{ ...baseProgress(), apps: ["binance"] }}
+        detail={detail}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Retry required secrets" }),
+    );
+    await waitFor(() => expect(refreshRequiredSecrets).toHaveBeenCalledOnce());
   });
 });

--- a/apps/aomi-build/src/features/launch/components/deploy-step.tsx
+++ b/apps/aomi-build/src/features/launch/components/deploy-step.tsx
@@ -23,6 +23,7 @@ import {
   type LaunchDeployPayload,
   type LaunchProgress,
 } from "@build/features/launch";
+import { MissingRequiredSecretsError } from "@build/features/launch/required-secrets";
 
 // The subset of `useProjectDetail`'s return value this step needs to gate
 // Activate on required secrets. Optional: the onboarding wizard renders this
@@ -34,7 +35,16 @@ type SecretsGateDetail = {
     string,
     { slots: SecretSlot[]; missing: string[] }
   > | null;
+  requiredSecretsError?: string | null;
   loadRequiredSecrets: () => void;
+  ensureRequiredSecrets?: (
+    apps: string[],
+    appSourceId?: number,
+  ) => Promise<void>;
+  setEnvVars?: (
+    app: string,
+    secrets: Record<string, string>,
+  ) => Promise<unknown>;
 };
 
 type Phase =
@@ -188,6 +198,10 @@ export function DeployStep({
     progress.deploymentId,
   );
   const [error, setError] = useState<string | null>(null);
+  const [requiredSecretValues, setRequiredSecretValues] = useState<
+    Record<string, string>
+  >({});
+  const [savingRequiredSecrets, setSavingRequiredSecrets] = useState(false);
   const [showManifest, setShowManifest] = useState(false);
   const [verifyAttempt, setVerifyAttempt] = useState(0);
   const [copied, setCopied] = useState(false);
@@ -216,17 +230,65 @@ export function DeployStep({
     detail?.loadRequiredSecrets();
   }, [detail]);
 
-  // Gate on the apps this step is about to activate (`progress.apps`), not
-  // the `apps` memo above — that one falls back to the preflight/deploy
-  // manifest, which can list apps not yet targeted for this activation.
-  const blockedApps = (progress.apps ?? []).filter((app) =>
-    detail?.hasMissingSecrets(app),
+  // Gate on the apps this step is about to deploy or activate. After a
+  // preflight, `apps` comes from the resolved deployment manifest even before
+  // the deploy result has been written back into progress.
+  const blockedApps = apps.filter((app) => detail?.hasMissingSecrets(app));
+  const secretsCheckPending = Boolean(
+    detail &&
+    apps.length > 0 &&
+    detail.requiredSecrets === null &&
+    !detail.requiredSecretsError,
   );
-  const secretsBlocked = blockedApps.length > 0;
+  const secretsCheckFailed = Boolean(
+    detail && apps.length > 0 && detail.requiredSecretsError,
+  );
+  const secretsBlocked = Boolean(
+    detail &&
+    apps.length > 0 &&
+    (secretsCheckPending || secretsCheckFailed || blockedApps.length > 0),
+  );
   const missingSecretsCount = blockedApps.reduce(
     (n, app) => n + (detail?.requiredSecrets?.[app]?.missing.length ?? 0),
     0,
   );
+  const missingSecretSlots = blockedApps.flatMap((app) =>
+    (detail?.requiredSecrets?.[app]?.slots ?? [])
+      .filter((slot) =>
+        detail?.requiredSecrets?.[app]?.missing.includes(slot.name),
+      )
+      .map((slot) => ({ app, slot })),
+  );
+
+  const saveRequiredSecrets = useCallback(async () => {
+    if (!detail?.setEnvVars || missingSecretSlots.length === 0) return;
+    const valuesByApp = new Map<string, Record<string, string>>();
+    for (const { app, slot } of missingSecretSlots) {
+      const value = requiredSecretValues[`${app}::${slot.name}`] ?? "";
+      if (!value) {
+        setError(`Enter a value for ${slot.name}.`);
+        return;
+      }
+      const values = valuesByApp.get(app) ?? {};
+      values[slot.name] = value;
+      valuesByApp.set(app, values);
+    }
+    setSavingRequiredSecrets(true);
+    setError(null);
+    try {
+      await Promise.all(
+        Array.from(valuesByApp, ([app, values]) =>
+          detail.setEnvVars?.(app, values),
+        ),
+      );
+      setRequiredSecretValues({});
+      await detail.ensureRequiredSecrets?.(apps);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSavingRequiredSecrets(false);
+    }
+  }, [apps, detail, missingSecretSlots, requiredSecretValues]);
 
   const applyDeployment = useCallback(
     (next: {
@@ -293,6 +355,7 @@ export function DeployStep({
       // preview); afterwards we go straight through by id.
       let appSourceId = progress.appSourceId;
       let sourceRef = progress.sourceRef ?? deployment?.source?.ref;
+      let targetApps = apps;
       if (!appSourceId || !sourceRef) {
         const preflightResult = await launchPreflight({
           installationId,
@@ -305,12 +368,14 @@ export function DeployStep({
         appSourceId = preflightResult.appSourceId;
         sourceRef =
           preflightResult.sourceRef ?? preflightResult.deployment.source?.ref;
+        targetApps = preflightResult.apps;
       }
       if (!appSourceId) {
         throw new Error(
           "Could not resolve a source to deploy. Run a preflight first.",
         );
       }
+      await detail?.ensureRequiredSecrets?.(targetApps, appSourceId);
       const result = await launchDeploy({
         appSourceId,
         sourceRef,
@@ -334,12 +399,19 @@ export function DeployStep({
       onProgress(patch);
       setPhase("building");
     } catch (e) {
+      if (e instanceof MissingRequiredSecretsError) {
+        setError(e.message);
+        setPhase("preflight_ready");
+        return;
+      }
       setError(e instanceof Error ? e.message : String(e));
       setPhase("error");
     }
   }, [
     actor,
     applyDeployment,
+    apps,
+    detail,
     installationId,
     onProgress,
     progress.appSourceId,
@@ -587,6 +659,14 @@ export function DeployStep({
   return (
     <div className="space-y-4 text-sm" aria-busy={busy}>
       <StepTrack phase={phase} />
+      {error && (
+        <div
+          className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-800"
+          role="alert"
+        >
+          {error}
+        </div>
+      )}
       <div className="flex flex-wrap items-center gap-2">
         <Button
           onClick={preflight}
@@ -631,13 +711,6 @@ export function DeployStep({
           )}
           Activate
         </Button>
-        {secretsBlocked && (
-          <span className="text-xs text-amber-700">
-            {missingSecretsCount} required secret
-            {missingSecretsCount === 1 ? "" : "s"} missing — set them in the
-            Environment tab.
-          </span>
-        )}
         {["building", "ready", "activating", "verifying"].includes(phase) && (
           <Button
             onClick={reset}
@@ -647,6 +720,65 @@ export function DeployStep({
           </Button>
         )}
       </div>
+
+      {secretsBlocked && (
+        <div
+          className="space-y-3 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs"
+          role="alert"
+        >
+          <div className="font-medium text-amber-800">
+            {secretsCheckPending
+              ? "Checking required secrets…"
+              : detail?.requiredSecretsError
+                ? "Required secrets could not be verified."
+                : `${missingSecretsCount} required secret${missingSecretsCount === 1 ? "" : "s"} missing.`}
+          </div>
+          {detail?.requiredSecretsError ? (
+            <div className="text-amber-800">
+              {detail.requiredSecretsError}. Refresh and try again.
+            </div>
+          ) : (
+            <>
+              {missingSecretSlots.map(({ app, slot }) => (
+                <label key={`${app}::${slot.name}`} className="block">
+                  <span className="mb-1 block font-mono text-[11px] text-amber-900">
+                    {app} · {slot.name}
+                  </span>
+                  <input
+                    type="password"
+                    value={requiredSecretValues[`${app}::${slot.name}`] ?? ""}
+                    onChange={(event) =>
+                      setRequiredSecretValues((values) => ({
+                        ...values,
+                        [`${app}::${slot.name}`]: event.target.value,
+                      }))
+                    }
+                    placeholder={slot.description || "Required value"}
+                    aria-label={`${app} ${slot.name}`}
+                    disabled={savingRequiredSecrets}
+                    className="bg-input text-foreground border-border h-8 w-full rounded-md border px-2 text-xs"
+                  />
+                </label>
+              ))}
+              {missingSecretSlots.length > 0 && detail?.setEnvVars && (
+                <Button
+                  onClick={() => void saveRequiredSecrets()}
+                  disabled={savingRequiredSecrets || secretsCheckPending}
+                  className="h-8 rounded-full px-3 text-xs font-medium"
+                >
+                  {savingRequiredSecrets ? "Saving…" : "Save required secrets"}
+                </Button>
+              )}
+              {missingSecretSlots.length > 0 && !detail?.setEnvVars && (
+                <div className="text-amber-800">
+                  Set these values in the project Environment tab before
+                  activating.
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
 
       <div
         className="text-muted-foreground flex min-h-5 items-center gap-2 text-xs"

--- a/apps/aomi-build/src/features/launch/components/deploy-step.tsx
+++ b/apps/aomi-build/src/features/launch/components/deploy-step.tsx
@@ -37,6 +37,7 @@ type SecretsGateDetail = {
   > | null;
   requiredSecretsError?: string | null;
   loadRequiredSecrets: () => void;
+  refreshRequiredSecrets?: () => Promise<unknown>;
   ensureRequiredSecrets?: (
     apps: string[],
     appSourceId?: number,
@@ -202,6 +203,7 @@ export function DeployStep({
     Record<string, string>
   >({});
   const [savingRequiredSecrets, setSavingRequiredSecrets] = useState(false);
+  const [retryingRequiredSecrets, setRetryingRequiredSecrets] = useState(false);
   const [showManifest, setShowManifest] = useState(false);
   const [verifyAttempt, setVerifyAttempt] = useState(0);
   const [copied, setCopied] = useState(false);
@@ -289,6 +291,19 @@ export function DeployStep({
       setSavingRequiredSecrets(false);
     }
   }, [apps, detail, missingSecretSlots, requiredSecretValues]);
+
+  const retryRequiredSecrets = useCallback(async () => {
+    if (!detail?.refreshRequiredSecrets) return;
+    setRetryingRequiredSecrets(true);
+    setError(null);
+    try {
+      await detail.refreshRequiredSecrets();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRetryingRequiredSecrets(false);
+    }
+  }, [detail]);
 
   const applyDeployment = useCallback(
     (next: {
@@ -734,8 +749,19 @@ export function DeployStep({
                 : `${missingSecretsCount} required secret${missingSecretsCount === 1 ? "" : "s"} missing.`}
           </div>
           {detail?.requiredSecretsError ? (
-            <div className="text-amber-800">
-              {detail.requiredSecretsError}. Refresh and try again.
+            <div className="flex flex-wrap items-center gap-3 text-amber-800">
+              <span>{detail.requiredSecretsError}. Try again.</span>
+              {detail.refreshRequiredSecrets && (
+                <Button
+                  onClick={() => void retryRequiredSecrets()}
+                  disabled={retryingRequiredSecrets}
+                  className="h-8 rounded-full px-3 text-xs font-medium"
+                >
+                  {retryingRequiredSecrets
+                    ? "Retrying…"
+                    : "Retry required secrets"}
+                </Button>
+              )}
             </div>
           ) : (
             <>

--- a/apps/aomi-build/src/features/launch/components/deployments/project-page.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/project-page.tsx
@@ -41,13 +41,20 @@ export function ProjectPage({
   const active: TabId = TABS.some((t) => t.id === raw)
     ? (raw as TabId)
     : "home";
+  const openEnvironment = () =>
+    router.push(
+      tabHref?.("environment") ??
+        (tabBaseHref
+          ? `${tabBaseHref}?tab=environment`
+          : `/operate/deployments?project=${sourceId}&tab=environment`),
+    );
 
   useEffect(() => {
     setLastProjectId(sourceId);
   }, [sourceId]);
 
   return (
-    <main className="min-h-screen bg-background text-foreground">
+    <main className="bg-background text-foreground min-h-screen">
       <ProjectHeader
         source={detail.source}
         latest={detail.source?.latestDeployment ?? null}
@@ -58,7 +65,7 @@ export function ProjectPage({
       <div className="mx-auto w-full max-w-5xl px-4 py-6 sm:px-6">
         <div
           role="tablist"
-          className="mb-4 flex w-fit items-center gap-1 rounded-md bg-surface-2 p-1 text-sm"
+          className="bg-surface-2 mb-4 flex w-fit items-center gap-1 rounded-md p-1 text-sm"
         >
           {TABS.map((tab) => (
             <button
@@ -85,7 +92,7 @@ export function ProjectPage({
             </button>
           ))}
         </div>
-        <div className="overflow-hidden rounded-lg border border-border bg-surface-1">
+        <div className="border-border bg-surface-1 overflow-hidden rounded-lg border">
           {detail.loading && detail.source === null && !detail.error ? (
             <LoadingPanel label="Loading project…" />
           ) : detail.error ? (
@@ -93,7 +100,10 @@ export function ProjectPage({
           ) : active === "home" ? (
             <HomeTab detail={detail} tabBaseHref={tabBaseHref} />
           ) : active === "deployments" ? (
-            <DeploymentsTab detail={detail} />
+            <DeploymentsTab
+              detail={detail}
+              onOpenEnvironment={openEnvironment}
+            />
           ) : active === "chat" ? (
             <ChatTab detail={detail} />
           ) : active === "environment" ? (

--- a/apps/aomi-build/src/features/launch/components/deployments/tabs/deployments-tab.test.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/tabs/deployments-tab.test.tsx
@@ -222,6 +222,27 @@ describe("DeploymentsTab", () => {
     expect(screen.getByText(/required secrets missing/i)).toBeInTheDocument();
   });
 
+  it("blocks redeploy and offers the Environment tab when secrets are missing", () => {
+    const blockedDetail = makeDetail({
+      hasMissingSecrets: (app) => app === "my-bot",
+    });
+    const openEnvironment = vi.fn();
+    renderTab(
+      <DeploymentsTab
+        detail={blockedDetail}
+        onOpenEnvironment={openEnvironment}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /redeploy from linked repository/i }),
+    ).toBeDisabled();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Set required secrets" }),
+    );
+    expect(openEnvironment).toHaveBeenCalledOnce();
+  });
+
   it("is honest when live but deployment history is empty", () => {
     const liveEmpty = {
       ...detail,

--- a/apps/aomi-build/src/features/launch/components/deployments/tabs/deployments-tab.tsx
+++ b/apps/aomi-build/src/features/launch/components/deployments/tabs/deployments-tab.tsx
@@ -30,7 +30,13 @@ type Pending =
   | null;
 type View = "deployments" | "activity";
 
-export function DeploymentsTab({ detail }: { detail: Detail }) {
+export function DeploymentsTab({
+  detail,
+  onOpenEnvironment,
+}: {
+  detail: Detail;
+  onOpenEnvironment?: () => void;
+}) {
   const { toast } = useToast();
   const [op, setOp] = useState<OpState | null>(null);
   const [pending, setPending] = useState<Pending>(null);
@@ -116,6 +122,35 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
     () => new Map(source?.apps.map((app) => [app.name, app]) ?? []),
     [source],
   );
+  const missingRequiredApps = useMemo(
+    () =>
+      source?.apps
+        .map((app) => app.name)
+        .filter((app) => detail.hasMissingSecrets(app)) ?? [],
+    [detail, source],
+  );
+  const secretsCheckPending = Boolean(
+    source &&
+    source.apps.length > 0 &&
+    detail.requiredSecrets === null &&
+    !detail.requiredSecretsError,
+  );
+  const secretsCheckFailed = Boolean(
+    source && source.apps.length > 0 && detail.requiredSecretsError,
+  );
+  const secretsGateBlocked = Boolean(
+    source &&
+    source.apps.length > 0 &&
+    (secretsCheckPending ||
+      secretsCheckFailed ||
+      missingRequiredApps.length > 0),
+  );
+  const missingRequiredCount =
+    missingRequiredApps.reduce(
+      (count, app) =>
+        count + (detail.requiredSecrets?.[app]?.missing.length ?? 0),
+      0,
+    ) || missingRequiredApps.length;
 
   if (!source) {
     return detail.loading ? (
@@ -317,7 +352,7 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
           )}
           <button
             type="button"
-            disabled={deploying}
+            disabled={deploying || secretsGateBlocked}
             onClick={() => {
               setOp(null);
               void detail.redeploySource();
@@ -375,6 +410,30 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
         </div>
       )}
 
+      {secretsGateBlocked && (
+        <div
+          className="border-warning/40 bg-warning/10 text-warning flex items-center justify-between gap-3 border-b px-4 py-3 text-xs"
+          role="alert"
+        >
+          <span>
+            {secretsCheckPending
+              ? "Checking required secrets before deployment…"
+              : detail.requiredSecretsError
+                ? "Required secrets could not be verified. Refresh before deploying."
+                : `${missingRequiredCount} required secret${missingRequiredCount === 1 ? "" : "s"} missing for ${missingRequiredApps.join(", ")}.`}
+          </span>
+          {onOpenEnvironment && !secretsCheckPending && !secretsCheckFailed && (
+            <button
+              type="button"
+              onClick={onOpenEnvironment}
+              className="shrink-0 font-medium underline underline-offset-2"
+            >
+              Set required secrets
+            </button>
+          )}
+        </div>
+      )}
+
       {view === "deployments" &&
       deployments.length === 0 &&
       !detail.recordsError ? (
@@ -387,8 +446,16 @@ export function DeploymentsTab({ detail }: { detail: Detail }) {
               ? "This project is live, but no deployment records are available yet. Deploy a new version to start a history."
               : "Deploy the current version from the linked repository."
           }
-          onAction={() => void detail.redeploySource()}
-          actionLabel="Deploy from Linked Repository"
+          onAction={() =>
+            secretsGateBlocked
+              ? onOpenEnvironment?.()
+              : void detail.redeploySource()
+          }
+          actionLabel={
+            secretsGateBlocked
+              ? "Set required secrets"
+              : "Deploy from Linked Repository"
+          }
         />
       ) : view === "deployments" && deployments.length > 0 ? (
         deployments.map((deployment) => {

--- a/apps/aomi-build/src/features/launch/components/oneshot-wizard.test.tsx
+++ b/apps/aomi-build/src/features/launch/components/oneshot-wizard.test.tsx
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { OneshotWizard } from "./oneshot-wizard";
-import { launchCreateRepo, deploymentRequiredSecrets } from "@build/features/launch";
+import {
+  deploymentRequiredSecrets,
+  deploymentSetSecrets,
+  launchCreateRepo,
+} from "@build/features/launch";
 import type { LaunchProgress } from "@build/features/launch";
 
 const noop = () => {};
@@ -43,6 +47,7 @@ vi.mock("@build/features/launch", () => ({
   installationStatusLabel: () => null,
   launchCreateRepo: vi.fn(),
   deploymentRequiredSecrets: vi.fn(),
+  deploymentSetSecrets: vi.fn(),
   // DeployStep (rendered at the "build" step) imports these too; they're
   // only invoked from button clicks / a polling timer this suite never
   // triggers, but they must exist so the mocked module doesn't crash on
@@ -197,5 +202,49 @@ describe("OneshotWizard", () => {
     expect(
       await screen.findByText(/1 required secret missing/i),
     ).toBeInTheDocument();
+  });
+
+  it("lets a new project save the missing required secret before activation", async () => {
+    vi.mocked(deploymentRequiredSecrets).mockResolvedValue({
+      byApp: {
+        "my-bot": {
+          slots: [
+            {
+              name: "MY_BOT_API_KEY",
+              description: "API key for the bot.",
+              required: true,
+            },
+          ],
+          missing: ["MY_BOT_API_KEY"],
+        },
+      },
+    });
+
+    render(
+      <OneshotWizard
+        {...defaultProps}
+        progress={{
+          installationId: "12345",
+          repo: "alice/bot",
+          appSourceId: 7,
+          deploymentId: "dep_1",
+          apps: ["my-bot"],
+        }}
+      />,
+    );
+
+    const input = await screen.findByLabelText("my-bot MY_BOT_API_KEY");
+    fireEvent.change(input, { target: { value: "secret-value" } });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save required secrets" }),
+    );
+
+    await waitFor(() =>
+      expect(deploymentSetSecrets).toHaveBeenCalledWith({
+        app: "my-bot",
+        appSourceId: 7,
+        secrets: { MY_BOT_API_KEY: "secret-value" },
+      }),
+    );
   });
 });

--- a/apps/aomi-build/src/features/launch/components/oneshot-wizard.tsx
+++ b/apps/aomi-build/src/features/launch/components/oneshot-wizard.tsx
@@ -3,8 +3,8 @@
 import { useCallback, useRef, useState } from "react";
 import { ExternalLink, Loader2, Plus, RotateCcw } from "lucide-react";
 import { Button } from "@aomi-labs/widget-lib";
-import type { SecretSlot } from "@aomi-labs/deploy";
 import {
+  deploymentSetSecrets,
   deploymentRequiredSecrets,
   installationStatusLabel,
   launchCreateRepo,
@@ -12,6 +12,11 @@ import {
   TEMPLATE_REPO,
   type LaunchProgress,
 } from "@build/features/launch";
+import {
+  MissingRequiredSecretsError,
+  missingRequiredSecrets,
+  type RequiredSecretsByApp,
+} from "@build/features/launch/required-secrets";
 import { chatAppUrl } from "@build/lib/chat-url";
 import { Stepper } from "./stepper";
 import { DeployStep } from "./deploy-step";
@@ -24,34 +29,75 @@ import { LivePanel } from "./live-panel";
  * mints alongside `progress.repo` (the wizard's sole setter of both). So this
  * mirrors just the read-only slice `DeployStep` needs, keyed on that id,
  * instead of fabricating a project-detail hook the wizard doesn't otherwise
- * use. If `appSourceId` is ever absent, this fails open (no fetch, nothing
- * ever reported missing) — same policy as the activate 409 backstop.
+ * use. If `appSourceId` is ever absent, there is no target app to gate yet.
+ * Once a source exists, failures are surfaced and block deployment/activation
+ * until the required-secret state can be verified.
  */
 function useWizardSecretsGate(appSourceId?: number) {
-  const [requiredSecrets, setRequiredSecrets] = useState<Record<
-    string,
-    { slots: SecretSlot[]; missing: string[] }
-  > | null>(null);
+  const [requiredSecrets, setRequiredSecrets] =
+    useState<RequiredSecretsByApp | null>(null);
+  const [requiredSecretsError, setRequiredSecretsError] = useState<
+    string | null
+  >(null);
   const requestedFor = useRef<number | null>(null);
 
   const loadRequiredSecrets = useCallback(() => {
     if (!appSourceId || requestedFor.current === appSourceId) return;
     requestedFor.current = appSourceId;
+    setRequiredSecretsError(null);
     void deploymentRequiredSecrets({ appSourceId })
       .then((r) => setRequiredSecrets(r.byApp))
-      .catch(() => {
-        // Fail open: leave requiredSecrets as-is (nothing reported missing)
-        // and allow a retry on the next mount effect.
+      .catch((err) => {
+        setRequiredSecretsError(
+          err instanceof Error
+            ? err.message
+            : "Failed to load required secrets",
+        );
         requestedFor.current = null;
       });
   }, [appSourceId]);
+
+  const ensureRequiredSecrets = useCallback(
+    async (apps: string[], sourceIdOverride?: number) => {
+      const sourceId = sourceIdOverride ?? appSourceId;
+      if (!sourceId) return;
+      const result = await deploymentRequiredSecrets({ appSourceId: sourceId });
+      setRequiredSecrets(result.byApp);
+      setRequiredSecretsError(null);
+      requestedFor.current = sourceId;
+      const missing = missingRequiredSecrets(result.byApp, apps);
+      if (Object.keys(missing).length > 0) {
+        throw new MissingRequiredSecretsError(missing);
+      }
+    },
+    [appSourceId],
+  );
+
+  const setEnvVars = useCallback(
+    async (app: string, secrets: Record<string, string>) => {
+      if (!appSourceId) throw new Error("App source is missing.");
+      await deploymentSetSecrets({ app, appSourceId, secrets });
+      const result = await deploymentRequiredSecrets({ appSourceId });
+      setRequiredSecrets(result.byApp);
+      setRequiredSecretsError(null);
+      requestedFor.current = appSourceId;
+    },
+    [appSourceId],
+  );
 
   const hasMissingSecrets = useCallback(
     (app: string) => (requiredSecrets?.[app]?.missing.length ?? 0) > 0,
     [requiredSecrets],
   );
 
-  return { requiredSecrets, loadRequiredSecrets, hasMissingSecrets };
+  return {
+    requiredSecrets,
+    requiredSecretsError,
+    loadRequiredSecrets,
+    ensureRequiredSecrets,
+    setEnvVars,
+    hasMissingSecrets,
+  };
 }
 
 const STEPS = [

--- a/apps/aomi-build/src/features/launch/components/oneshot-wizard.tsx
+++ b/apps/aomi-build/src/features/launch/components/oneshot-wizard.tsx
@@ -41,36 +41,46 @@ function useWizardSecretsGate(appSourceId?: number) {
   >(null);
   const requestedFor = useRef<number | null>(null);
 
-  const loadRequiredSecrets = useCallback(() => {
-    if (!appSourceId || requestedFor.current === appSourceId) return;
+  const refreshRequiredSecrets = useCallback(async () => {
+    if (!appSourceId) return;
     requestedFor.current = appSourceId;
     setRequiredSecretsError(null);
-    void deploymentRequiredSecrets({ appSourceId })
-      .then((r) => setRequiredSecrets(r.byApp))
-      .catch((err) => {
-        setRequiredSecretsError(
-          err instanceof Error
-            ? err.message
-            : "Failed to load required secrets",
-        );
-        requestedFor.current = null;
-      });
+    try {
+      const result = await deploymentRequiredSecrets({ appSourceId });
+      setRequiredSecrets(result.byApp);
+      return result.byApp;
+    } catch (err) {
+      setRequiredSecretsError(
+        err instanceof Error ? err.message : "Failed to load required secrets",
+      );
+      requestedFor.current = null;
+      throw err;
+    }
   }, [appSourceId]);
+
+  const loadRequiredSecrets = useCallback(() => {
+    if (!appSourceId || requestedFor.current === appSourceId) return;
+    void refreshRequiredSecrets().catch(() => undefined);
+  }, [appSourceId, refreshRequiredSecrets]);
 
   const ensureRequiredSecrets = useCallback(
     async (apps: string[], sourceIdOverride?: number) => {
       const sourceId = sourceIdOverride ?? appSourceId;
       if (!sourceId) return;
-      const result = await deploymentRequiredSecrets({ appSourceId: sourceId });
-      setRequiredSecrets(result.byApp);
+      const byApp =
+        sourceId === appSourceId
+          ? await refreshRequiredSecrets()
+          : (await deploymentRequiredSecrets({ appSourceId: sourceId })).byApp;
+      if (!byApp) return;
+      setRequiredSecrets(byApp);
       setRequiredSecretsError(null);
       requestedFor.current = sourceId;
-      const missing = missingRequiredSecrets(result.byApp, apps);
+      const missing = missingRequiredSecrets(byApp, apps);
       if (Object.keys(missing).length > 0) {
         throw new MissingRequiredSecretsError(missing);
       }
     },
-    [appSourceId],
+    [appSourceId, refreshRequiredSecrets],
   );
 
   const setEnvVars = useCallback(
@@ -94,6 +104,7 @@ function useWizardSecretsGate(appSourceId?: number) {
     requiredSecrets,
     requiredSecretsError,
     loadRequiredSecrets,
+    refreshRequiredSecrets,
     ensureRequiredSecrets,
     setEnvVars,
     hasMissingSecrets,

--- a/apps/aomi-build/src/features/launch/hooks/use-project-detail.ts
+++ b/apps/aomi-build/src/features/launch/hooks/use-project-detail.ts
@@ -1,11 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import type {
-  SecretSlot,
-  UserSource,
-  UserSourceLatestDeployment,
-} from "@aomi-labs/deploy";
+import type { UserSource, UserSourceLatestDeployment } from "@aomi-labs/deploy";
 import {
   deploymentSources,
   deploymentHistory,
@@ -23,6 +19,11 @@ import {
   launchStatus,
   launchActivate,
 } from "@build/features/launch/client";
+import {
+  MissingRequiredSecretsError,
+  missingRequiredSecrets,
+  type RequiredSecretsByApp,
+} from "@build/features/launch/required-secrets";
 import type {
   LaunchSdkStatus,
   DeploymentPromoteResult,
@@ -59,10 +60,8 @@ export function useProjectDetail(sourceId: number) {
     DeploymentRecord[]
   > | null>(null);
   const [recordsError, setRecordsError] = useState<string | null>(null);
-  const [requiredSecrets, setRequiredSecrets] = useState<Record<
-    string,
-    { slots: SecretSlot[]; missing: string[] }
-  > | null>(null);
+  const [requiredSecrets, setRequiredSecrets] =
+    useState<RequiredSecretsByApp | null>(null);
   const [requiredSecretsError, setRequiredSecretsError] = useState<
     string | null
   >(null);
@@ -132,21 +131,45 @@ export function useProjectDetail(sourceId: number) {
       });
   }, [sourceId, secretsByApp]);
 
-  const loadRequiredSecrets = useCallback(() => {
-    if (requiredSecretsReq.current || requiredSecrets !== null) return;
+  const refreshRequiredSecrets = useCallback(async () => {
     requiredSecretsReq.current = true;
     setRequiredSecretsError(null);
-    void deploymentRequiredSecrets({ appSourceId: sourceId })
-      .then((r) => setRequiredSecrets(r.byApp))
-      .catch((err) => {
-        setRequiredSecretsError(
-          err instanceof Error
-            ? err.message
-            : "Failed to load required secrets",
-        );
-        requiredSecretsReq.current = false;
-      });
-  }, [sourceId, requiredSecrets]);
+    try {
+      const result = await deploymentRequiredSecrets({ appSourceId: sourceId });
+      setRequiredSecrets(result.byApp);
+      return result.byApp;
+    } catch (err) {
+      setRequiredSecretsError(
+        err instanceof Error ? err.message : "Failed to load required secrets",
+      );
+      requiredSecretsReq.current = false;
+      throw err;
+    }
+  }, [sourceId]);
+
+  const loadRequiredSecrets = useCallback(() => {
+    if (requiredSecretsReq.current || requiredSecrets !== null) return;
+    void refreshRequiredSecrets().catch(() => undefined);
+  }, [refreshRequiredSecrets, requiredSecrets]);
+
+  const ensureRequiredSecrets = useCallback(
+    async (apps: string[], appSourceIdOverride?: number) => {
+      const byApp =
+        appSourceIdOverride === undefined
+          ? await refreshRequiredSecrets()
+          : (
+              await deploymentRequiredSecrets({
+                appSourceId: appSourceIdOverride,
+              })
+            ).byApp;
+      if (appSourceIdOverride !== undefined) setRequiredSecrets(byApp);
+      const missing = missingRequiredSecrets(byApp, apps);
+      if (Object.keys(missing).length > 0) {
+        throw new MissingRequiredSecretsError(missing);
+      }
+    },
+    [refreshRequiredSecrets],
+  );
 
   const hasMissingSecrets = useCallback(
     (app: string) => (requiredSecrets?.[app]?.missing.length ?? 0) > 0,
@@ -176,11 +199,10 @@ export function useProjectDetail(sourceId: number) {
         secrets,
       });
       await refreshSecrets();
-      setRequiredSecrets(null);
-      requiredSecretsReq.current = false;
+      await refreshRequiredSecrets();
       return result;
     },
-    [sourceId, refreshSecrets],
+    [refreshRequiredSecrets, refreshSecrets, sourceId],
   );
 
   const deleteEnvVar = useCallback(
@@ -262,6 +284,7 @@ export function useProjectDetail(sourceId: number) {
       });
       const pre = await launchPreflight({ repo });
       const appSourceId = pre.appSourceId ?? sourceId;
+      await ensureRequiredSecrets(pre.apps, appSourceId);
       setDeployFlow({ phase: "deploying", message: "Deploying new version…" });
       const deployed = await launchDeploy({
         appSourceId,
@@ -334,7 +357,7 @@ export function useProjectDetail(sourceId: number) {
         message: err instanceof Error ? err.message : "Deploy failed",
       });
     }
-  }, [source, sourceId, reload, refreshRecords]);
+  }, [ensureRequiredSecrets, source, sourceId, reload, refreshRecords]);
 
   const upgradeSdk = useCallback(
     () => deploymentUpgradeSdk({ appSourceId: sourceId }),
@@ -358,6 +381,8 @@ export function useProjectDetail(sourceId: number) {
     loadHistory,
     loadSecrets,
     loadRequiredSecrets,
+    refreshRequiredSecrets,
+    ensureRequiredSecrets,
     hasMissingSecrets,
     setEnvVars,
     deleteEnvVar,

--- a/apps/aomi-build/src/features/launch/required-secrets.ts
+++ b/apps/aomi-build/src/features/launch/required-secrets.ts
@@ -1,0 +1,30 @@
+import type { SecretSlot } from "@aomi-labs/deploy";
+
+export type RequiredSecretsByApp = Record<
+  string,
+  { slots: SecretSlot[]; missing: string[] }
+>;
+
+export class MissingRequiredSecretsError extends Error {
+  readonly missing: Record<string, string[]>;
+
+  constructor(missing: Record<string, string[]>) {
+    const names = Object.entries(missing)
+      .map(([app, keys]) => `${app}: ${keys.join(", ")}`)
+      .join("; ");
+    super(`Missing required secrets — ${names}`);
+    this.name = "MissingRequiredSecretsError";
+    this.missing = missing;
+  }
+}
+
+export function missingRequiredSecrets(
+  byApp: RequiredSecretsByApp,
+  apps: string[],
+): Record<string, string[]> {
+  return Object.fromEntries(
+    apps
+      .map((app) => [app, byApp[app]?.missing ?? []] as const)
+      .filter(([, missing]) => missing.length > 0),
+  );
+}


### PR DESCRIPTION
## Summary

- Block existing-project redeploys until required secrets are verified.
- Add inline required-secret inputs and save/recheck flow to the new-project wizard.
- Preserve structured activation errors so missing secret names reach the UI.
- Add a direct Environment action for blocked existing projects.

## Root cause

The existing-project one-click redeploy path started the build before checking required secrets, while the onboarding gate only disabled activation and did not offer a way to enter the values. The client also discarded the structured backend error body.

## Validation

- `pnpm exec vitest run src/features/launch/components/deploy-step.test.tsx src/features/launch/components/oneshot-wizard.test.tsx src/features/launch/components/deployments/tabs/deployments-tab.test.tsx src/features/launch/components/deployments/project-page.test.tsx src/features/launch/hooks/use-project-detail.test.ts` — 39 passed
- `pnpm --filter aomi-build type-check`
- `pnpm --filter aomi-build lint` — 3 existing warnings, 0 errors
- `pnpm --filter aomi-build build`