### PR TITLE
Promote auth research article to production

### DIFF
--- a/apps/landing/content/research/auth-across-two-worlds.md
+++ b/apps/landing/content/research/auth-across-two-worlds.md
@@ -1,0 +1,301 @@
+<!--
+Aomi Research post — auth-across-two-worlds
+slug: auth-across-two-worlds
+tag: engineering
+Figures live in public/research/auth-across-two-worlds/figures/ and are referenced
+by absolute path so the shared renderer serves them without slug-specific rewrites.
+Code samples are architectural pseudocode; they deliberately avoid internal package,
+table, env, and endpoint names.
+-->
+
+# One User, Many Wallets: Authentication Across the Onchain–Offchain Boundary
+
+*A design study in authentication for applications that straddle the chain: why "how many users do we have?" is a surprisingly hard question, the four proofs a hybrid system has to keep separate, and the patterns that hold them apart — with the stack we settled on at Aomi as the running example.*
+
+Start with a question every product team assumes is trivial: **how many users do you have?**
+
+An offchain application answers it with one query against its users table. A crypto application usually cannot. What it has is addresses, and an address is not a person. One person shows up as a MetaMask EOA, an embedded wallet minted by a provider, a smart account owned by the first address, and a Solana account in a different key format. And the mapping drifts — wallets get created, imported, rotated, abandoned, and replaced, and nobody tells your database.
+
+If counting were only an analytics problem, you could shrug it off. It isn't, because almost everything an application does offchain keys off "user":
+
+- **Continuity.** Recognize the returning person — same history, same settings, same entitlements — even when they arrive on a new device with a different wallet connected. Users experience a failure here as amnesia: "I was here yesterday, why does the app not know me?"
+- **Limits and quotas.** Rate limits, free tiers, and usage metering have to be per person. Addresses are free to mint, so a per-address limit is a 10× coupon for anyone willing to click "new wallet" ten times.
+- **Billing.** You cannot invoice an address — and you especially cannot invoice five of them separately for what is one customer.
+- **Abuse, support, recovery.** Fraud signals, bans, "I lost my wallet" tickets — all of it needs a person-level root that survives any single key.
+
+![Figure 1 — The counting problem: one person spans many addresses, and the mapping drifts.](/research/auth-across-two-worlds/figures/f00_users_vs_addresses.svg)
+
+**Figure 1 — The counting problem.** One person spans several wallets — external, embedded, smart, rotated, abandoned — and the mapping changes without anyone telling your database. Every per-user question — counting, limits, history, billing — is unanswerable until the application owns an account object of its own.
+
+For us the forcing function was sharper still. Aomi runs conversations and prepares transactions server-side: every request burns model tokens, RPC calls, and fork simulations, and the end of a session can be a signed transaction. Metering that per address is meaningless. Authorizing it per address is dangerous. Somewhere between "how many users do we have?" and "may this signer approve this action?" an analytics annoyance turns into a security requirement — and the missing object is the same in both cases: the user.
+
+The tension underneath is that a hybrid application inherits two identity systems that were never designed to line up. Onchain identity is a keypair: permissionless, pseudonymous, free to create, impossible to recover. Offchain identity is an account: issued by the application, recoverable, countable, attached to state. The tempting fixes collapse one into the other. The wallet address becomes the user id. The wallet provider's access token becomes the session. One JWT gets reused for login, backend access, and signing. "The connected wallet" is whichever address a React hook reported most recently. Each of these holds together while the app has one provider, one chain, one wallet, and no server-side execution — and falls apart the moment a real user shows up with an external EVM wallet *and* an embedded one, a Solana account next to an Ethereum one, a smart account, a second login method, or an agent preparing transactions on their behalf.
+
+Our answer, condensed to one rule:
+
+> **A wallet is not a user, a provider is not the identity root, and a session is not a signing grant.**
+
+The rest of this post walks that rule outward. Section 2 lays out a small framework — the four different proofs hiding inside "sign in with a wallet." Sections 3 through 8 turn it into six patterns that apply to any hybrid application regardless of stack, each stated generally first and then grounded in our own implementation: Better Auth for sessions, a backend-for-frontend, a Rust backend, Privy and Para as embedded-wallet providers. Section 9 catalogues every token in the system, and Section 10 explains why we picked that particular stack and what you could swap without losing the properties.
+
+## 1. What "sign in with a wallet" actually asks
+
+Before the framework, it is worth being precise about why wallet login feels deceptively complete. A signature from a wallet is real cryptographic evidence — it proves control of a key at a moment in time. The mistake is treating that one proof as an answer to every identity question an application has.
+
+An agentic or execution-capable application has to answer at least these, separately: Which account is this person? Is this still the same session as an hour ago? Which addresses belong to that account? Which address should act on this chain right now? And may this particular signer approve this particular action? A wallet signature answers the first question weakly and the rest not at all. Those questions sit side by side in a wallet picker, and they are not the same security question.
+
+## 2. A framework: four proofs, two planes
+
+"Sign in with a wallet" is at least four operations, with different lifetimes, different verifiers, and different blast radii when stolen.
+
+**Table 1 — The four proofs a hybrid application must keep separate.**
+
+| Proof | Question it answers | Typical evidence | What it does **not** prove |
+|---|---|---|---|
+| Login proof | Did the user satisfy a login method just now? | SIWE signature, provider JWT, passkey, email link | A permanent person-level identity |
+| First-party session | Is this still the same authenticated session? | HttpOnly session cookie or opaque session token | Control of every linked wallet |
+| Wallet association | Is this address linked to this account? | SIWE proof, provider-side wallet attestation | Permission to sign every future action |
+| Execution authority | May this signer approve this class of action? | Interactive approval, delegated provider grant | The user's global application identity |
+
+A login proof is short-lived and method-specific. A session is application-specific and should outlive any one login provider. A wallet association stays useful long after the login ceremony that discovered it has ended. And an execution grant can be far narrower than the wallet itself: one provider, one address, one chain family, one expiry, one signer mode.
+
+We found it useful to arrange these on two planes. The **identity plane** consumes login proofs, resolves account linking, and emits one stable user id — it answers who. The **execution plane** manages wallets and authority: which addresses exist, which one is active per chain family, whether a wallet signs interactively or through a provider, and which delegated approvals are still valid — it answers what a wallet may do. The planes meet at the canonical user id, and nowhere else.
+
+![Figure 2 — Four proofs across the identity and execution planes, meeting at one canonical user id.](/research/auth-across-two-worlds/figures/f01_four_proofs.svg)
+
+**Figure 2 — Four proofs, two planes.** Login proves a credential, the first-party session preserves continuity, a wallet attestation associates an address, and a signing grant authorizes one execution path. The identity plane answers who the user is; the execution plane answers what a wallet may do.
+
+One subtle consequence: the same vendor can appear in both planes without doing the same job. An embedded-wallet provider's token used at the edge answers "which account does this credential belong to?" A provider connection created later answers "how can this wallet authorize an action?" Same vendor, different proof, different lifetime, different verifier.
+
+The common shortcuts are attractive precisely because each deletes one of these layers:
+
+1. **Use the wallet address as the user id.** A second wallet now looks like a second person, and rotating a wallet becomes an account migration.
+2. **Pass the provider JWT to every backend service.** Every service is now coupled to every provider's issuer, key format, claims, outages, and deprecation schedule.
+3. **Put everything in one long-lived JWT.** Login continuity, backend access, wallet selection, and signing collapse into a single replayable credential with an oversized blast radius.
+4. **Assume the currently connected address is the intended signer.** Multi-connector sessions, EVM/SVM coexistence, embedded wallets, and smart accounts make "current" an unstable concept.
+5. **Treat a successful provider fetch as the only truth.** A transient outage now looks like the provider deleted every wallet.
+
+The six patterns below add boundaries instead of removing them. The extra boundaries are what make the system possible to reason about.
+
+## 3. Own your identity root
+
+> Mint your own user id — a boring, application-owned identifier — and treat every external identity as a *signal attached to it*: wallet addresses, provider subjects, verified emails, session records. Nothing you do not issue can be the root, because anything you do not issue can be rotated, revoked, or taken away by someone else's outage, migration, or deprecation.
+
+This is the move that answers the counting question directly. Users become countable because the application finally has a row per person. Limits, billing, and history hang off that row. A user who arrives through a wallet signature, later adds a provider login, then switches providers does not become three people — and if a provider has an outage, the account still exists.
+
+It also turns abuse economics right-side up. Once limits hang off the account instead of the address, they can be tiered by *identity strength*: a wallet-only account gets a conservative free tier, and linking a verified email or phone raises it — because every added factor raises the cost of manufacturing another account. Sybil resistance stops being a binary gate and becomes a pricing curve. The session layer's position pays off here too: because every login terminates in one framework, fleet-level abuse tooling plugs in at exactly one place. Better Auth's [Sentinel](https://better-auth.com/docs/infrastructure/plugins/sentinel) plugin, for example, adds signup and sign-in velocity limits per IP and visitor, device fingerprinting that catches one machine farming "different" free accounts, email normalization that collapses alias tricks into a single identity, and bot and credential-stuffing defenses — all upstream of the account graph, not reimplemented per service. For a product whose requests are genuinely expensive to serve — ours burn model tokens, RPC calls, and simulations — this is the difference between rate-limiting people and rate-limiting whoever bothered to mint a fresh address.
+
+In our implementation, the account model is a graph with three classes of node: the **canonical user** (the stable Aomi-owned id), **authentication identities** (Better Auth user references, SIWE identities, Privy and Para subjects, verified emails), and **wallets** (external, embedded, or smart-account addresses, tagged by chain family, provider, provenance, and status). A fourth class — execution approvals — belongs to the execution plane and is linked later.
+
+![Figure 3 — The canonical account graph: login identities above, wallets below, execution approvals attached separately.](/research/auth-across-two-worlds/figures/f02_account_graph.svg)
+
+**Figure 3 — The canonical account graph.** Login factors and wallet resources attach to one application-owned user. Provider subjects are credential keys, wallet addresses are resources, and execution approvals are separate capability records that reference — but never replace — the canonical id.
+
+The resolver can use any verified signal to find an existing user: a session mapping, a provider subject, a verified email, a previously proven wallet. It creates a new canonical user only when nothing resolves. Two rules keep the graph trustworthy:
+
+**Uniqueness is a security invariant.** A provider identity, verified email, or normalized wallet address must never silently move between accounts. For each verified signal there are exactly three outcomes: unclaimed (attach it), already attached here (no-op), attached elsewhere (conflict — roll back). That turns ambiguous identity evidence into an explicit support case instead of an accidental account takeover. Linking is transactional: if a provider subject belongs to one user but one of its attested wallets already belongs to another, the exchange fails and the graph stays untouched.
+
+**A linked wallet is not a login root.** External wallets link through a SIWE-style challenge binding user, address, chain, domain, nonce, and time — signature recovery for EOAs, an onchain or deployless check for smart accounts, since not every valid wallet has a recoverable secp256k1 signer behind it. Embedded wallets link through a server-verified provider attestation instead, and the record is marked with that provenance so it is never confused with a signature-proven link. The account stays stable across wallet types; the wallet record stays honest about how it got there.
+
+One positioning decision matters more than any library choice: the session framework sits *in front of* the account graph, never inside it. Better Auth handles what session systems are good at — cookies, rotation, expiry, sign-out, login-method plugins — and when a session resolves, we map its user reference to the canonical id. That id, never the session record and never a provider DID, is what the rest of the system sees. It makes the session layer replaceable, which is exactly the property an identity root should force on everything around it.
+
+## 4. Verify at the edge, normalize after
+
+> Every external credential gets verified according to *its own* cryptographic contract, at the edge, before anything else touches it — and only verified claims get normalized into a common internal shape. The order matters: normalize after verification, never before. An unverified claim is input, not identity.
+
+The anti-pattern is a generic "decode JWT" helper that treats all vendor tokens alike. Different providers pin different things — one a fixed verification key and issuer, another a JWKS lookup with key-id and audience checks — and a helper that papers over the differences will eventually accept something it should not.
+
+In practice, the frontend presents several login surfaces — SIWE from an external or smart-account wallet, a Privy token, a Para session JWT, a plain email flow. The browser can *acquire* those proofs; it cannot declare them valid. Every lane converges server-side:
+
+![Figure 4 — SIWE, Privy, and Para login lanes converge through normalization and transactional linking into one first-party session.](/research/auth-across-two-worlds/figures/f03_login_lanes.svg)
+
+**Figure 4 — Three ceremonies, one session.** Provider-specific verification is isolated at the edge. After verification, each lane emits the same normalized identity and wallet signals, which are linked transactionally before a session is created. Raw provider tokens never travel past this boundary.
+
+For a Privy token, the verifier pins algorithm, verification key, issuer, audience, expiry, and required claims. For a Para session JWT, it resolves the signing key from a JWKS, checks the key id, and validates algorithm, audience, expiry, and subject. In both cases the raw token is never the user id, is never forwarded deeper into the system, and never appears in logs. After verification, every adapter emits the same shape:
+
+![Code 1 — VerifiedCredential: the normalized shape every provider adapter emits.](/research/auth-across-two-worlds/figures/code1_verified_credential.svg)
+
+**Code 1.** The normalization seam keeps provider-specific claim names, wallet nesting, and API conventions out of the account graph. A provider can populate this from more than one source — token claims as a low-latency fallback, a server-side API for a fresher wallet list — merged and deduplicated by chain family and normalized address.
+
+The exchange itself is intentionally boring:
+
+![Code 2 — the provider exchange: verify, then link transactionally, then create the session.](/research/auth-across-two-worlds/figures/code2_provider_exchange.svg)
+
+**Code 2.** Verification happens before mutation, linking happens in one transaction, and the session is created only after the graph is coherent.
+
+One reconciliation rule deserves emphasis because so many systems get it wrong: **an outage is not a revocation.** Provider wallet lists change — users create, import, archive, and remove embedded wallets — and the graph needs to converge without turning an upstream incident into mass deletion. So reconciliation is monotonic: upsert every attested wallet, and only after a *successful* provider read, soft-revoke previously attested wallets from that same provider that are no longer present. If the fetch fails, existing links stay untouched. A Privy sync cannot touch a Para wallet, and no embedded-wallet sync can remove a signature-proven external wallet. "The provider returned no wallets" and "we could not ask the provider" are different facts.
+
+## 5. Broker identity across the service boundary
+
+> Do not let your session format leak into your backend services. Terminate the session at one edge service, and have that service mint a small, short-lived, audience-bound assertion for everything behind it. The backend verifies the assertion and stays ignorant of how the user logged in.
+
+Another token is justified only when it removes more coupling than it adds; here it removes a lot. Without the broker, every backend service parses session cookies, depends on the session store, understands provider fallback flows, and changes whenever the login stack changes. With it, the backend needs one stable contract:
+
+> "A trusted first-party issuer states that canonical user `sub` is making this request for audience `aud`, under role `role`, until `exp`."
+
+The frontend stays free to change login providers. The backend stays free to change language or framework. The contract between them is one small signed object.
+
+Concretely, the broker is a backend-for-frontend next to the web app; the consumer is a Rust backend that has no idea whether the user arrived through SIWE, Privy, Para, or an email link. The assertion, in full:
+
+**Table 2 — The backend assertion.**
+
+| Field | Meaning |
+|---|---|
+| `sub` | Stable canonical user id |
+| `iss` | Identity of the issuing BFF |
+| `aud` | Identity of the backend that may accept it |
+| `role` | Principal kind: user, service, or admin |
+| `iat` / `exp` | Issuance time and a short expiry — minutes, not days |
+| `kid` header | Public-key selector for rotation and multiple issuers |
+
+No provider tokens, no wallet secrets, no account graph — those facts have different lifetimes and do not belong frozen inside a service identity token. The browser session can live for days because it is first-party and revocable; the assertion is re-minted from a valid session as needed.
+
+In the default web path the browser never even holds the assertion. It calls a same-origin route with its HttpOnly cookie, and the BFF matches an explicit route allowlist, resolves the session to the canonical user, mints the assertion, **discards incoming cookies and any client-supplied authorization header**, injects its own `Authorization: Bearer`, and streams the response.
+
+![Figure 5 — The BFF converts a browser session into a server-injected backend assertion; no client credential crosses the boundary.](/research/auth-across-two-worlds/figures/f04_bff_boundary.svg)
+
+**Figure 5 — The credential-changing boundary.** The session cookie never crosses into the backend, and the browser cannot choose the backend identity header. The private signing key lives only in the BFF; the backend holds only public verification keys. Provider tokens stop one hop earlier still.
+
+This does more than hide a JWT from JavaScript: it makes it impossible for a client to smuggle an arbitrary bearer through the proxy, and it guarantees the backend sees identity only when the broker has resolved a real session. Clients that cannot use a same-origin proxy — a CLI, an embedded host — obtain the same short-lived assertion through an authenticated flow and carry it directly; only the transport changes, and the exposure is larger, which is why proxy injection stays the preferred web path.
+
+The whole handoff, end to end:
+
+![Figure 6 — one request end to end: each step changes credential type.](/research/auth-across-two-worlds/figures/f09_credential_pipeline.svg)
+
+**Figure 6 — One request, end to end.** Every arrow changes credential type. That is the point — reusing one credential across all five steps would erase the trust boundaries between them.
+
+## 6. Make verification boring and fail-closed
+
+> Verification should be a chain of small, independent checks where any failure is a hard rejection — and the verifier should be structurally unable to mint what it verifies. Key material is architecture: give the issuer the private key and the verifier only public keys, and "the backend cannot impersonate users" stops being a convention and becomes a physical fact.
+
+![Figure 7 — The backend verification chain: seven independent checks, each with a hard rejection exit, ending in typed context.](/research/auth-across-two-worlds/figures/f05_verification_chain.svg)
+
+**Figure 7 — Verification is a chain, and every link can fail.** A recognized key id is only a search hint. Signature, issuer, audience, expiry, issuer role policy, and the route's required role must all pass independently before `sub` becomes authenticated context.
+
+Two details generalize beyond our stack. First, the untrusted `kid` header only *selects candidate keys* — it narrows a search, it grants nothing. Second, roles are constrained per issuer: each trusted issuer is configured with the roles it may assert, so a frontend issuer trusted for `user` cannot sign a syntactically perfect token claiming `admin` and have it accepted. The signature is fine; the *permission to make that claim* is not.
+
+In our stack, the Rust backend registers every route with explicit, composable auth classes — which turns authentication from a middleware convention into a property of route construction:
+
+**Table 3 — Backend auth classes.**
+
+| Class | Requires | Resolves |
+|---|---|---|
+| Public | Nothing | No authenticated context |
+| Thread | Thread/session identifier | Conversation or runtime thread context |
+| Account | User-role assertion | Canonical user and account context |
+| App gate | Valid application key for private apps | App entitlement |
+| Service | Service-role assertion | Trusted service principal |
+| Admin | Admin-role assertion | Human operator principal |
+
+A chat route requires `Thread + Account + App gate`; a profile route only `Account`; a service callback only `Service`. Composition is AND. The property that matters is structural: adding a route *forces* choosing its auth class — there is no informal path list that can drift away from the router, and no handler that silently assumes middleware ran. A thread id identifies a conversation; an app key grants an entitlement; neither identifies the person. Keeping the dimensions separate is what lets policy be precise: the right user on the wrong thread fails, and the right user without the entitlement fails. Auth is a vector, not a Boolean.
+
+## 7. Wallets are a registry, not a variable
+
+> Model wallets as a registry of durable records with explicit state — not as "the connected address," a mutable global that happens to hold whatever a frontend hook last reported. A registry can represent what is actually true: many wallets known to the account, a subset live in the current client, and exactly one active per chain family.
+
+![Figure 8 — The multi-wallet registry: many known wallets, one active wallet per chain family, live and stored states kept distinct.](/research/auth-across-two-worlds/figures/f06_wallet_registry.svg)
+
+**Figure 8 — Durable ownership versus current selection.** The account can know many wallets while the client picks one active wallet independently per family. Selecting a Solana wallet does not touch the active EVM wallet, and connecting MetaMask does not erase an embedded wallet from the graph. Changing the active wallet never changes the authenticated user.
+
+Our registry distinguishes three states — **live** (attached through a connector, can act now), **stored** (linked to the account, useful for history and labels, cannot sign until reconnected), and **connectable** (brands and methods the user could activate). The picker renders one list, but every row carries capability and provenance instead of provider-specific branches: which chain family, external or embedded or smart, which provider manages it, how it was linked, what it can do (read, sign, send, display), and whether its association is live, revoked, or stale. That kills a recurring anti-pattern — deriving security policy from a display label like "Privy wallet." Labels are presentation; provenance and capability are state.
+
+The registry earns its keep at execution time. When an action needs a signature, the resolver does not ask for "the user's Privy wallet" and take the first match. It resolves a grant by canonical user, provider, chain family, **exact operating address**, and an active approval — EVM matching normalized, Solana matching exact — and fails if no grant yields the requested address. In a system where the server prepares transactions, this check is not optional: the transaction may target one wallet while several are linked, and "first available" is not a selection policy, it is a bug with a settlement layer.
+
+Smart accounts fit without special cases: account abstraction adds an owner address, a smart-account address, and sometimes a delegated authorization address, and all of them can matter to execution — but none replaces the canonical user. An account can move from an EOA path to a 4337 or 7702 path without becoming a new person.
+
+## 8. Login is not signing
+
+> Authenticating *with* a wallet provider and executing *through* one are different flows with different proofs, and a user can have either without the other.
+
+A **login flow** verifies a provider-issued credential and attaches the subject and attested wallets to the account. A **connection flow** establishes an operational grant a signer runtime can use later — wallet id, session material, policy, expiry. Logged in through Privy but executing through MetaMask is a perfectly coherent state; so is holding a Para wallet whose every signature stays interactive in the browser.
+
+In our system, connection flows leave the application and come back through a callback, so the callback needs cryptographic context. Before redirecting, the backend mints a short-lived state token binding the runtime thread, the canonical user, the requested provider, the application scope, and an expiry. The provider name lives *inside* the signed state — the callback cannot switch adapters by editing an unsigned query param.
+
+![Figure 9 — The provider connection ceremony: signed state protects the redirect round-trip before any approval is persisted.](/research/auth-across-two-worlds/figures/f08_connection_ceremony.svg)
+
+**Figure 9 — The connection ceremony.** Signed state travels out with the redirect and is verified before anything else on the way back — the adapter is selected from the verified state, never from the request, and only a fully verified callback is normalized into a revocable execution grant. The state token protects one round-trip; it is not a session and it is not a signing grant.
+
+The signer layer uses one provider abstraction with four responsibilities:
+
+![Code 3 — the provider interface: four responsibilities, one shape.](/research/auth-across-two-worlds/figures/code3_wallet_provider.svg)
+
+**Code 3.** The shared driver owns state verification and persistence; the provider owns its login URLs, callback interpretation, credential slots, and signing transport. Persistence never needs to know whether a provider called a field `wallets`, `linked_accounts`, or nested it inside a JWT claim.
+
+The abstraction unifies *shape*, not *authority*:
+
+**Table 4 — Provider capabilities in the current architecture.**
+
+| Dimension | Privy | Para |
+|---|---|---|
+| Login/link proof | Identity or access token | Session JWT |
+| Key verification | Pinned provider key, expected claims | Remote JWKS with key-id and audience checks |
+| Wallet discovery | Verified token + server-side lookup | Signed JWT wallet claims + optional server checks |
+| EVM and SVM association | Supported | Supported |
+| Server-side delegated signing | Supported with the required signer authorization | Not exposed through the current server path |
+| Interactive browser signing | Separate client path | Primary execution path |
+
+A provider that cannot safely sign server-side returns "unsupported" — it does not emulate success or leak a browser session into the backend. **Provider-neutral core does not mean capability-neutral providers.**
+
+The same discipline bounds what an agent can do. Provider credential material is resolved through a narrow signer interface: the agent sees wallet candidates, capabilities, approval status, and transaction results — never access tokens, never raw secret maps, and nothing that could be serialized into model context or logs. Delegation does not hand the agent a pen. The execution path keeps its gates — authenticated account, authorized route and app, exact-address grant match, provider mode support — and policy, simulation, and guards can still reject the action. The agent decides that an action *needs* a wallet; it never gains the unilateral ability to sign an arbitrary payload.
+
+### The payoff: execution that outlives the session
+
+The reason to keep these flows separate is not tidiness — it is that they have different lifetimes. A session ends when the user closes the tab. A standing grant does not, and that is what makes unattended work possible. A user can tell the agent to do something *later* — a one-shot task for tomorrow morning, a recurring check every day — and a scheduler will spawn the run with nobody present: no browser, no session, no signature prompt to click.
+
+What authorizes that run is deliberately narrow. Two independent axes must both hold:
+
+- **Policy.** The operating wallet's signing mode must be explicitly set to autonomous — and the backend refuses to even offer that change unless the wallet is provider-managed and already holds an active delegated approval, so the policy axis can never be loosened ahead of the capability axis. The flip itself is a ceremony: a short-lived, replay-protected permit signed *by that wallet* while the user is present (EIP-712 on EVM, a wallet-standard signed message on Solana). Loosening authority always traces back to the key being loosened — a sibling wallet on the same account cannot escalate it, and the agent cannot self-grant it. Tightening is deliberately easier: any key on the account can sign a lockdown.
+- **Capability.** An active, unexpired delegated approval from the connection ceremony above — revocable at any time, at most one active per provider identity, with its secrets resolved from a vault only at the moment of signing.
+
+At sign time the resolver runs the same match it runs for an interactive request — user, provider, chain family, exact address, active grant — and the provider executes the signature server-side under the application's provider authorization key (in our stack, Privy's quorum-key authorization; the user's permit never signs a transaction, it only flips the policy row). If either axis is missing, the run fails closed: a wallet whose mode still requires a human simply cannot sign unattended, and the job stalls and retries rather than falling back to a weaker path. Crucially, the authority is the user's own standing grant, never a service credential — the scheduler has no signing power of its own to escalate.
+
+![Figure 10 — Unattended execution: a scheduled run signs only when the policy axis and the capability axis both hold.](/research/auth-across-two-worlds/figures/f10_unattended_execution.svg)
+
+**Figure 10 — Unattended execution.** A scheduled task fires with no user in the session. It can sign only if two independently granted axes agree — the wallet's signing mode (set by a user-present, wallet-signed permit) and an active delegated approval — resolved through the same exact-address match as any interactive request. Anything less fails closed.
+
+The bounds today are the grant's expiry, its revocability, and the user-present permit gating the mode change. Binding grants to per-action budgets and spend limits is the natural next tightening — and the grant record is exactly the seam where those controls belong.
+
+## 9. A field guide to the tokens
+
+By this point the system contains several signed or opaque artifacts, and calling all of them "the auth token" would make the design impossible to audit. The inventory:
+
+**Table 5 — Credential and capability taxonomy.**
+
+| Artifact | Issuer | Verifier | Purpose | Lifetime |
+|---|---|---|---|---|
+| SIWE message + signature | User's wallet | BFF | Prove control of an address | One ceremony |
+| Privy/Para provider token | Wallet provider | BFF adapter | Prove provider subject, attest wallets | Provider-defined, short |
+| Better Auth session | First-party auth service | BFF | Preserve login continuity | Days, revocable |
+| Backend account assertion | BFF signing key | Rust backend | Assert canonical user and role | Minutes |
+| Provider connection state | Backend | Callback driver | Protect one redirect round-trip | Minutes to an hour |
+| Delegated approval | Application/provider policy | Signer runtime | Authorize one execution path | Policy-defined, revocable |
+| Signing-mode permit | User's wallet | Backend policy layer | Loosen or tighten a wallet's autonomy | Minutes, replay-protected |
+| Thread id | Runtime | Runtime | Select conversation state | Runtime-defined |
+| Application key | Platform | Backend app gate | Grant app entitlement | Revocable |
+
+![Figure 11 — Credential lifetimes on one time axis: proofs are consumed in minutes, sessions live for days, and only the short-lived assertion crosses into the backend.](/research/auth-across-two-worlds/figures/f07_credential_lifetimes.svg)
+
+**Figure 11 — Different artifacts, different clocks.** Provider proofs are consumed at the edge in one ceremony, sessions preserve login for days, backend assertions live for minutes, state tokens protect a single redirect, and delegated approvals run on policy time. Exactly one artifact crosses the BFF–backend trust boundary.
+
+Three naming rules kept this table honest, and they transfer to any stack. Name a credential after the authority it carries, not its serialization — "backend account assertion" says more than "JWT." Include the verifier in the design — a token with no intended verifier tends to spread. And define what each artifact *cannot* authorize — negative scope is part of the contract.
+
+## 10. Why this particular stack
+
+The patterns are stack-agnostic; the stack is where we spent our tradeoff budget. For each choice, what we picked, why, and what you could swap.
+
+**A session framework in front of the graph — Better Auth.** Session mechanics — cookie flags, rotation, device sessions, sign-out, CSRF — are commodity engineering with expensive failure modes, so we rent them. The non-negotiable was topology, not vendor: the framework sits in front of the account graph, and its user record maps to our canonical id rather than being it. Better Auth's plugin model let SIWE and provider exchanges attach as ordinary login methods. Swap freely: any session library with the same position in the diagram preserves the architecture.
+
+**A BFF as the identity broker.** Something has to be the credential exchange point, and the BFF is the natural place for three reasons at once: same-origin HttpOnly cookies want to live next to the web app; the assertion signing key wants to exist in exactly one service; and backend services want one small contract instead of a session dependency. An API gateway could play the role; what cannot be swapped away is the *existence* of a single, reviewable exchange point.
+
+**Ed25519 JWTs for the assertion.** The issuer is TypeScript and the verifier is Rust, so the token is effectively a cross-language protocol — which argues for a small, rigid contract: one modern signature scheme with no algorithm-negotiation footguns, tiny keys, a `kid` header for rotation, and fixture tests in both directions (a token minted by the production issuer must verify in the backend library; wrong audience, issuer, expiry, role, and key id must each fail independently). We load trusted keys from deployment-controlled configuration for deterministic startup; a JWKS endpoint can be added later without changing the token contract.
+
+**A backend that verifies and cannot mint.** Keeping the Rust backend ignorant of the login stack is a feature, not an accident: it holds only public keys, so a compromised verifier cannot impersonate its issuer, and no frontend auth migration has ever required a backend deploy. The typed route classes (Section 6) are the other half — identity arrives as one small object, so policy can be declared where routes are constructed.
+
+**Two embedded-wallet providers behind one adapter seam.** Users arrive with preferences, and providers genuinely differ — one exposes server-side delegated signing, the other keeps signatures interactive. Running two from day one forced the adapter seam to be real rather than aspirational, and the seam is also vendor insurance: any single provider's outage, pricing change, or deprecation is a credential swap at the edge, not an identity rewrite.
+
+## 11. Closing
+
+Come back to the opening question: how many users do you have? In this architecture it has a boring answer — count the canonical accounts — and the boring answer is the achievement. Rate limits meter people instead of addresses. History follows the person across wallets, providers, and devices. And when a transaction request arrives, the system can say exactly which user, which wallet, which provider path, and which grant authorized it.
+
+The general lesson is about preserving meaning across boundaries. A provider token means a provider verified a subject. A session means the application still recognizes a login. A canonical user id means history and ownership have a stable root. A wallet association means an address belongs in the graph. An active wallet means the client selected an execution context. A delegated approval means one provider path may authorize a bounded class of actions. A backend assertion means a trusted issuer authenticated one user, for one service, for one short window. Every one of those statements is useful — and they become dangerous the moment they are treated as synonyms.
+
+That is the whole design, and none of it is specific to our stack: own the identity root, verify at the edge, broker identity across service boundaries, fail closed, keep wallets in a registry, and keep login separate from signing. The result is not fewer auth objects — it is fewer ambiguous ones. For applications that execute onchain on a user's behalf, as ours does, that is the difference between an app that knows who it serves and one that hopes the connected wallet is the right one.

--- a/apps/landing/lib/research.ts
+++ b/apps/landing/lib/research.ts
@@ -14,6 +14,17 @@ export type ResearchPost = {
 
 export const researchPosts: ResearchPost[] = [
   {
+    slug: "auth-across-two-worlds",
+    title:
+      "One User, Many Wallets: Authentication Across the Onchain–Offchain Boundary",
+    date: "July 13, 2026",
+    isoDate: "2026-07-13",
+    tag: "engineering",
+    subtitle:
+      "A design study in hybrid crypto authentication: why counting users is hard onchain, the four proofs to keep separate, and the patterns — and stack — that hold them apart.",
+    fileName: "auth-across-two-worlds.md",
+  },
+  {
     slug: "aomibench-v0-1",
     title: "AomiBench: Benchmarking Frontier Models on Onchain Execution",
     date: "June 4, 2026",

--- a/apps/landing/public/research/auth-across-two-worlds/figures/code1_verified_credential.svg
+++ b/apps/landing/public/research/auth-across-two-worlds/figures/code1_verified_credential.svg
@@ -1,0 +1,30 @@
+<svg width="800" height="440" viewBox="0 0 800 440" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" role="img" aria-label="VerifiedCredential: the normalized shape every provider adapter emits">
+<style>
+text{font-family:ui-monospace, SFMono-Regular, Menlo, monospace;font-size:13px;fill:#1f2937;}
+.kw{fill:#534AB7;font-weight:700}
+.ty{fill:#185FA5}
+.st{fill:#0F6E56}
+.pn{fill:#6b7280}
+.fn{font-size:11.5px;fill:#6b7280}
+</style>
+
+<rect x="40" y="24" width="720" height="392" rx="12" fill="#ffffff" stroke="#d1d5db" stroke-width="1.3"/>
+<circle cx="70" cy="52" r="5" fill="#e5e7eb"/>
+<circle cx="88" cy="52" r="5" fill="#e5e7eb"/>
+<circle cx="106" cy="52" r="5" fill="#e5e7eb"/>
+<text x="128" y="57" class="fn">verified-credential.ts</text>
+<line x1="40" y1="74" x2="760" y2="74" stroke="#eceef1"/>
+
+<text x="68" y="108" xml:space="preserve"><tspan class="kw">type</tspan> <tspan class="ty">VerifiedCredential</tspan> <tspan class="pn">= {</tspan></text>
+<text x="68" y="134" xml:space="preserve">  provider<tspan class="pn">:</tspan> <tspan class="st">"privy"</tspan> <tspan class="pn">|</tspan> <tspan class="st">"para"</tspan><tspan class="pn">;</tspan></text>
+<text x="68" y="160" xml:space="preserve">  subject<tspan class="pn">:</tspan> <tspan class="ty">string</tspan><tspan class="pn">;</tspan></text>
+<text x="68" y="186" xml:space="preserve">  expiresAt<tspan class="pn">:</tspan> <tspan class="ty">number</tspan><tspan class="pn">;</tspan></text>
+<text x="68" y="212" xml:space="preserve">  verifiedEmail<tspan class="pn">?:</tspan> <tspan class="ty">string</tspan><tspan class="pn">;</tspan></text>
+<text x="68" y="238" xml:space="preserve">  wallets<tspan class="pn">:</tspan> <tspan class="ty">Array</tspan><tspan class="pn">&lt;{</tspan></text>
+<text x="68" y="264" xml:space="preserve">    family<tspan class="pn">:</tspan> <tspan class="st">"evm"</tspan> <tspan class="pn">|</tspan> <tspan class="st">"svm"</tspan><tspan class="pn">;</tspan></text>
+<text x="68" y="290" xml:space="preserve">    address<tspan class="pn">:</tspan> <tspan class="ty">string</tspan><tspan class="pn">;</tspan></text>
+<text x="68" y="316" xml:space="preserve">    providerWalletId<tspan class="pn">?:</tspan> <tspan class="ty">string</tspan><tspan class="pn">;</tspan></text>
+<text x="68" y="342" xml:space="preserve">    provenance<tspan class="pn">:</tspan> <tspan class="st">"provider_attested"</tspan><tspan class="pn">;</tspan></text>
+<text x="68" y="368" xml:space="preserve">  <tspan class="pn">}&gt;;</tspan></text>
+<text x="68" y="394" xml:space="preserve"><tspan class="pn">};</tspan></text>
+</svg>

--- a/apps/landing/public/research/auth-across-two-worlds/figures/code2_provider_exchange.svg
+++ b/apps/landing/public/research/auth-across-two-worlds/figures/code2_provider_exchange.svg
@@ -1,0 +1,47 @@
+<svg width="1140" height="470" viewBox="0 0 1140 470" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" role="img" aria-label="The provider exchange: verify, then link transactionally, then create the session">
+<style>
+text{font-family:ui-monospace, SFMono-Regular, Menlo, monospace;font-size:13px;fill:#1f2937;}
+.kw{fill:#534AB7;font-weight:700}
+.fnc{fill:#185FA5}
+.pn{fill:#6b7280}
+.fn{font-size:11.5px;fill:#6b7280}
+.an{font-size:12.5px;fill:#B0710F}
+.bn{font-size:12px;font-weight:700;fill:#3a2a08;text-anchor:middle}
+</style>
+
+<rect x="40" y="24" width="700" height="420" rx="12" fill="#ffffff" stroke="#d1d5db" stroke-width="1.3"/>
+<circle cx="70" cy="52" r="5" fill="#e5e7eb"/>
+<circle cx="88" cy="52" r="5" fill="#e5e7eb"/>
+<circle cx="106" cy="52" r="5" fill="#e5e7eb"/>
+<text x="128" y="57" class="fn">provider-exchange.ts</text>
+<line x1="40" y1="74" x2="740" y2="74" stroke="#eceef1"/>
+
+<text x="68" y="108" xml:space="preserve"><tspan class="kw">async function</tspan> <tspan class="fnc">exchangeProviderProof</tspan><tspan class="pn">(</tspan>input<tspan class="pn">) {</tspan></text>
+<text x="68" y="134" xml:space="preserve">  <tspan class="kw">const</tspan> proof <tspan class="pn">=</tspan> <tspan class="kw">await</tspan> <tspan class="fnc">verifyWithProviderAdapter</tspan><tspan class="pn">(</tspan>input<tspan class="pn">);</tspan></text>
+<text x="68" y="160" xml:space="preserve">  <tspan class="kw">const</tspan> sessionUser <tspan class="pn">=</tspan> <tspan class="kw">await</tspan> <tspan class="fnc">findOrCreateSessionUser</tspan><tspan class="pn">(</tspan>proof<tspan class="pn">);</tspan></text>
+<text x="68" y="186" xml:space="preserve">  <tspan class="kw">const</tspan> account <tspan class="pn">=</tspan> <tspan class="kw">await</tspan> <tspan class="fnc">resolveCanonicalAccount</tspan><tspan class="pn">(</tspan>sessionUser<tspan class="pn">,</tspan> proof.signals<tspan class="pn">);</tspan></text>
+<text x="68" y="238" xml:space="preserve">  <tspan class="kw">await</tspan> <tspan class="fnc">transaction</tspan><tspan class="pn">(</tspan><tspan class="kw">async</tspan> <tspan class="pn">(</tspan>db<tspan class="pn">) =&gt; {</tspan></text>
+<text x="68" y="264" xml:space="preserve">    <tspan class="kw">await</tspan> <tspan class="fnc">linkProviderIdentity</tspan><tspan class="pn">(</tspan>account.id<tspan class="pn">,</tspan> proof.subject<tspan class="pn">,</tspan> db<tspan class="pn">);</tspan></text>
+<text x="68" y="290" xml:space="preserve">    <tspan class="kw">await</tspan> <tspan class="fnc">reconcileAttestedWallets</tspan><tspan class="pn">(</tspan>account.id<tspan class="pn">,</tspan> proof.wallets<tspan class="pn">,</tspan> db<tspan class="pn">);</tspan></text>
+<text x="68" y="316" xml:space="preserve">  <tspan class="pn">});</tspan></text>
+<text x="68" y="368" xml:space="preserve">  <tspan class="kw">const</tspan> session <tspan class="pn">=</tspan> <tspan class="kw">await</tspan> <tspan class="fnc">createFirstPartySession</tspan><tspan class="pn">(</tspan>sessionUser.id<tspan class="pn">);</tspan></text>
+<text x="68" y="394" xml:space="preserve">  <tspan class="kw">return</tspan> <tspan class="fnc">setHttpOnlySessionCookie</tspan><tspan class="pn">(</tspan>session<tspan class="pn">);</tspan></text>
+<text x="68" y="420" xml:space="preserve"><tspan class="pn">}</tspan></text>
+
+<!-- annotations -->
+<circle cx="778" cy="128" r="11" fill="#EF9F27"/>
+<text class="bn" x="778" y="132">1</text>
+<text x="800" y="124" class="an">verify before anything</text>
+<text x="800" y="142" class="an">mutates</text>
+
+<circle cx="778" cy="262" r="11" fill="#EF9F27"/>
+<text class="bn" x="778" y="266">2</text>
+<text x="800" y="250" class="an">identity + wallets linked in</text>
+<text x="800" y="268" class="an">ONE transaction — a conflict</text>
+<text x="800" y="286" class="an">rolls everything back</text>
+
+<circle cx="778" cy="380" r="11" fill="#EF9F27"/>
+<text class="bn" x="778" y="384">3</text>
+<text x="800" y="376" class="an">the session exists only after</text>
+<text x="800" y="394" class="an">the graph is coherent</text>
+</svg>

--- a/apps/landing/public/research/auth-across-two-worlds/figures/code3_wallet_provider.svg
+++ b/apps/landing/public/research/auth-across-two-worlds/figures/code3_wallet_provider.svg
@@ -1,0 +1,35 @@
+<svg width="1140" height="320" viewBox="0 0 1140 320" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" role="img" aria-label="The provider interface: four responsibilities, one shape">
+<style>
+text{font-family:ui-monospace, SFMono-Regular, Menlo, monospace;font-size:13px;fill:#1f2937;}
+.kw{fill:#534AB7;font-weight:700}
+.ty{fill:#185FA5}
+.fnc{fill:#185FA5}
+.pn{fill:#6b7280}
+.fn{font-size:11.5px;fill:#6b7280}
+.an{font-size:12.5px;fill:#B0710F}
+</style>
+
+<rect x="40" y="24" width="640" height="264" rx="12" fill="#ffffff" stroke="#d1d5db" stroke-width="1.3"/>
+<circle cx="70" cy="52" r="5" fill="#e5e7eb"/>
+<circle cx="88" cy="52" r="5" fill="#e5e7eb"/>
+<circle cx="106" cy="52" r="5" fill="#e5e7eb"/>
+<text x="128" y="57" class="fn">wallet-provider.ts</text>
+<line x1="40" y1="74" x2="680" y2="74" stroke="#eceef1"/>
+
+<text x="68" y="108" xml:space="preserve"><tspan class="kw">interface</tspan> <tspan class="ty">WalletProvider</tspan> <tspan class="pn">{</tspan></text>
+<text x="68" y="138" xml:space="preserve">  <tspan class="fnc">buildAuthorizationUrl</tspan><tspan class="pn">(</tspan>context<tspan class="pn">,</tspan> signedState<tspan class="pn">):</tspan> <tspan class="ty">URL</tspan><tspan class="pn">;</tspan></text>
+<text x="68" y="168" xml:space="preserve">  <tspan class="fnc">verifyCallback</tspan><tspan class="pn">(</tspan>context<tspan class="pn">,</tspan> callback<tspan class="pn">):</tspan> <tspan class="ty">Promise&lt;Connection&gt;</tspan><tspan class="pn">;</tspan></text>
+<text x="68" y="198" xml:space="preserve">  <tspan class="fnc">declaredSecretSlots</tspan><tspan class="pn">():</tspan> <tspan class="ty">SlotSchema</tspan><tspan class="pn">;</tspan></text>
+<text x="68" y="228" xml:space="preserve">  <tspan class="fnc">sign</tspan><tspan class="pn">(</tspan>secrets<tspan class="pn">,</tspan> request<tspan class="pn">):</tspan> <tspan class="ty">Promise&lt;SignResult&gt;</tspan><tspan class="pn">;</tspan></text>
+<text x="68" y="258" xml:space="preserve"><tspan class="pn">}</tspan></text>
+
+<!-- annotations -->
+<line x1="686" y1="133" x2="712" y2="133" stroke="#EF9F27" stroke-width="1.3"/>
+<text x="722" y="138" class="an">the provider owns its login surface…</text>
+<line x1="686" y1="163" x2="712" y2="163" stroke="#EF9F27" stroke-width="1.3"/>
+<text x="722" y="168" class="an">…and its callback payload contract</text>
+<line x1="686" y1="193" x2="712" y2="193" stroke="#EF9F27" stroke-width="1.3"/>
+<text x="722" y="198" class="an">declares vault slots — never raw secrets</text>
+<line x1="686" y1="223" x2="712" y2="223" stroke="#EF9F27" stroke-width="1.3"/>
+<text x="722" y="228" class="an">signing transport — delegated or interactive</text>
+</svg>

--- a/apps/landing/public/research/auth-across-two-worlds/figures/f00_users_vs_addresses.svg
+++ b/apps/landing/public/research/auth-across-two-worlds/figures/f00_users_vs_addresses.svg
@@ -1,0 +1,79 @@
+<svg width="1140" height="660" viewBox="0 0 1140 660" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" role="img" aria-label="The counting problem: one person spans many addresses, and the mapping drifts">
+<defs>
+<style>
+text{font-family:ui-monospace, SFMono-Regular, Menlo, monospace;}
+.h{font-size:13px;font-weight:700}
+.b{font-size:12px;fill:#1f2937}
+.s{font-size:11.5px;fill:#6b7280}
+.edge{stroke:#9CA3AF;stroke-width:1.4;fill:none}
+</style>
+</defs>
+
+<text x="40" y="36" class="h" fill="#1f2937">PEOPLE</text>
+<text x="116" y="36" class="s">what your product thinks in</text>
+<text x="760" y="36" class="h" fill="#0F6E56">ADDRESSES</text>
+<text x="856" y="36" class="s">what the chain gives you</text>
+
+<!-- people -->
+<rect x="40" y="90" width="260" height="70" rx="10" fill="#fafafa" stroke="#9CA3AF" stroke-width="1.3"/>
+<text x="60" y="118" class="b" font-weight="700">Alice</text>
+<text x="60" y="140" class="s">one person · three wallets</text>
+
+<rect x="40" y="252" width="260" height="70" rx="10" fill="#fafafa" stroke="#9CA3AF" stroke-width="1.3"/>
+<text x="60" y="280" class="b" font-weight="700">Bob</text>
+<text x="60" y="302" class="s">one person · one wallet</text>
+
+<rect x="40" y="392" width="260" height="70" rx="10" fill="#fafafa" stroke="#9CA3AF" stroke-width="1.3"/>
+<text x="60" y="420" class="b" font-weight="700">Carol</text>
+<text x="60" y="442" class="s">same person · rotated wallets</text>
+
+<!-- addresses -->
+<rect x="760" y="56" width="340" height="56" rx="9" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.3"/>
+<text x="778" y="80" class="b">0xA11c…e9F3</text>
+<text x="778" y="99" class="s">MetaMask EOA</text>
+
+<rect x="760" y="132" width="340" height="56" rx="9" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.3"/>
+<text x="778" y="156" class="b">0x9bE2…D441</text>
+<text x="778" y="175" class="s">embedded wallet · provider-managed</text>
+
+<rect x="760" y="208" width="340" height="56" rx="9" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.3"/>
+<text x="778" y="232" class="b">0x4337…0AA0</text>
+<text x="778" y="251" class="s">smart account · owner: 0xA11c…</text>
+
+<rect x="760" y="284" width="340" height="56" rx="9" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.3"/>
+<text x="778" y="308" class="b">0xB0B1…C77e</text>
+<text x="778" y="327" class="s">MetaMask EOA</text>
+
+<rect x="760" y="360" width="340" height="56" rx="9" fill="#f6fcf9" stroke="#9CA3AF" stroke-width="1.3" stroke-dasharray="5 4"/>
+<text x="778" y="384" class="b" fill="#6b7280">0xC4a0…011D</text>
+<text x="778" y="403" class="s">old EOA · abandoned</text>
+
+<rect x="760" y="436" width="340" height="56" rx="9" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.3"/>
+<text x="778" y="460" class="b">0xC4a1…F9E2</text>
+<text x="778" y="479" class="s">new EOA · replaced the old one</text>
+
+<!-- edges: Alice -> 3 -->
+<path class="edge" d="M300,110 C480,98 600,90 756,84"/>
+<path class="edge" d="M300,123 C480,130 600,150 756,160"/>
+<path class="edge" d="M300,136 C500,170 600,210 756,236"/>
+<!-- Bob -> 1 -->
+<path class="edge" d="M300,287 C480,296 600,306 756,312"/>
+<!-- Carol -> old (dashed) + new -->
+<path class="edge" d="M300,417 C480,406 600,396 756,388" stroke-dasharray="5 4"/>
+<path class="edge" d="M300,434 C480,442 600,456 756,464"/>
+
+<!-- annotations -->
+<text x="528" y="60" class="s" fill="#B0710F" text-anchor="middle">one person → many addresses</text>
+<text x="528" y="510" class="s" fill="#B0710F" text-anchor="middle">…and the mapping drifts: wallets get created, imported, rotated, abandoned</text>
+
+<!-- question chips -->
+<rect x="60" y="536" width="315" height="46" rx="9" fill="#fffaf0" stroke="#EF9F27" stroke-width="1.3"/>
+<text x="217" y="564" class="h" fill="#B0710F" text-anchor="middle">how many users?</text>
+<rect x="412" y="536" width="315" height="46" rx="9" fill="#fffaf0" stroke="#EF9F27" stroke-width="1.3"/>
+<text x="569" y="564" class="h" fill="#B0710F" text-anchor="middle">whose rate limit is this?</text>
+<rect x="764" y="536" width="315" height="46" rx="9" fill="#fffaf0" stroke="#EF9F27" stroke-width="1.3"/>
+<text x="921" y="564" class="h" fill="#B0710F" text-anchor="middle">which history is theirs?</text>
+
+<rect x="40" y="606" width="1060" height="34" rx="8" fill="#f3f4f6" stroke="#d1d5db"/>
+<text x="570" y="628" font-size="12px" fill="#374151" text-anchor="middle">An address is not a person. Without an application-owned account, every per-user question is unanswerable.</text>
+</svg>

--- a/apps/landing/public/research/auth-across-two-worlds/figures/f01_four_proofs.svg
+++ b/apps/landing/public/research/auth-across-two-worlds/figures/f01_four_proofs.svg
@@ -1,0 +1,79 @@
+<svg width="1140" height="760" viewBox="0 0 1140 760" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" role="img" aria-label="Four proofs across the identity and execution planes, meeting at one canonical user id">
+<defs>
+<marker id="a" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#6b7280"/></marker>
+<style>
+text{font-family:ui-monospace, SFMono-Regular, Menlo, monospace;}
+.h{font-size:14px;font-weight:700}
+.ch{font-size:12.5px;font-weight:700}
+.b{font-size:12px;fill:#1f2937}
+.s{font-size:11.5px;fill:#6b7280}
+.arw{stroke:#6b7280;stroke-width:1.5;fill:none}
+</style>
+</defs>
+
+<!-- identity plane -->
+<rect x="40" y="46" width="505" height="424" rx="12" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.4"/>
+<text x="66" y="78" class="h" fill="#0F6E56">IDENTITY PLANE</text>
+<text x="66" y="97" class="s">who is the user?</text>
+
+<rect x="70" y="116" width="445" height="104" rx="9" fill="#ffffff" stroke="#1D9E75" stroke-width="1.2"/>
+<text x="90" y="142" class="ch" fill="#0F6E56">LOGIN PROOF</text>
+<text x="90" y="164" class="b">"did a login method succeed just now?"</text>
+<text x="90" y="184" class="b">SIWE sig · provider JWT · passkey · email link</text>
+<text x="90" y="204" class="s">short-lived · method-specific</text>
+
+<path class="arw" d="M292,220 V252" marker-end="url(#a)"/>
+
+<rect x="70" y="254" width="445" height="104" rx="9" fill="#ffffff" stroke="#1D9E75" stroke-width="1.2"/>
+<text x="90" y="280" class="ch" fill="#0F6E56">FIRST-PARTY SESSION</text>
+<text x="90" y="302" class="b">"is this still the same login?"</text>
+<text x="90" y="322" class="b">HttpOnly cookie · opaque bearer</text>
+<text x="90" y="342" class="s">days · revocable · survives provider swaps</text>
+
+<path class="arw" d="M292,358 V392" marker-end="url(#a)"/>
+<text x="292" y="424" class="b" text-anchor="middle">resolves to one stable id</text>
+<text x="292" y="444" class="s" text-anchor="middle">never a provider DID · never an address</text>
+
+<!-- execution plane -->
+<rect x="595" y="46" width="505" height="424" rx="12" fill="#faf9ff" stroke="#7F77DD" stroke-width="1.4"/>
+<text x="621" y="78" class="h" fill="#534AB7">EXECUTION PLANE</text>
+<text x="621" y="97" class="s">what may a wallet do?</text>
+
+<rect x="625" y="112" width="445" height="88" rx="9" fill="#ffffff" stroke="#7F77DD" stroke-width="1.2"/>
+<text x="645" y="138" class="ch" fill="#534AB7">WALLET ATTESTATION</text>
+<text x="645" y="160" class="b">"does this address belong to this account?"</text>
+<text x="645" y="180" class="s">SIWE proof · provider attestation · provenance-tagged</text>
+
+<path class="arw" d="M847,200 V222" marker-end="url(#a)"/>
+
+<rect x="625" y="224" width="445" height="88" rx="9" fill="#ffffff" stroke="#7F77DD" stroke-width="1.2"/>
+<text x="645" y="250" class="ch" fill="#534AB7">ACTIVE WALLET</text>
+<text x="645" y="272" class="b">"which address acts on this chain?"</text>
+<text x="645" y="292" class="s">one per chain family (evm / svm) · session-scoped</text>
+
+<path class="arw" d="M847,312 V334" marker-end="url(#a)"/>
+
+<rect x="625" y="336" width="445" height="88" rx="9" fill="#ffffff" stroke="#7F77DD" stroke-width="1.2"/>
+<text x="645" y="362" class="ch" fill="#534AB7">SIGNING AUTHORITY</text>
+<text x="645" y="384" class="b">"may this signer approve this action?"</text>
+<text x="645" y="404" class="s">interactive · delegated · one provider · one expiry</text>
+
+<!-- convergence -->
+<path class="arw" d="M292,470 V506" marker-end="url(#a)"/>
+<path class="arw" d="M847,470 V506" marker-end="url(#a)"/>
+
+<rect x="40" y="510" width="1060" height="60" rx="10" fill="#1f2937"/>
+<text x="570" y="536" font-size="14px" font-weight="700" fill="#ffffff" text-anchor="middle">CANONICAL USER ID</text>
+<text x="570" y="556" font-size="11.5px" fill="#c7cdd6" text-anchor="middle">application-owned · the only place the two planes meet</text>
+
+<!-- non-equivalences -->
+<rect x="60" y="606" width="315" height="52" rx="9" fill="#fdeee7" stroke="#D85A30" stroke-width="1.3"/>
+<text x="217" y="638" class="ch" fill="#9e3f17" text-anchor="middle">wallet  ≠  user</text>
+<rect x="412" y="606" width="315" height="52" rx="9" fill="#fdeee7" stroke="#D85A30" stroke-width="1.3"/>
+<text x="569" y="638" class="ch" fill="#9e3f17" text-anchor="middle">provider token  ≠  session</text>
+<rect x="764" y="606" width="315" height="52" rx="9" fill="#fdeee7" stroke="#D85A30" stroke-width="1.3"/>
+<text x="921" y="638" class="ch" fill="#9e3f17" text-anchor="middle">session  ≠  signing grant</text>
+
+<rect x="40" y="694" width="1060" height="34" rx="8" fill="#f3f4f6" stroke="#d1d5db"/>
+<text x="570" y="716" font-size="12px" fill="#374151" text-anchor="middle">Collapse any two of these and revocation, recovery, and multi-wallet selection all become ambiguous at once.</text>
+</svg>

--- a/apps/landing/public/research/auth-across-two-worlds/figures/f02_account_graph.svg
+++ b/apps/landing/public/research/auth-across-two-worlds/figures/f02_account_graph.svg
@@ -1,0 +1,102 @@
+<svg width="1140" height="740" viewBox="0 0 1140 740" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" role="img" aria-label="The canonical account graph: login identities above, wallets below, execution approvals attached separately">
+<defs>
+<marker id="a" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#6b7280"/></marker>
+<style>
+text{font-family:ui-monospace, SFMono-Regular, Menlo, monospace;}
+.ch{font-size:12.5px;font-weight:700}
+.b{font-size:11.5px;fill:#1f2937}
+.s{font-size:11px;fill:#6b7280}
+.edge{stroke:#9CA3AF;stroke-width:1.3;fill:none}
+.cap{stroke:#EF9F27;stroke-width:1.4;fill:none;stroke-dasharray:5 4}
+</style>
+</defs>
+
+<text x="40" y="34" font-size="12.5px" font-weight="700" fill="#185FA5">AUTHENTICATION IDENTITIES</text>
+<text x="326" y="34" class="s">credential keys — how the user proves who they are</text>
+
+<!-- identity nodes -->
+<rect x="40" y="52" width="196" height="84" rx="9" fill="#eef5fc" stroke="#378ADD" stroke-width="1.3"/>
+<text x="56" y="78" class="ch" fill="#185FA5">BETTER AUTH</text>
+<text x="56" y="99" class="b">session user ref</text>
+<text x="56" y="118" class="s">first-party login</text>
+
+<rect x="260" y="52" width="196" height="84" rx="9" fill="#eef5fc" stroke="#378ADD" stroke-width="1.3"/>
+<text x="276" y="78" class="ch" fill="#185FA5">SIWE IDENTITY</text>
+<text x="276" y="99" class="b">0xA11c…e9F3 · evm</text>
+<text x="276" y="118" class="s">signature-proven</text>
+
+<rect x="480" y="52" width="196" height="84" rx="9" fill="#eef5fc" stroke="#378ADD" stroke-width="1.3"/>
+<text x="496" y="78" class="ch" fill="#185FA5">VERIFIED EMAIL</text>
+<text x="496" y="99" class="b">alice@example.com</text>
+<text x="496" y="118" class="s">verified profile signal</text>
+
+<rect x="700" y="52" width="196" height="84" rx="9" fill="#eef5fc" stroke="#378ADD" stroke-width="1.3"/>
+<text x="716" y="78" class="ch" fill="#185FA5">PRIVY SUBJECT</text>
+<text x="716" y="99" class="b">did:privy:cle4…</text>
+<text x="716" y="118" class="s">provider-verified</text>
+
+<rect x="920" y="52" width="196" height="84" rx="9" fill="#eef5fc" stroke="#378ADD" stroke-width="1.3"/>
+<text x="936" y="78" class="ch" fill="#185FA5">PARA SUBJECT</text>
+<text x="936" y="99" class="b">para:usr_8k2…</text>
+<text x="936" y="118" class="s">provider-verified</text>
+
+<!-- edges identities -> canonical -->
+<path class="edge" d="M138,136 C138,240 480,240 528,324" marker-end="url(#a)"/>
+<path class="edge" d="M358,136 C358,230 500,240 548,322" marker-end="url(#a)"/>
+<path class="edge" d="M578,136 C578,220 570,260 570,320" marker-end="url(#a)"/>
+<path class="edge" d="M798,136 C798,230 640,240 592,322" marker-end="url(#a)"/>
+<path class="edge" d="M1018,136 C1018,240 660,240 612,324" marker-end="url(#a)"/>
+
+<!-- canonical user -->
+<rect x="420" y="326" width="300" height="70" rx="12" fill="#1f2937"/>
+<text x="570" y="356" font-size="14px" font-weight="700" fill="#ffffff" text-anchor="middle">CANONICAL USER</text>
+<text x="570" y="378" font-size="11.5px" fill="#c7cdd6" text-anchor="middle">application-owned · stable UUID</text>
+
+<!-- delegated approval -->
+<rect x="880" y="300" width="230" height="130" rx="9" fill="#fffaf0" stroke="#EF9F27" stroke-width="1.4"/>
+<text x="896" y="326" class="ch" fill="#B0710F">DELEGATED APPROVAL</text>
+<text x="896" y="348" class="b">provider: privy</text>
+<text x="896" y="368" class="b">wallet: embedded evm</text>
+<text x="896" y="388" class="b">expiry · revocable</text>
+<text x="896" y="410" class="s">execution plane — not identity</text>
+
+<path class="cap" d="M995,300 C995,240 880,200 830,140"/>
+<path class="cap" d="M995,430 C995,500 850,510 780,554"/>
+
+<!-- edges canonical -> wallets -->
+<path class="edge" d="M540,396 C500,470 240,460 176,548" marker-end="url(#a)"/>
+<path class="edge" d="M556,396 C540,470 480,470 442,548" marker-end="url(#a)"/>
+<path class="edge" d="M584,396 C600,470 660,470 698,548" marker-end="url(#a)"/>
+<path class="edge" d="M600,396 C640,470 900,460 964,548" marker-end="url(#a)"/>
+
+<!-- wallet nodes -->
+<text x="40" y="530" font-size="12.5px" font-weight="700" fill="#0F6E56">WALLETS</text>
+<text x="150" y="530" class="s">linked resources — never the person</text>
+
+<rect x="46" y="552" width="240" height="104" rx="9" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.3"/>
+<text x="62" y="578" class="ch" fill="#0F6E56">EXTERNAL EOA</text>
+<text x="62" y="599" class="b">MetaMask · evm</text>
+<text x="62" y="618" class="s">linked via SIWE proof</text>
+<rect x="62" y="628" width="96" height="18" rx="9" fill="#1D9E75"/>
+<text x="110" y="641" font-size="10.5px" font-weight="700" fill="#ffffff" text-anchor="middle">ACTIVE · EVM</text>
+
+<rect x="316" y="552" width="240" height="104" rx="9" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.3"/>
+<text x="332" y="578" class="ch" fill="#0F6E56">SMART ACCOUNT</text>
+<text x="332" y="599" class="b">4337 · owner: the EOA</text>
+<text x="332" y="618" class="s">linked via onchain check</text>
+
+<rect x="586" y="552" width="240" height="104" rx="9" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.3"/>
+<text x="602" y="578" class="ch" fill="#0F6E56">EMBEDDED EVM</text>
+<text x="602" y="599" class="b">Privy · evm</text>
+<text x="602" y="618" class="s">linked via provider attestation</text>
+
+<rect x="856" y="552" width="240" height="104" rx="9" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.3"/>
+<text x="872" y="578" class="ch" fill="#0F6E56">EMBEDDED SVM</text>
+<text x="872" y="599" class="b">Para · svm</text>
+<text x="872" y="618" class="s">linked via provider attestation</text>
+<rect x="872" y="628" width="96" height="18" rx="9" fill="#7F77DD"/>
+<text x="920" y="641" font-size="10.5px" font-weight="700" fill="#ffffff" text-anchor="middle">ACTIVE · SVM</text>
+
+<rect x="40" y="692" width="1060" height="34" rx="8" fill="#f3f4f6" stroke="#d1d5db"/>
+<text x="570" y="714" font-size="12px" fill="#374151" text-anchor="middle">solid = durable identity / resource link · dashed = execution-plane capability · badge = current session selection</text>
+</svg>

--- a/apps/landing/public/research/auth-across-two-worlds/figures/f03_login_lanes.svg
+++ b/apps/landing/public/research/auth-across-two-worlds/figures/f03_login_lanes.svg
@@ -1,0 +1,84 @@
+<svg width="1140" height="820" viewBox="0 0 1140 820" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" role="img" aria-label="SIWE, Privy, and Para login lanes converge through normalization and transactional linking into one first-party session">
+<defs>
+<marker id="a" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#6b7280"/></marker>
+<style>
+text{font-family:ui-monospace, SFMono-Regular, Menlo, monospace;}
+.h{font-size:14px;font-weight:700}
+.b{font-size:12px;fill:#1f2937}
+.s{font-size:11.5px;fill:#6b7280}
+.arw{stroke:#6b7280;stroke-width:1.5;fill:none}
+</style>
+</defs>
+
+<!-- SIWE lane -->
+<rect x="40" y="46" width="310" height="380" rx="10" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.4"/>
+<text x="60" y="76" class="h" fill="#0F6E56">SIWE</text>
+<text x="60" y="96" class="s">external / smart-account wallet</text>
+<line x1="60" y1="110" x2="330" y2="110" stroke="#cdeadd"/>
+<text x="60" y="140" class="b">① nonce challenge binds</text>
+<text x="78" y="160" class="s">user · address · domain · time</text>
+<text x="60" y="192" class="b">② wallet signs the message</text>
+<text x="60" y="224" class="b">③ verify envelope + signature</text>
+<text x="60" y="256" class="b">④ EOA → signature recovery</text>
+<text x="60" y="288" class="b">⑤ smart account → onchain</text>
+<text x="78" y="308" class="s">contract / deployless check</text>
+<line x1="60" y1="336" x2="330" y2="336" stroke="#cdeadd"/>
+<text x="60" y="366" class="b" font-weight="700" fill="#0F6E56">proof of address control</text>
+<text x="60" y="388" class="s">one ceremony, then it is spent</text>
+
+<!-- Privy lane -->
+<rect x="415" y="46" width="310" height="380" rx="10" fill="#faf9ff" stroke="#7F77DD" stroke-width="1.4"/>
+<text x="435" y="76" class="h" fill="#534AB7">PRIVY</text>
+<text x="435" y="96" class="s">identity / access token</text>
+<line x1="435" y1="110" x2="705" y2="110" stroke="#ddd9f7"/>
+<text x="435" y="140" class="b">① provider JWT arrives</text>
+<text x="435" y="172" class="b">② pin the contract:</text>
+<text x="453" y="192" class="s">algorithm · key · issuer · audience</text>
+<text x="435" y="224" class="b">③ check expiry + subject</text>
+<text x="435" y="256" class="b">④ accepted token kind explicit</text>
+<text x="435" y="288" class="b">⑤ parse linked accounts</text>
+<text x="453" y="308" class="s">+ server-side wallet lookup</text>
+<line x1="435" y1="336" x2="705" y2="336" stroke="#ddd9f7"/>
+<text x="435" y="366" class="b" font-weight="700" fill="#534AB7">proof of provider subject</text>
+<text x="435" y="388" class="s">token terminates at the BFF</text>
+
+<!-- Para lane -->
+<rect x="790" y="46" width="310" height="380" rx="10" fill="#eef5fc" stroke="#378ADD" stroke-width="1.4"/>
+<text x="810" y="76" class="h" fill="#185FA5">PARA</text>
+<text x="810" y="96" class="s">session JWT</text>
+<line x1="810" y1="110" x2="1080" y2="110" stroke="#cfe3f6"/>
+<text x="810" y="140" class="b">① session JWT arrives</text>
+<text x="810" y="172" class="b">② resolve JWKS · match kid</text>
+<text x="810" y="204" class="b">③ verify alg · aud · exp · sub</text>
+<text x="810" y="236" class="b">④ normalize wallet claims</text>
+<text x="810" y="268" class="b">⑤ optional live session check</text>
+<text x="828" y="288" class="s">endpoint down ≠ invalid token</text>
+<line x1="810" y1="336" x2="1080" y2="336" stroke="#cfe3f6"/>
+<text x="810" y="366" class="b" font-weight="700" fill="#185FA5">proof of provider subject</text>
+<text x="810" y="388" class="s">token terminates at the BFF</text>
+
+<!-- convergence arrows -->
+<path class="arw" d="M195,426 C195,458 480,452 540,484" marker-end="url(#a)"/>
+<path class="arw" d="M570,426 V484" marker-end="url(#a)"/>
+<path class="arw" d="M945,426 C945,458 660,452 600,484" marker-end="url(#a)"/>
+
+<!-- normalize -->
+<rect x="40" y="488" width="1060" height="64" rx="10" fill="#fafafa" stroke="#9CA3AF" stroke-width="1.3"/>
+<text x="570" y="514" class="h" fill="#374151" text-anchor="middle">NORMALIZE  →  VerifiedCredential { provider, subject, wallets[] }</text>
+<text x="570" y="536" class="s" text-anchor="middle">normalize after verification, never before — an unverified claim is input, not identity</text>
+
+<path class="arw" d="M570,552 V584" marker-end="url(#a)"/>
+
+<!-- transactional linking -->
+<rect x="40" y="588" width="1060" height="90" rx="10" fill="#fffaf0" stroke="#EF9F27" stroke-width="1.4"/>
+<text x="570" y="616" class="h" fill="#B0710F" text-anchor="middle">TRANSACTIONAL LINKING</text>
+<text x="570" y="638" class="b" text-anchor="middle">link provider identity + reconcile attested wallets — one transaction</text>
+<text x="570" y="660" font-size="12px" font-weight="700" fill="#9e3f17" text-anchor="middle">signal already attached elsewhere → conflict · roll back · no session</text>
+
+<path class="arw" d="M570,678 V710" marker-end="url(#a)"/>
+
+<!-- session -->
+<rect x="400" y="714" width="340" height="48" rx="24" fill="#1f2937"/>
+<text x="570" y="744" font-size="13.5px" font-weight="700" fill="#ffffff" text-anchor="middle">FIRST-PARTY SESSION</text>
+<text x="570" y="786" class="s" text-anchor="middle">HttpOnly cookie · days · revocable — the backend never sees any of the ceremonies above</text>
+</svg>

--- a/apps/landing/public/research/auth-across-two-worlds/figures/f04_bff_boundary.svg
+++ b/apps/landing/public/research/auth-across-two-worlds/figures/f04_bff_boundary.svg
@@ -1,0 +1,71 @@
+<svg width="1140" height="640" viewBox="0 0 1140 640" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" role="img" aria-label="The BFF converts a browser session into a server-injected backend assertion; no client credential crosses the boundary">
+<defs>
+<marker id="a" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#6b7280"/></marker>
+<marker id="ar" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#D85A30"/></marker>
+<style>
+text{font-family:ui-monospace, SFMono-Regular, Menlo, monospace;}
+.h{font-size:13.5px;font-weight:700}
+.b{font-size:12px;fill:#1f2937}
+.s{font-size:11.5px;fill:#6b7280}
+.arw{stroke:#6b7280;stroke-width:1.5;fill:none}
+</style>
+</defs>
+
+<!-- provider proofs stop -->
+<rect x="430" y="36" width="300" height="54" rx="9" fill="#fafafa" stroke="#9CA3AF" stroke-width="1.2" stroke-dasharray="4 4"/>
+<text x="580" y="59" class="b" text-anchor="middle">SIWE · Privy · Para proofs</text>
+<text x="580" y="78" class="s" text-anchor="middle">consumed one hop earlier — never proxied</text>
+<path class="arw" d="M580,90 V126" marker-end="url(#a)"/>
+
+<!-- browser -->
+<rect x="40" y="180" width="240" height="170" rx="10" fill="#fafafa" stroke="#9CA3AF" stroke-width="1.3"/>
+<text x="60" y="210" class="h" fill="#374151">BROWSER</text>
+<text x="60" y="240" class="b">holds: HttpOnly cookie</text>
+<text x="60" y="264" class="b">holds: no backend token</text>
+<text x="60" y="292" class="s">cannot read the cookie,</text>
+<text x="60" y="310" class="s">cannot pick its identity</text>
+
+<!-- BFF -->
+<rect x="430" y="130" width="300" height="290" rx="10" fill="#eef5fc" stroke="#378ADD" stroke-width="1.4"/>
+<text x="450" y="160" class="h" fill="#185FA5">BFF — IDENTITY BROKER</text>
+<text x="450" y="192" class="b">① match route allowlist</text>
+<text x="450" y="218" class="b">② resolve Better Auth session</text>
+<text x="450" y="244" class="b">③ map → canonical user</text>
+<text x="450" y="270" class="b">④ mint EdDSA assertion</text>
+<text x="450" y="296" class="b" font-weight="700" fill="#9e3f17">⑤ drop Cookie + client Authorization</text>
+<text x="450" y="322" class="b">⑥ inject its own Bearer</text>
+<text x="450" y="348" class="b">⑦ stream the response back</text>
+<text x="450" y="394" class="s">a policy boundary — review it</text>
+<text x="450" y="410" class="s">like an API gateway config</text>
+
+<!-- backend -->
+<rect x="880" y="180" width="220" height="170" rx="10" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.4"/>
+<text x="900" y="210" class="h" fill="#0F6E56">RUST BACKEND</text>
+<text x="900" y="240" class="b">verifies assertion</text>
+<text x="900" y="264" class="b">typed route policy</text>
+<text x="900" y="292" class="s">never parses cookies,</text>
+<text x="900" y="310" class="s">never sees a provider</text>
+
+<!-- edges -->
+<path class="arw" d="M280,255 H426" marker-end="url(#a)"/>
+<text x="353" y="238" class="s" text-anchor="middle">same-origin request</text>
+<text x="353" y="278" class="b" text-anchor="middle" font-size="11.5px">Cookie: session</text>
+
+<path class="arw" d="M730,255 H876" marker-end="url(#a)"/>
+<text x="803" y="228" class="s" text-anchor="middle">Authorization: Bearer</text>
+<text x="803" y="244" class="s" text-anchor="middle">&lt;assertion&gt;</text>
+<text x="803" y="278" class="b" text-anchor="middle" font-size="11.5px">aud-bound · minutes</text>
+
+<!-- key custody -->
+<rect x="450" y="448" width="260" height="44" rx="9" fill="#fffaf0" stroke="#EF9F27" stroke-width="1.4"/>
+<text x="580" y="475" class="b" text-anchor="middle" font-weight="700" fill="#B0710F">PRIVATE KEY — issuer only</text>
+<rect x="870" y="448" width="240" height="44" rx="9" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.4"/>
+<text x="990" y="475" class="b" text-anchor="middle" font-weight="700" fill="#0F6E56">PUBLIC KEYS — verify only</text>
+<text x="795" y="522" class="b" text-anchor="middle" font-weight="700">→ the verifier cannot mint ←</text>
+
+<!-- blocked direct path -->
+<path d="M160,350 C160,580 990,580 990,496" stroke="#D85A30" stroke-width="1.5" fill="none" stroke-dasharray="6 5" marker-end="url(#ar)"/>
+<rect x="380" y="560" width="26" height="26" rx="13" fill="#fdeee7" stroke="#D85A30" stroke-width="1.3"/>
+<text x="393" y="578" font-size="13px" font-weight="700" fill="#9e3f17" text-anchor="middle">✕</text>
+<text x="418" y="578" class="s" fill="#9e3f17">no client-chosen identity header ever reaches the backend</text>
+</svg>

--- a/apps/landing/public/research/auth-across-two-worlds/figures/f05_verification_chain.svg
+++ b/apps/landing/public/research/auth-across-two-worlds/figures/f05_verification_chain.svg
@@ -1,0 +1,72 @@
+<svg width="940" height="860" viewBox="0 0 940 860" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" role="img" aria-label="The backend verification chain: seven independent checks, each with a hard rejection exit, ending in typed context">
+<defs>
+<marker id="a" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#6b7280"/></marker>
+<marker id="ar" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#D85A30"/></marker>
+<style>
+text{font-family:ui-monospace, SFMono-Regular, Menlo, monospace;}
+.b{font-size:12.5px;fill:#1f2937}
+.s{font-size:11.5px;fill:#6b7280}
+.r{font-size:11.5px;fill:#9e3f17}
+.box{fill:#fafafa;stroke:#9CA3AF;stroke-width:1.3}
+.arw{stroke:#6b7280;stroke-width:1.5;fill:none}
+.rej{stroke:#D85A30;stroke-width:1.3;fill:none}
+</style>
+</defs>
+
+<text x="60" y="36" font-size="13.5px" font-weight="700" fill="#1f2937">Authorization: Bearer &lt;assertion&gt;</text>
+<path class="arw" d="M300,50 V72" marker-end="url(#a)"/>
+
+<rect class="box" x="60" y="76" width="480" height="56" rx="9"/>
+<text x="80" y="100" class="b">① kid → select candidate public keys</text>
+<text x="80" y="120" class="s">selection only — a recognized kid grants nothing</text>
+<path class="arw" d="M300,132 V158" marker-end="url(#a)"/>
+
+<rect class="box" x="60" y="162" width="480" height="56" rx="9"/>
+<text x="80" y="186" class="b">② EdDSA signature matches a trusted key</text>
+<text x="80" y="206" class="s">expected algorithm pinned</text>
+<path class="rej" d="M540,190 H640" marker-end="url(#ar)"/>
+<text x="652" y="194" class="r">✕ 401 — bad signature</text>
+<path class="arw" d="M300,218 V244" marker-end="url(#a)"/>
+
+<rect class="box" x="60" y="248" width="480" height="56" rx="9"/>
+<text x="80" y="272" class="b">③ iss matches that key's configured issuer</text>
+<text x="80" y="292" class="s">keys and issuers travel together</text>
+<path class="rej" d="M540,276 H640" marker-end="url(#ar)"/>
+<text x="652" y="280" class="r">✕ 401 — wrong issuer</text>
+<path class="arw" d="M300,304 V330" marker-end="url(#a)"/>
+
+<rect class="box" x="60" y="334" width="480" height="56" rx="9"/>
+<text x="80" y="358" class="b">④ aud names this backend</text>
+<text x="80" y="378" class="s">a token for one service fails at another</text>
+<path class="rej" d="M540,362 H640" marker-end="url(#ar)"/>
+<text x="652" y="366" class="r">✕ 401 — wrong audience</text>
+<path class="arw" d="M300,390 V416" marker-end="url(#a)"/>
+
+<rect class="box" x="60" y="420" width="480" height="56" rx="9"/>
+<text x="80" y="444" class="b">⑤ exp still in the future</text>
+<text x="80" y="464" class="s">lifetimes are minutes, not days</text>
+<path class="rej" d="M540,448 H640" marker-end="url(#ar)"/>
+<text x="652" y="452" class="r">✕ 401 — expired</text>
+<path class="arw" d="M300,476 V502" marker-end="url(#a)"/>
+
+<rect class="box" x="60" y="506" width="480" height="56" rx="9"/>
+<text x="80" y="530" class="b">⑥ this issuer may assert this role</text>
+<text x="80" y="550" class="s">a valid signature cannot claim admin</text>
+<path class="rej" d="M540,534 H640" marker-end="url(#ar)"/>
+<text x="652" y="538" class="r">✕ 401 — role not allowed</text>
+<path class="arw" d="M300,562 V588" marker-end="url(#a)"/>
+
+<rect class="box" x="60" y="592" width="480" height="56" rx="9"/>
+<text x="80" y="616" class="b">⑦ route requires exactly this role</text>
+<text x="80" y="636" class="s">service ≠ user ≠ admin — no crossover</text>
+<path class="rej" d="M540,620 H640" marker-end="url(#ar)"/>
+<text x="652" y="624" class="r">✕ 401 — wrong principal</text>
+<path class="arw" d="M300,648 V674" marker-end="url(#a)"/>
+
+<rect x="60" y="678" width="480" height="64" rx="9" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.4"/>
+<text x="80" y="704" class="b" font-weight="700" fill="#0F6E56">typed context { canonical_user, role }</text>
+<text x="80" y="724" class="s">the only thing a handler ever receives</text>
+
+<rect x="60" y="784" width="820" height="34" rx="8" fill="#f3f4f6" stroke="#d1d5db"/>
+<text x="470" y="806" font-size="12px" fill="#374151" text-anchor="middle">Seven independent checks — any failure is a hard 401. Nothing falls through, and the verifier holds no signing key.</text>
+</svg>

--- a/apps/landing/public/research/auth-across-two-worlds/figures/f06_wallet_registry.svg
+++ b/apps/landing/public/research/auth-across-two-worlds/figures/f06_wallet_registry.svg
@@ -1,0 +1,78 @@
+<svg width="1140" height="700" viewBox="0 0 1140 700" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" role="img" aria-label="The multi-wallet registry: many known wallets, one active wallet per chain family, live and stored states kept distinct">
+<defs>
+<marker id="a" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#6b7280"/></marker>
+<style>
+text{font-family:ui-monospace, SFMono-Regular, Menlo, monospace;}
+.h{font-size:13.5px;font-weight:700}
+.b{font-size:12px;fill:#1f2937}
+.s{font-size:11.5px;fill:#6b7280}
+.arw{stroke:#6b7280;stroke-width:1.5;fill:none}
+.tag{font-size:10.5px;font-weight:700}
+</style>
+</defs>
+
+<!-- canonical account -->
+<rect x="40" y="212" width="220" height="70" rx="12" fill="#1f2937"/>
+<text x="150" y="242" font-size="13.5px" font-weight="700" fill="#ffffff" text-anchor="middle">CANONICAL ACCOUNT</text>
+<text x="150" y="264" font-size="11px" fill="#c7cdd6" text-anchor="middle">one user · many wallets</text>
+
+<path class="arw" d="M260,236 C300,200 300,180 336,160" marker-end="url(#a)"/>
+<path class="arw" d="M260,258 C300,300 700,120 756,150" marker-end="url(#a)"/>
+
+<!-- EVM family -->
+<rect x="340" y="46" width="380" height="404" rx="10" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.4"/>
+<text x="360" y="76" class="h" fill="#0F6E56">EVM FAMILY</text>
+<text x="490" y="76" class="s">exactly one active</text>
+
+<rect x="360" y="94" width="340" height="98" rx="9" fill="#ffffff" stroke="#1D9E75" stroke-width="1.2"/>
+<text x="378" y="120" class="b" font-weight="700">MetaMask</text>
+<text x="378" y="141" class="s">external EOA · linked via SIWE</text>
+<rect x="378" y="154" width="52" height="19" rx="9.5" fill="none" stroke="#1D9E75" stroke-width="1.2"/>
+<text x="404" y="168" class="tag" fill="#0F6E56" text-anchor="middle">LIVE</text>
+<rect x="440" y="154" width="72" height="19" rx="9.5" fill="#1D9E75"/>
+<text x="476" y="168" class="tag" fill="#ffffff" text-anchor="middle">● ACTIVE</text>
+
+<rect x="360" y="208" width="340" height="98" rx="9" fill="#ffffff" stroke="#1D9E75" stroke-width="1.2"/>
+<text x="378" y="234" class="b" font-weight="700">Privy embedded</text>
+<text x="378" y="255" class="s">embedded EVM · provider-attested</text>
+<rect x="378" y="268" width="52" height="19" rx="9.5" fill="none" stroke="#1D9E75" stroke-width="1.2"/>
+<text x="404" y="282" class="tag" fill="#0F6E56" text-anchor="middle">LIVE</text>
+
+<rect x="360" y="322" width="340" height="98" rx="9" fill="#ffffff" stroke="#9CA3AF" stroke-width="1.2"/>
+<text x="378" y="348" class="b" font-weight="700">Smart account</text>
+<text x="378" y="369" class="s">4337 · owner: the MetaMask EOA</text>
+<rect x="378" y="382" width="66" height="19" rx="9.5" fill="none" stroke="#9CA3AF" stroke-width="1.2"/>
+<text x="411" y="396" class="tag" fill="#6b7280" text-anchor="middle">STORED</text>
+
+<!-- SVM family -->
+<rect x="760" y="46" width="340" height="404" rx="10" fill="#faf9ff" stroke="#7F77DD" stroke-width="1.4"/>
+<text x="780" y="76" class="h" fill="#534AB7">SVM FAMILY</text>
+<text x="908" y="76" class="s">exactly one active</text>
+
+<rect x="780" y="94" width="300" height="98" rx="9" fill="#ffffff" stroke="#7F77DD" stroke-width="1.2"/>
+<text x="798" y="120" class="b" font-weight="700">Phantom</text>
+<text x="798" y="141" class="s">external · case-sensitive base58</text>
+<rect x="798" y="154" width="52" height="19" rx="9.5" fill="none" stroke="#7F77DD" stroke-width="1.2"/>
+<text x="824" y="168" class="tag" fill="#534AB7" text-anchor="middle">LIVE</text>
+<rect x="860" y="154" width="72" height="19" rx="9.5" fill="#7F77DD"/>
+<text x="896" y="168" class="tag" fill="#ffffff" text-anchor="middle">● ACTIVE</text>
+
+<rect x="780" y="208" width="300" height="98" rx="9" fill="#ffffff" stroke="#9CA3AF" stroke-width="1.2"/>
+<text x="798" y="234" class="b" font-weight="700">Para embedded</text>
+<text x="798" y="255" class="s">embedded SVM · provider-attested</text>
+<rect x="798" y="268" width="66" height="19" rx="9.5" fill="none" stroke="#9CA3AF" stroke-width="1.2"/>
+<text x="831" y="282" class="tag" fill="#6b7280" text-anchor="middle">STORED</text>
+
+<text x="780" y="368" class="s">selecting here never touches</text>
+<text x="780" y="388" class="s">the active EVM wallet →</text>
+
+<!-- capability strip -->
+<rect x="40" y="490" width="1060" height="120" rx="10" fill="#fafafa" stroke="#9CA3AF" stroke-width="1.3"/>
+<text x="66" y="520" class="h" fill="#374151">EVERY ROW CARRIES STATE, NOT A LABEL</text>
+<text x="66" y="550" class="b">family (evm / svm) · provenance (siwe / attested / derived) · provider · capability (read / sign / send / display)</text>
+<text x="66" y="574" class="b">status (live / stored / revoked / stale) · linked-by evidence · provider wallet id</text>
+<text x="66" y="596" class="s">policy derives from provenance and capability — never from a display label like "Privy wallet"</text>
+
+<rect x="40" y="642" width="1060" height="34" rx="8" fill="#f3f4f6" stroke="#d1d5db"/>
+<text x="570" y="664" font-size="12px" fill="#374151" text-anchor="middle">Active is a session-level execution choice, never an identity fact — changing it does not change the authenticated user.</text>
+</svg>

--- a/apps/landing/public/research/auth-across-two-worlds/figures/f07_credential_lifetimes.svg
+++ b/apps/landing/public/research/auth-across-two-worlds/figures/f07_credential_lifetimes.svg
@@ -1,0 +1,59 @@
+<svg width="1140" height="560" viewBox="0 0 1140 560" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" role="img" aria-label="Credential lifetimes on one time axis: proofs are consumed in minutes, sessions live for days, only the short-lived assertion crosses into the backend">
+<defs>
+<style>
+text{font-family:ui-monospace, SFMono-Regular, Menlo, monospace;}
+.n{font-size:12.5px;font-weight:700;fill:#1f2937}
+.v{font-size:11px;fill:#6b7280}
+.s{font-size:11.5px;fill:#6b7280}
+.gl{stroke:#eceef1;stroke-width:1}
+.tk{fill:#6b7280;font-size:11px;text-anchor:middle}
+</style>
+</defs>
+
+<!-- gridlines: 1 min / 1 h / 1 day / 30 days (log-ish) -->
+<line class="gl" x1="420" y1="60" x2="420" y2="452"/>
+<line class="gl" x1="600" y1="60" x2="600" y2="452"/>
+<line class="gl" x1="780" y1="60" x2="780" y2="452"/>
+<line class="gl" x1="960" y1="60" x2="960" y2="452"/>
+<line x1="340" y1="452" x2="1080" y2="452" stroke="#d1d5db" stroke-width="1"/>
+<text class="tk" x="420" y="472">1 min</text>
+<text class="tk" x="600" y="472">1 hour</text>
+<text class="tk" x="780" y="472">1 day</text>
+<text class="tk" x="960" y="472">30 days</text>
+
+<!-- row 1: provider proof -->
+<text class="n" x="40" y="92">SIWE / provider proof</text>
+<text class="v" x="40" y="110">verifier: BFF adapter</text>
+<rect x="340" y="80" width="96" height="22" rx="5" fill="#378ADD"/>
+<text class="s" x="448" y="96">one ceremony — consumed at the edge</text>
+
+<!-- row 2: first-party session -->
+<text class="n" x="40" y="166">Better Auth session</text>
+<text class="v" x="40" y="184">verifier: BFF</text>
+<rect x="340" y="154" width="500" height="22" rx="5" fill="#1D9E75"/>
+<line x1="840" y1="146" x2="840" y2="184" stroke="#D85A30" stroke-width="2"/>
+<text class="s" x="852" y="170">days · ends by revocation, not just expiry</text>
+
+<!-- row 3: backend assertion -->
+<text class="n" x="40" y="240">Backend assertion</text>
+<text class="v" x="40" y="258">verifier: Rust backend</text>
+<rect x="340" y="228" width="150" height="22" rx="5" fill="#EF9F27"/>
+<text class="s" x="502" y="244" font-weight="700" fill="#B0710F">minutes — the only artifact that crosses into the backend</text>
+
+<!-- row 4: connection state -->
+<text class="n" x="40" y="314">Connection state token</text>
+<text class="v" x="40" y="332">verifier: callback driver</text>
+<rect x="340" y="302" width="230" height="22" rx="5" fill="#7F77DD"/>
+<text class="s" x="582" y="318">minutes → 1 h · protects one redirect round-trip</text>
+
+<!-- row 5: delegated approval -->
+<text class="n" x="40" y="388">Delegated approval</text>
+<text class="v" x="40" y="406">verifier: signer runtime</text>
+<rect x="340" y="376" width="560" height="22" rx="5" fill="#9CA3AF"/>
+<rect x="900" y="376" width="120" height="22" rx="5" fill="none" stroke="#9CA3AF" stroke-width="1.3" stroke-dasharray="4 4"/>
+<line x1="1020" y1="368" x2="1020" y2="406" stroke="#D85A30" stroke-width="2"/>
+<text class="s" x="340" y="422">policy-defined · always revocable · never outlives its wallet link</text>
+
+<rect x="40" y="500" width="1060" height="34" rx="8" fill="#f3f4f6" stroke="#d1d5db"/>
+<text x="570" y="522" font-size="12px" fill="#374151" text-anchor="middle">Solid bar = expiry window · red tick = revocation point · dashed = policy-extendable. Different artifacts, different clocks.</text>
+</svg>

--- a/apps/landing/public/research/auth-across-two-worlds/figures/f08_connection_ceremony.svg
+++ b/apps/landing/public/research/auth-across-two-worlds/figures/f08_connection_ceremony.svg
@@ -1,0 +1,77 @@
+<svg width="1140" height="880" viewBox="0 0 1140 880" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" role="img" aria-label="The provider connection ceremony: signed state protects the redirect round-trip before any approval is persisted">
+<defs>
+<marker id="a" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#6b7280"/></marker>
+<marker id="ar" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#D85A30"/></marker>
+<style>
+text{font-family:ui-monospace, SFMono-Regular, Menlo, monospace;}
+.h{font-size:13px;font-weight:700}
+.b{font-size:12px;fill:#1f2937}
+.s{font-size:11.5px;fill:#6b7280}
+.r{font-size:11.5px;fill:#9e3f17}
+.arw{stroke:#6b7280;stroke-width:1.5;fill:none}
+.rej{stroke:#D85A30;stroke-width:1.3;fill:none}
+</style>
+</defs>
+
+<!-- begin -->
+<rect x="410" y="36" width="320" height="48" rx="24" fill="#1f2937"/>
+<text x="570" y="66" font-size="13.5px" font-weight="700" fill="#ffffff" text-anchor="middle">BEGIN CONNECTION</text>
+<path class="arw" d="M570,84 V112" marker-end="url(#a)"/>
+
+<!-- sign state -->
+<rect x="290" y="116" width="560" height="92" rx="10" fill="#fffaf0" stroke="#EF9F27" stroke-width="1.4"/>
+<text x="314" y="144" class="h" fill="#B0710F">① SIGN STATE</text>
+<text x="314" y="168" class="b">state = { provider, user, thread, app, exp }</text>
+<text x="314" y="190" class="s">short-lived — and the provider name lives inside the signature</text>
+
+<path class="arw" d="M570,208 C570,232 380,246 372,280" marker-end="url(#a)"/>
+
+<!-- outside the application -->
+<rect x="180" y="244" width="780" height="140" rx="12" fill="none" stroke="#9CA3AF" stroke-width="1.2" stroke-dasharray="6 5"/>
+<text x="204" y="270" class="s" font-weight="700">OUTSIDE THE APPLICATION</text>
+
+<rect x="220" y="286" width="300" height="72" rx="9" fill="#faf9ff" stroke="#7F77DD" stroke-width="1.3"/>
+<text x="240" y="314" class="h" fill="#534AB7">② REDIRECT TO PROVIDER</text>
+<text x="240" y="336" class="s">login / consent on their surface</text>
+
+<path class="arw" d="M524,322 H636" marker-end="url(#a)"/>
+
+<rect x="640" y="286" width="300" height="72" rx="9" fill="#faf9ff" stroke="#7F77DD" stroke-width="1.3"/>
+<text x="660" y="314" class="h" fill="#534AB7">③ CALLBACK RETURNS</text>
+<text x="660" y="336" class="s">provider payload + state token</text>
+
+<path class="arw" d="M790,358 C790,392 570,388 570,416" marker-end="url(#a)"/>
+
+<!-- gate 1 -->
+<rect x="290" y="420" width="560" height="68" rx="9" fill="#fafafa" stroke="#9CA3AF" stroke-width="1.3"/>
+<text x="314" y="446" class="h" fill="#1f2937">④ VERIFY STATE — before anything else</text>
+<text x="314" y="468" class="s">binds the callback to its initiating user, thread, app, expiry</text>
+<path class="rej" d="M850,454 H886" marker-end="url(#ar)"/>
+<text x="898" y="458" class="r">✕ tampered / expired state</text>
+<path class="arw" d="M570,488 V512" marker-end="url(#a)"/>
+
+<!-- gate 2 -->
+<rect x="290" y="516" width="560" height="68" rx="9" fill="#fafafa" stroke="#9CA3AF" stroke-width="1.3"/>
+<text x="314" y="542" class="h" fill="#1f2937">⑤ SELECT PROVIDER ADAPTER</text>
+<text x="314" y="564" class="s">from the verified state — never from the request</text>
+<path class="rej" d="M850,550 H886" marker-end="url(#ar)"/>
+<text x="898" y="554" class="r">✕ no adapter switch via query params</text>
+<path class="arw" d="M570,584 V608" marker-end="url(#a)"/>
+
+<!-- gate 3 -->
+<rect x="290" y="612" width="560" height="68" rx="9" fill="#fafafa" stroke="#9CA3AF" stroke-width="1.3"/>
+<text x="314" y="638" class="h" fill="#1f2937">⑥ VERIFY PROVIDER PAYLOAD</text>
+<text x="314" y="660" class="s">that provider's own cryptographic contract</text>
+<path class="rej" d="M850,646 H886" marker-end="url(#ar)"/>
+<text x="898" y="650" class="r">✕ invalid payload</text>
+<path class="arw" d="M570,680 V704" marker-end="url(#a)"/>
+
+<!-- persist -->
+<rect x="290" y="708" width="560" height="92" rx="10" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.4"/>
+<text x="314" y="736" class="h" fill="#0F6E56">⑦ NORMALIZE + PERSIST APPROVAL</text>
+<text x="314" y="760" class="b">subject · verified wallets · secret handles · lifetime</text>
+<text x="314" y="782" class="s">a revocable execution grant — resolved later for one exact address</text>
+
+<rect x="40" y="830" width="1060" height="34" rx="8" fill="#f3f4f6" stroke="#d1d5db"/>
+<text x="570" y="852" font-size="12px" fill="#374151" text-anchor="middle">The state token is a seatbelt for one redirect — it is not a session, and it is not a signing grant.</text>
+</svg>

--- a/apps/landing/public/research/auth-across-two-worlds/figures/f09_credential_pipeline.svg
+++ b/apps/landing/public/research/auth-across-two-worlds/figures/f09_credential_pipeline.svg
@@ -1,0 +1,51 @@
+<svg width="900" height="620" viewBox="0 0 900 620" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" role="img" aria-label="One request end to end: each step changes credential type">
+<defs>
+<marker id="a" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#6b7280"/></marker>
+<style>
+text{font-family:ui-monospace, SFMono-Regular, Menlo, monospace;}
+.h{font-size:13.5px;font-weight:700}
+.s{font-size:11.5px;fill:#6b7280}
+.lbl{font-size:12px;fill:#6b7280;font-style:italic}
+.arw{stroke:#6b7280;stroke-width:1.5;fill:none}
+</style>
+</defs>
+
+<rect x="140" y="36" width="440" height="68" rx="10" fill="#eef5fc" stroke="#378ADD" stroke-width="1.4"/>
+<text x="164" y="64" class="h" fill="#185FA5">PROVIDER PROOF · or SIWE</text>
+<text x="164" y="88" class="s">verified at the edge · consumed in one ceremony</text>
+
+<path class="arw" d="M360,104 V152" marker-end="url(#a)"/>
+<text x="378" y="132" class="lbl">verify</text>
+
+<rect x="140" y="156" width="440" height="68" rx="10" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.4"/>
+<text x="164" y="184" class="h" fill="#0F6E56">FIRST-PARTY SESSION</text>
+<text x="164" y="208" class="s">HttpOnly cookie · days · revocable</text>
+
+<path class="arw" d="M360,224 V272" marker-end="url(#a)"/>
+<text x="378" y="252" class="lbl">resolve</text>
+
+<rect x="140" y="276" width="440" height="68" rx="10" fill="#1f2937"/>
+<text x="164" y="304" class="h" fill="#ffffff">CANONICAL USER ID</text>
+<text x="164" y="328" font-size="11.5px" fill="#c7cdd6">the stable, application-owned root</text>
+
+<path class="arw" d="M360,344 V392" marker-end="url(#a)"/>
+<text x="378" y="372" class="lbl">sign at the BFF</text>
+
+<rect x="140" y="396" width="440" height="68" rx="10" fill="#fffaf0" stroke="#EF9F27" stroke-width="1.4"/>
+<text x="164" y="424" class="h" fill="#B0710F">BACKEND ASSERTION</text>
+<text x="164" y="448" class="s">aud-bound · role-bound · minutes</text>
+
+<path class="arw" d="M360,464 V512" marker-end="url(#a)"/>
+<text x="378" y="492" class="lbl">verify at the route</text>
+
+<rect x="140" y="516" width="440" height="68" rx="10" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.4"/>
+<text x="164" y="544" class="h" fill="#0F6E56">TYPED ACCOUNT CONTEXT</text>
+<text x="164" y="568" class="s">{ canonical_user, role } — all a handler ever sees</text>
+
+<!-- side note -->
+<text x="628" y="292" font-size="13px" font-weight="700" fill="#B0710F">EVERY ARROW CHANGES</text>
+<text x="628" y="312" font-size="13px" font-weight="700" fill="#B0710F">CREDENTIAL TYPE</text>
+<text x="628" y="340" class="s">reusing one credential across</text>
+<text x="628" y="358" class="s">all five steps would erase the</text>
+<text x="628" y="376" class="s">trust boundaries between them</text>
+</svg>

--- a/apps/landing/public/research/auth-across-two-worlds/figures/f10_unattended_execution.svg
+++ b/apps/landing/public/research/auth-across-two-worlds/figures/f10_unattended_execution.svg
@@ -1,0 +1,66 @@
+<svg width="1140" height="740" viewBox="0 0 1140 740" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" role="img" aria-label="Unattended execution: a scheduled run signs only when the policy axis and the capability axis both hold">
+<defs>
+<marker id="a" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#6b7280"/></marker>
+<marker id="ag" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#1D9E75"/></marker>
+<marker id="ar" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#D85A30"/></marker>
+<style>
+text{font-family:ui-monospace, SFMono-Regular, Menlo, monospace;}
+.h{font-size:13px;font-weight:700}
+.b{font-size:12px;fill:#1f2937}
+.s{font-size:11.5px;fill:#6b7280}
+.arw{stroke:#6b7280;stroke-width:1.5;fill:none}
+</style>
+</defs>
+
+<!-- trigger -->
+<rect x="380" y="28" width="380" height="52" rx="26" fill="#1f2937"/>
+<text x="570" y="60" font-size="13.5px" font-weight="700" fill="#ffffff" text-anchor="middle">SCHEDULED TASK FIRES</text>
+<text x="570" y="106" class="s" text-anchor="middle">cron · no user in session · agent spawned with its saved wallet context</text>
+
+<path class="arw" d="M420,66 C340,84 316,104 306,134" marker-end="url(#a)"/>
+<path class="arw" d="M720,66 C800,84 824,104 834,134" marker-end="url(#a)"/>
+
+<!-- policy axis -->
+<rect x="60" y="140" width="490" height="160" rx="10" fill="#fffaf0" stroke="#EF9F27" stroke-width="1.4"/>
+<text x="84" y="170" class="h" fill="#B0710F">POLICY — signing mode = auto</text>
+<text x="84" y="198" class="b">set by a user-present permit, signed</text>
+<text x="84" y="220" class="b">by the wallet itself (EIP-712 / signed message)</text>
+<text x="84" y="248" class="s">short-lived · replay-protected · not agent-grantable</text>
+<text x="84" y="268" class="s">offered only when an active delegated grant already exists</text>
+
+<!-- capability axis -->
+<rect x="590" y="140" width="490" height="160" rx="10" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.4"/>
+<text x="614" y="170" class="h" fill="#0F6E56">CAPABILITY — active delegated approval</text>
+<text x="614" y="198" class="b">granted in the connection ceremony</text>
+<text x="614" y="220" class="b">expiry · revocable · one active per identity</text>
+<text x="614" y="248" class="s">secrets live in a vault — resolved</text>
+<text x="614" y="268" class="s">only at the moment of signing</text>
+
+<!-- converge -->
+<path class="arw" d="M305,300 C305,340 480,338 532,368" marker-end="url(#a)"/>
+<path class="arw" d="M835,300 C835,340 660,338 608,368" marker-end="url(#a)"/>
+<text x="570" y="340" font-size="12px" font-weight="700" fill="#B0710F" text-anchor="middle">both must hold</text>
+
+<!-- resolution -->
+<rect x="290" y="372" width="560" height="92" rx="10" fill="#fafafa" stroke="#9CA3AF" stroke-width="1.3"/>
+<text x="314" y="400" class="h" fill="#1f2937">SIGN-TIME RESOLUTION</text>
+<text x="314" y="424" class="b">user · provider · chain family · exact address → active grant</text>
+<text x="314" y="446" class="s">the same resolver as an interactive run — no special path for automation</text>
+
+<path class="arw" d="M450,464 C400,500 340,506 300,540" marker-end="url(#ag)" stroke="#1D9E75"/>
+<path class="arw" d="M690,464 C740,500 800,506 840,540" marker-end="url(#ar)" stroke="#D85A30"/>
+
+<!-- outcomes -->
+<rect x="60" y="544" width="470" height="100" rx="10" fill="#f6fcf9" stroke="#1D9E75" stroke-width="1.4"/>
+<text x="84" y="572" class="h" fill="#0F6E56">PROVIDER SIGNS SERVER-SIDE</text>
+<text x="84" y="596" class="b">quorum-key authorization · tx broadcast</text>
+<text x="84" y="618" class="s">bounded by the grant, not by trust in the scheduler</text>
+
+<rect x="610" y="544" width="470" height="100" rx="10" fill="#fdeee7" stroke="#D85A30" stroke-width="1.4"/>
+<text x="634" y="572" class="h" fill="#9e3f17">FAIL CLOSED</text>
+<text x="634" y="596" class="b">human-in-the-loop wallet or no grant → no signature</text>
+<text x="634" y="618" class="s">the run stalls and retries — never a weaker fallback</text>
+
+<rect x="40" y="684" width="1060" height="34" rx="8" fill="#f3f4f6" stroke="#d1d5db"/>
+<text x="570" y="706" font-size="12px" fill="#374151" text-anchor="middle">Unattended authority is the user's own standing grant — the scheduler has no signing power of its own to escalate.</text>
+</svg>


### PR DESCRIPTION
## Summary

- promote only the landing research article from #367 onto `prod`
- add the article to the production research index/main landing site
- include the article's 14 house-style SVG figures

## Scope

This branch starts from the current `prod` tip and cherry-picks the merge delta of #367. It does not merge or include any other commits currently on `main`.

## Validation

- [x] Confirmed all 16 promoted files match #367 byte-for-byte
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter landing build`
- [x] Confirmed static generation includes `/research/auth-across-two-worlds`

Promotes #367 to production.
