### PR TITLE
Harden runtime materialization activation checks

### DIFF
--- a/apps/aomi-build/src/features/launch/hooks/use-project-detail.test.ts
+++ b/apps/aomi-build/src/features/launch/hooks/use-project-detail.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
 
 vi.mock("@build/features/launch/client", () => ({
@@ -28,6 +28,7 @@ vi.mock("@build/features/launch/client", () => ({
   launchDeploy: vi.fn(),
   launchStatus: vi.fn(),
   launchActivate: vi.fn(),
+  launchAppStatus: vi.fn(),
   deploymentRecords: vi.fn(async () => ({
     app: "my-bot",
     currentReleaseTag: "tag-b",
@@ -57,10 +58,48 @@ import {
   deploymentRecords,
   deploymentHistory,
   deploymentSecrets,
+  launchPreflight,
+  launchDeploy,
+  launchStatus,
+  launchActivate,
+  launchAppStatus,
 } from "@build/features/launch/client";
 
 describe("useProjectDetail", () => {
   beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.useRealTimers());
+
+  function mockReadyDeployment() {
+    vi.mocked(launchPreflight).mockResolvedValue({
+      appSourceId: 7,
+      sourceRef: "sha-1",
+      repo: "a/b",
+      deployment: {},
+      releaseTags: ["tag-c"],
+      apps: ["my-bot"],
+    });
+    vi.mocked(launchDeploy).mockResolvedValue({
+      appSourceId: 7,
+      sourceRef: "sha-1",
+      repo: "a/b",
+      deployment: { id: "dep-c" },
+      releaseTags: ["tag-c"],
+      apps: ["my-bot"],
+    });
+    vi.mocked(launchStatus).mockResolvedValue({
+      state: "ready",
+      releaseTags: ["tag-c"],
+    });
+    vi.mocked(launchActivate).mockResolvedValue({
+      ok: true,
+      activation: {
+        status: "activating",
+        platform: "test",
+        target: { kind: "release", value: "tag-c", promoted: [] },
+        apps: [{ name: "my-bot", releaseTag: "tag-c" }],
+      },
+    });
+  }
 
   it("resolves the source and lazily loads history once", async () => {
     const { result } = renderHook(() => useProjectDetail(7));
@@ -165,5 +204,112 @@ describe("useProjectDetail", () => {
       expect(result.current.secretsByApp?.demo).toHaveLength(1),
     );
     expect(result.current.secretsError).toBeNull();
+  });
+
+  it("keeps polling when runtime status is temporarily unavailable", async () => {
+    mockReadyDeployment();
+    vi.mocked(launchAppStatus)
+      .mockRejectedValueOnce(new Error("app not found yet"))
+      .mockResolvedValueOnce({
+        ok: false,
+        state: "pending",
+        app: { name: "my-bot", is_active: false, loaded: false },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        state: "live",
+        app: { name: "my-bot", is_active: true, loaded: true },
+      });
+    const { result } = renderHook(() => useProjectDetail(7));
+    await waitFor(() => expect(result.current.source?.id).toBe(7));
+    vi.useFakeTimers();
+
+    let deployPromise!: Promise<void>;
+    await act(async () => {
+      deployPromise = result.current.deployNewVersion();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(launchAppStatus).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(launchAppStatus).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+      await deployPromise;
+    });
+
+    expect(result.current.deployFlow).toEqual({
+      phase: "done",
+      message: "New version is live.",
+    });
+  });
+
+  it("requires two consecutive terminal runtime results before failing", async () => {
+    mockReadyDeployment();
+    vi.mocked(launchAppStatus).mockResolvedValue({
+      ok: false,
+      state: "pending",
+      app: { name: "my-bot", is_active: false, loaded: false },
+    });
+    const { result } = renderHook(() => useProjectDetail(7));
+    await waitFor(() => expect(result.current.source?.id).toBe(7));
+    vi.useFakeTimers();
+
+    let deployPromise!: Promise<void>;
+    await act(async () => {
+      deployPromise = result.current.deployNewVersion();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(launchAppStatus).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+      await deployPromise;
+    });
+
+    expect(launchAppStatus).toHaveBeenCalledTimes(2);
+    expect(result.current.deployFlow).toEqual({
+      phase: "error",
+      message: "Runtime check failed for my-bot.",
+    });
+  });
+
+  it("fails with a timeout after the bounded runtime polling window", async () => {
+    mockReadyDeployment();
+    vi.mocked(launchAppStatus).mockResolvedValue({
+      ok: false,
+      state: "pending",
+      app: { name: "my-bot", is_active: true, loaded: false },
+    });
+    const { result } = renderHook(() => useProjectDetail(7));
+    await waitFor(() => expect(result.current.source?.id).toBe(7));
+    vi.useFakeTimers();
+
+    let deployPromise!: Promise<void>;
+    await act(async () => {
+      deployPromise = result.current.deployNewVersion();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(launchAppStatus).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000 * 29);
+      await deployPromise;
+    });
+
+    expect(launchAppStatus).toHaveBeenCalledTimes(30);
+    expect(result.current.deployFlow).toEqual({
+      phase: "error",
+      message:
+        "Activation was accepted, but the app artifact did not become ready.",
+    });
   });
 });

--- a/apps/aomi-build/src/features/launch/hooks/use-project-detail.ts
+++ b/apps/aomi-build/src/features/launch/hooks/use-project-detail.ts
@@ -278,8 +278,9 @@ export function useProjectDetail(sourceId: number) {
         apps,
       });
       const activatedApps = activated.activation.apps;
+      const terminalPolls = new Map<string, number>();
       for (let attempt = 0; attempt < RUNTIME_POLL_ATTEMPTS; attempt += 1) {
-        const checks = await Promise.all(
+        const results = await Promise.allSettled(
           activatedApps.map((app) =>
             launchAppStatus({
               name: app.name,
@@ -287,8 +288,15 @@ export function useProjectDetail(sourceId: number) {
             }),
           ),
         );
+        const checks = results.flatMap((result) =>
+          result.status === "fulfilled" ? [result.value] : [],
+        );
+        const pollFailed = results.some(
+          (result) => result.status === "rejected",
+        );
         if (
-          checks.length > 0 &&
+          !pollFailed &&
+          checks.length === activatedApps.length &&
           checks.every((check) => check.ok && check.state === "live")
         ) {
           setDeployFlow({ phase: "done", message: "New version is live." });
@@ -296,24 +304,44 @@ export function useProjectDetail(sourceId: number) {
           refreshRecords();
           return;
         }
-        const terminal = checks.find(
-          (check) =>
-            check.app?.is_active === false && check.app?.loaded === false,
-        );
-        if (terminal) {
-          setDeployFlow({
-            phase: "error",
-            message: terminal.app?.name
-              ? `Runtime check failed for ${terminal.app.name}.`
-              : "Runtime reported a terminal error during activation.",
+        if (pollFailed) {
+          // A freshly activated app may not be visible through the status
+          // endpoint yet. Treat lookup errors as pending and restart the
+          // terminal-failure streak so one transient miss cannot fail a live
+          // activation.
+          terminalPolls.clear();
+        } else {
+          const terminal = checks.find((check) => {
+            const app = check.app;
+            if (!app) return false;
+            if (app.is_active === false && app.loaded === false) {
+              const name = app.name;
+              const streak = (terminalPolls.get(name) ?? 0) + 1;
+              terminalPolls.set(name, streak);
+              return streak >= 2;
+            }
+            terminalPolls.delete(app.name);
+            return false;
           });
-          return;
+          if (terminal) {
+            setDeployFlow({
+              phase: "error",
+              message: terminal.app?.name
+                ? `Runtime check failed for ${terminal.app.name}.`
+                : "Runtime reported a terminal error during activation.",
+            });
+            await reload();
+            refreshRecords();
+            return;
+          }
         }
         setDeployFlow({
           phase: "activating",
           message: `Waiting for runtime… (${attempt + 1}/${RUNTIME_POLL_ATTEMPTS})`,
         });
-        await new Promise((resolve) => setTimeout(resolve, RUNTIME_POLL_MS));
+        if (attempt < RUNTIME_POLL_ATTEMPTS - 1) {
+          await new Promise((resolve) => setTimeout(resolve, RUNTIME_POLL_MS));
+        }
       }
       setDeployFlow({
         phase: "error",

--- a/apps/aomi-build/src/features/launch/hooks/use-project-detail.ts
+++ b/apps/aomi-build/src/features/launch/hooks/use-project-detail.ts
@@ -277,7 +277,18 @@ export function useProjectDetail(sourceId: number) {
         releaseTags,
         apps,
       });
-      const activatedApps = activated.activation.apps;
+      // A rejected/partial activation still returns apps (with `error` set), and
+      // a malformed response may omit `activation` entirely — surface the real
+      // reason instead of throwing into the generic "Deploy failed" catch.
+      const activatedApps = activated.activation?.apps ?? [];
+      const failed = activatedApps.find((app) => app.error);
+      if (!activated.ok || failed) {
+        setDeployFlow({
+          phase: "error",
+          message: failed?.error ?? "Activation was not accepted.",
+        });
+        return;
+      }
       const terminalPolls = new Map<string, number>();
       for (let attempt = 0; attempt < RUNTIME_POLL_ATTEMPTS; attempt += 1) {
         const results = await Promise.allSettled(
@@ -312,15 +323,14 @@ export function useProjectDetail(sourceId: number) {
           terminalPolls.clear();
         } else {
           const terminal = checks.find((check) => {
-            const app = check.app;
-            if (!app) return false;
-            if (app.is_active === false && app.loaded === false) {
-              const name = app.name;
+            const name = check.app?.name;
+            if (!name) return false;
+            if (check.app.is_active === false && check.app.loaded === false) {
               const streak = (terminalPolls.get(name) ?? 0) + 1;
               terminalPolls.set(name, streak);
               return streak >= 2;
             }
-            terminalPolls.delete(app.name);
+            terminalPolls.delete(name);
             return false;
           });
           if (terminal) {

--- a/apps/portal/src/features/launch/hooks/use-project-detail.test.ts
+++ b/apps/portal/src/features/launch/hooks/use-project-detail.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
 
 vi.mock("@portal/features/launch/client", () => ({
@@ -28,6 +28,7 @@ vi.mock("@portal/features/launch/client", () => ({
   launchDeploy: vi.fn(),
   launchStatus: vi.fn(),
   launchActivate: vi.fn(),
+  launchAppStatus: vi.fn(),
   deploymentRecords: vi.fn(async () => ({
     app: "my-bot",
     currentReleaseTag: "tag-b",
@@ -57,10 +58,48 @@ import {
   deploymentRecords,
   deploymentHistory,
   deploymentSecrets,
+  launchPreflight,
+  launchDeploy,
+  launchStatus,
+  launchActivate,
+  launchAppStatus,
 } from "@portal/features/launch/client";
 
 describe("useProjectDetail", () => {
   beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.useRealTimers());
+
+  function mockReadyDeployment() {
+    vi.mocked(launchPreflight).mockResolvedValue({
+      appSourceId: 7,
+      sourceRef: "sha-1",
+      repo: "a/b",
+      deployment: {},
+      releaseTags: ["tag-c"],
+      apps: ["my-bot"],
+    });
+    vi.mocked(launchDeploy).mockResolvedValue({
+      appSourceId: 7,
+      sourceRef: "sha-1",
+      repo: "a/b",
+      deployment: { id: "dep-c" },
+      releaseTags: ["tag-c"],
+      apps: ["my-bot"],
+    });
+    vi.mocked(launchStatus).mockResolvedValue({
+      state: "ready",
+      releaseTags: ["tag-c"],
+    });
+    vi.mocked(launchActivate).mockResolvedValue({
+      ok: true,
+      activation: {
+        status: "activating",
+        platform: "test",
+        target: { kind: "release", value: "tag-c", promoted: [] },
+        apps: [{ name: "my-bot", releaseTag: "tag-c" }],
+      },
+    });
+  }
 
   it("resolves the source and lazily loads history once", async () => {
     const { result } = renderHook(() => useProjectDetail(7));
@@ -151,5 +190,112 @@ describe("useProjectDetail", () => {
       expect(result.current.secretsByApp?.demo).toHaveLength(1),
     );
     expect(result.current.secretsError).toBeNull();
+  });
+
+  it("keeps polling when runtime status is temporarily unavailable", async () => {
+    mockReadyDeployment();
+    vi.mocked(launchAppStatus)
+      .mockRejectedValueOnce(new Error("app not found yet"))
+      .mockResolvedValueOnce({
+        ok: false,
+        state: "pending",
+        app: { name: "my-bot", is_active: false, loaded: false },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        state: "live",
+        app: { name: "my-bot", is_active: true, loaded: true },
+      });
+    const { result } = renderHook(() => useProjectDetail(7));
+    await waitFor(() => expect(result.current.source?.id).toBe(7));
+    vi.useFakeTimers();
+
+    let deployPromise!: Promise<void>;
+    await act(async () => {
+      deployPromise = result.current.deployNewVersion();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(launchAppStatus).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(launchAppStatus).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+      await deployPromise;
+    });
+
+    expect(result.current.deployFlow).toEqual({
+      phase: "done",
+      message: "New version is live.",
+    });
+  });
+
+  it("requires two consecutive terminal runtime results before failing", async () => {
+    mockReadyDeployment();
+    vi.mocked(launchAppStatus).mockResolvedValue({
+      ok: false,
+      state: "pending",
+      app: { name: "my-bot", is_active: false, loaded: false },
+    });
+    const { result } = renderHook(() => useProjectDetail(7));
+    await waitFor(() => expect(result.current.source?.id).toBe(7));
+    vi.useFakeTimers();
+
+    let deployPromise!: Promise<void>;
+    await act(async () => {
+      deployPromise = result.current.deployNewVersion();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(launchAppStatus).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+      await deployPromise;
+    });
+
+    expect(launchAppStatus).toHaveBeenCalledTimes(2);
+    expect(result.current.deployFlow).toEqual({
+      phase: "error",
+      message: "Runtime check failed for my-bot.",
+    });
+  });
+
+  it("fails with a timeout after the bounded runtime polling window", async () => {
+    mockReadyDeployment();
+    vi.mocked(launchAppStatus).mockResolvedValue({
+      ok: false,
+      state: "pending",
+      app: { name: "my-bot", is_active: true, loaded: false },
+    });
+    const { result } = renderHook(() => useProjectDetail(7));
+    await waitFor(() => expect(result.current.source?.id).toBe(7));
+    vi.useFakeTimers();
+
+    let deployPromise!: Promise<void>;
+    await act(async () => {
+      deployPromise = result.current.deployNewVersion();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(launchAppStatus).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000 * 29);
+      await deployPromise;
+    });
+
+    expect(launchAppStatus).toHaveBeenCalledTimes(30);
+    expect(result.current.deployFlow).toEqual({
+      phase: "error",
+      message:
+        "Activation was accepted, but the app artifact did not become ready.",
+    });
   });
 });

--- a/apps/portal/src/features/launch/hooks/use-project-detail.ts
+++ b/apps/portal/src/features/launch/hooks/use-project-detail.ts
@@ -301,15 +301,14 @@ export function useProjectDetail(sourceId: number) {
           terminalPolls.clear();
         } else {
           const terminal = checks.find((check) => {
-            const app = check.app;
-            if (!app) return false;
-            if (app.is_active === false && app.loaded === false) {
-              const name = app.name;
+            const name = check.app?.name;
+            if (!name) return false;
+            if (check.app.is_active === false && check.app.loaded === false) {
               const streak = (terminalPolls.get(name) ?? 0) + 1;
               terminalPolls.set(name, streak);
               return streak >= 2;
             }
-            terminalPolls.delete(app.name);
+            terminalPolls.delete(name);
             return false;
           });
           if (terminal) {

--- a/apps/portal/src/features/launch/hooks/use-project-detail.ts
+++ b/apps/portal/src/features/launch/hooks/use-project-detail.ts
@@ -267,8 +267,9 @@ export function useProjectDetail(sourceId: number) {
         apps,
       });
       const activatedApps = activated.activation.apps;
+      const terminalPolls = new Map<string, number>();
       for (let attempt = 0; attempt < RUNTIME_POLL_ATTEMPTS; attempt += 1) {
-        const checks = await Promise.all(
+        const results = await Promise.allSettled(
           activatedApps.map((app) =>
             launchAppStatus({
               name: app.name,
@@ -276,8 +277,15 @@ export function useProjectDetail(sourceId: number) {
             }),
           ),
         );
+        const checks = results.flatMap((result) =>
+          result.status === "fulfilled" ? [result.value] : [],
+        );
+        const pollFailed = results.some(
+          (result) => result.status === "rejected",
+        );
         if (
-          checks.length > 0 &&
+          !pollFailed &&
+          checks.length === activatedApps.length &&
           checks.every((check) => check.ok && check.state === "live")
         ) {
           setDeployFlow({ phase: "done", message: "New version is live." });
@@ -285,24 +293,44 @@ export function useProjectDetail(sourceId: number) {
           refreshRecords();
           return;
         }
-        const terminal = checks.find(
-          (check) =>
-            check.app?.is_active === false && check.app?.loaded === false,
-        );
-        if (terminal) {
-          setDeployFlow({
-            phase: "error",
-            message: terminal.app?.name
-              ? `Runtime check failed for ${terminal.app.name}.`
-              : "Runtime reported a terminal error during activation.",
+        if (pollFailed) {
+          // A freshly activated app may not be visible through the status
+          // endpoint yet. Treat lookup errors as pending and restart the
+          // terminal-failure streak so one transient miss cannot fail a live
+          // activation.
+          terminalPolls.clear();
+        } else {
+          const terminal = checks.find((check) => {
+            const app = check.app;
+            if (!app) return false;
+            if (app.is_active === false && app.loaded === false) {
+              const name = app.name;
+              const streak = (terminalPolls.get(name) ?? 0) + 1;
+              terminalPolls.set(name, streak);
+              return streak >= 2;
+            }
+            terminalPolls.delete(app.name);
+            return false;
           });
-          return;
+          if (terminal) {
+            setDeployFlow({
+              phase: "error",
+              message: terminal.app?.name
+                ? `Runtime check failed for ${terminal.app.name}.`
+                : "Runtime reported a terminal error during activation.",
+            });
+            await reload();
+            refreshRecords();
+            return;
+          }
         }
         setDeployFlow({
           phase: "activating",
           message: `Waiting for runtime… (${attempt + 1}/${RUNTIME_POLL_ATTEMPTS})`,
         });
-        await new Promise((resolve) => setTimeout(resolve, RUNTIME_POLL_MS));
+        if (attempt < RUNTIME_POLL_ATTEMPTS - 1) {
+          await new Promise((resolve) => setTimeout(resolve, RUNTIME_POLL_MS));
+        }
       }
       setDeployFlow({
         phase: "error",


### PR DESCRIPTION
## What changed

Follow up the runtime-materialization polling fix with defensive activation-response handling in the Aomi Build and Portal project-detail hooks.

- Validate `launchActivate` responses before reading `activation.apps`.
- Surface partial or malformed activation failures with an actionable deploy-flow error instead of falling into the generic catch path.
- Treat runtime status results without an app name as pending/non-terminal in both hooks.

The branch also contains the earlier runtime polling hardening from `5dba6ce7`: transient status lookup failures are tolerated, terminal failures require two consecutive observations, and polling remains bounded.

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/features/launch/hooks/use-project-detail.test.ts` from `apps/aomi-build` — 9 passed
- Same focused command from `apps/portal` — 8 passed
- Prettier check passed
- `git diff --cached --check` passed