### PR TITLE
Wire mocked observability cards to detail view

### DIFF
--- a/apps/aomi-build/src/app/(control-plane)/operate/observability/[application]/page.tsx
+++ b/apps/aomi-build/src/app/(control-plane)/operate/observability/[application]/page.tsx
@@ -1,0 +1,24 @@
+import { notFound } from "next/navigation";
+import { AppDetailPage } from "@build/features/operate/app-detail-page";
+import { appFixture } from "@build/features/operate/fixtures";
+
+type PageProps = {
+  params: Promise<{ application: string }>;
+  searchParams: Promise<{ fixture?: string; project?: string }>;
+};
+
+export default async function OperateObservabilityDetailPage({
+  params,
+  searchParams,
+}: PageProps) {
+  const [{ application }, query] = await Promise.all([params, searchParams]);
+  const app = appFixture(query.fixture ?? application);
+  if (!app) notFound();
+  const projectId = Number(query.project);
+  const project =
+    Number.isSafeInteger(projectId) && projectId > 0 ? String(projectId) : null;
+
+  return (
+    <AppDetailPage app={app} application={application} project={project} />
+  );
+}

--- a/apps/aomi-build/src/app/dev-operate-preview/page.tsx
+++ b/apps/aomi-build/src/app/dev-operate-preview/page.tsx
@@ -8,8 +8,11 @@
 import { Suspense, useState } from "react";
 import { useRouter } from "next/navigation";
 import { GitHubSessionProvider } from "@build/components/control-plane/github-session-context";
-import { OperateView, type ViewKind } from "@build/features/operate/operate-view";
-import { AppDetailMock } from "./detail-mock";
+import {
+  OperateView,
+  type ViewKind,
+} from "@build/features/operate/operate-view";
+import { AppDetailView } from "@build/features/operate/app-detail-view";
 import {
   ALL_LOGS,
   ALL_TRANSACTIONS,
@@ -94,9 +97,17 @@ function logWire(log: LogRecord, index: number) {
 const OBSERVABILITY = {
   sources: [SOURCE],
   scope: "owned_applications",
-  monitoring: { provider: "grafana_prometheus", status: "ok", windowSeconds: 900 },
+  monitoring: {
+    provider: "grafana_prometheus",
+    status: "ok",
+    windowSeconds: 900,
+  },
   dashboardLinks: [
-    { label: "Open dashboard", url: "https://grafana.example.com/d/app", scope: "owned_applications" },
+    {
+      label: "Open dashboard",
+      url: "https://grafana.example.com/d/app",
+      scope: "owned_applications",
+    },
   ],
   platformMetrics: [],
   apps: exampleAppCards(SOURCE),
@@ -119,8 +130,26 @@ const USAGE = {
   range: { fromDate: "2026-07-01", toDate: "2026-07-15", maxDays: 31 },
   daily: [],
   breakdown: [
-    { provider: "anthropic", model: "claude-opus-4-8", paymentMethod: "quota", inputTokens: 1_100_000, outputTokens: 152_000, creditsUsed: 9.1204, events: 152, source: SOURCE },
-    { provider: "anthropic", model: "claude-haiku-4-5", paymentMethod: "quota", inputTokens: 206_000, outputTokens: 30_300, creditsUsed: 1.6233, events: 88, source: SOURCE },
+    {
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      paymentMethod: "quota",
+      inputTokens: 1_100_000,
+      outputTokens: 152_000,
+      creditsUsed: 9.1204,
+      events: 152,
+      source: SOURCE,
+    },
+    {
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      paymentMethod: "quota",
+      inputTokens: 206_000,
+      outputTokens: 30_300,
+      creditsUsed: 1.6233,
+      events: 88,
+      source: SOURCE,
+    },
   ],
   statement: exampleStatement(SOURCE),
 };
@@ -136,10 +165,18 @@ function stubFetch() {
   if (typeof window === "undefined") return;
   const real = window.fetch.bind(window);
   window.fetch = async (input, init) => {
-    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-    if (url.includes("/api/bff/auth/github/status")) return Response.json(SESSION);
-    if (url.includes("/api/bff/operate/observability")) return Response.json(OBSERVABILITY);
-    if (url.includes("/api/bff/operate/transactions")) return Response.json(TRANSACTIONS);
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    if (url.includes("/api/bff/auth/github/status"))
+      return Response.json(SESSION);
+    if (url.includes("/api/bff/operate/observability"))
+      return Response.json(OBSERVABILITY);
+    if (url.includes("/api/bff/operate/transactions"))
+      return Response.json(TRANSACTIONS);
     if (url.includes("/api/bff/operate/logs")) return Response.json(LOGS);
     if (url.includes("/api/bff/operate/usage")) return Response.json(USAGE);
     return real(input, init);
@@ -161,8 +198,10 @@ export default function DevOperatePreview() {
   const detail = detailApp ? appFixture(detailApp) : undefined;
   if (detail) {
     return (
-      <AppDetailMock
+      <AppDetailView
         app={detail}
+        example
+        dashboardHref="https://grafana.example.com/d/app"
         onBack={() => setDetailApp(null)}
         onOpenTrace={(tool) => {
           // Deep link through real URL params — the same links the product uses.
@@ -194,7 +233,9 @@ export default function DevOperatePreview() {
             type="button"
             onClick={() => setKind(k)}
             className={`rounded-t-md px-3 py-1.5 text-sm capitalize ${
-              k === kind ? "bg-surface text-foreground border-border border border-b-0" : "text-dim"
+              k === kind
+                ? "bg-surface text-foreground border-border border border-b-0"
+                : "text-dim"
             }`}
           >
             {k}
@@ -205,8 +246,12 @@ export default function DevOperatePreview() {
       <div
         onClickCapture={(event) => {
           if (kind !== "observability") return;
-          const card = (event.target as HTMLElement).closest("div.rounded-md.border");
-          const name = APP_NAMES.find((appName) => card?.textContent?.includes(appName));
+          const card = (event.target as HTMLElement).closest(
+            "div.rounded-md.border",
+          );
+          const name = APP_NAMES.find((appName) =>
+            card?.textContent?.includes(appName),
+          );
           if (name) setDetailApp(name);
         }}
       >

--- a/apps/aomi-build/src/features/operate/app-detail-page.test.tsx
+++ b/apps/aomi-build/src/features/operate/app-detail-page.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { appFixture } from "./fixtures";
+import { AppDetailPage } from "./app-detail-page";
+
+const push = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+describe("AppDetailPage", () => {
+  beforeEach(() => push.mockReset());
+
+  it("renders fixture detail under the clicked app identity", () => {
+    const fixture = appFixture("goal-digger");
+    expect(fixture).toBeDefined();
+    render(
+      <AppDetailPage
+        app={fixture!}
+        application="playground-example"
+        project="1586"
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "playground-example" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Example data")).toBeInTheDocument();
+    expect(screen.getByText("Conversion funnel · 24h")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Back to observability" }),
+    );
+    expect(push).toHaveBeenCalledWith("/operate/observability?project=1586");
+  });
+
+  it("deep-links fixture rows through the real operate routes", () => {
+    render(
+      <AppDetailPage
+        app={appFixture("goal-digger")!}
+        application="goal-digger"
+        project="1494"
+      />,
+    );
+
+    fireEvent.click(screen.getByText("get_price"));
+    expect(push).toHaveBeenCalledWith(
+      "/operate/logs?app=goal-digger&tool=get_price&project=1494",
+    );
+  });
+});

--- a/apps/aomi-build/src/features/operate/app-detail-page.tsx
+++ b/apps/aomi-build/src/features/operate/app-detail-page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import type { AppFixture } from "./fixtures";
+import { AppDetailView } from "./app-detail-view";
+
+function operateHref(
+  path: string,
+  values: Record<string, string | null>,
+): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(values)) {
+    if (value) params.set(key, value);
+  }
+  return `${path}${params.size ? `?${params}` : ""}`;
+}
+
+export function AppDetailPage({
+  app,
+  application,
+  project,
+}: {
+  app: AppFixture;
+  application: string;
+  project: string | null;
+}) {
+  const router = useRouter();
+  return (
+    <AppDetailView
+      app={app}
+      displayName={application}
+      example
+      onBack={() =>
+        router.push(operateHref("/operate/observability", { project }))
+      }
+      onOpenTrace={(tool) =>
+        router.push(
+          operateHref("/operate/logs", { app: application, tool, project }),
+        )
+      }
+      onOpenTx={(tx) =>
+        router.push(
+          operateHref("/operate/transactions", {
+            app: application,
+            tx,
+            project,
+          }),
+        )
+      }
+    />
+  );
+}

--- a/apps/aomi-build/src/features/operate/app-detail-view.tsx
+++ b/apps/aomi-build/src/features/operate/app-detail-view.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-// TEMPORARY design mock: the per-app drill-down dashboard, hydrated from an
-// AppFixture (Prometheus trends, Postgres ledger, registry lifecycle — as if
-// real). Rows deep-link out: tools → Logs, transactions → Transactions.
+// Per-app drill-down dashboard. While observability is using example metrics,
+// this renders the matching fixture detail; rows deep-link to the real Logs
+// and Transactions surfaces.
 
 import { ArrowLeft, ExternalLink } from "lucide-react";
 import type { AppFixture, TxRecord } from "@build/features/operate/fixtures";
@@ -20,7 +20,13 @@ function BarChart({
   const n = Math.max(...series.map((s) => s.values.length), 1);
   const band = 100 / n;
   return (
-    <svg viewBox={`0 0 100 ${height}`} preserveAspectRatio="none" className="w-full" style={{ height }} aria-hidden>
+    <svg
+      viewBox={`0 0 100 ${height}`}
+      preserveAspectRatio="none"
+      className="w-full"
+      style={{ height }}
+      aria-hidden
+    >
       {series.map((s, si) => {
         const w = (band * 0.7) / series.length;
         return s.values.map((v, i) => {
@@ -42,19 +48,50 @@ function BarChart({
   );
 }
 
-function LineChart({ values, height = 96 }: { values: number[]; height?: number }) {
+function LineChart({
+  values,
+  height = 96,
+}: {
+  values: number[];
+  height?: number;
+}) {
   const max = Math.max(...values, 1);
   const pts = values
-    .map((v, i) => `${(i / (values.length - 1)) * 100},${height - 6 - (v / max) * (height - 14)}`)
+    .map(
+      (v, i) =>
+        `${(i / (values.length - 1)) * 100},${height - 6 - (v / max) * (height - 14)}`,
+    )
     .join(" ");
   return (
-    <svg viewBox={`0 0 100 ${height}`} preserveAspectRatio="none" className="text-dim w-full" style={{ height }} aria-hidden>
-      <polyline points={pts} fill="none" stroke="currentColor" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
+    <svg
+      viewBox={`0 0 100 ${height}`}
+      preserveAspectRatio="none"
+      className="text-dim w-full"
+      style={{ height }}
+      aria-hidden
+    >
+      <polyline
+        points={pts}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        vectorEffect="non-scaling-stroke"
+      />
     </svg>
   );
 }
 
-function Tile({ label, value, sub, tone }: { label: string; value: string; sub?: string; tone?: "bad" | "warn" }) {
+function Tile({
+  label,
+  value,
+  sub,
+  tone,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  tone?: "bad" | "warn";
+}) {
   return (
     <div className="border-border bg-surface rounded-md border px-3 py-2.5">
       <div className="text-dim text-xs">{label}</div>
@@ -68,7 +105,15 @@ function Tile({ label, value, sub, tone }: { label: string; value: string; sub?:
   );
 }
 
-function Panel({ title, right, children }: { title: string; right?: React.ReactNode; children: React.ReactNode }) {
+function Panel({
+  title,
+  right,
+  children,
+}: {
+  title: string;
+  right?: React.ReactNode;
+  children: React.ReactNode;
+}) {
   return (
     <div className="border-border bg-surface rounded-md border">
       <div className="border-border flex items-center justify-between border-b px-3 py-2">
@@ -98,33 +143,59 @@ function clockOf(tx: TxRecord): string {
   return clock.replace(/(\d+:\d+):\d+ (AM|PM)/, "$1 $2");
 }
 
-export function AppDetailMock({
+export function AppDetailView({
   app,
+  displayName,
+  example = false,
+  dashboardHref,
   onBack,
   onOpenTrace,
   onOpenTx,
 }: {
   app: AppFixture;
+  displayName?: string;
+  example?: boolean;
+  dashboardHref?: string | null;
   onBack: () => void;
   onOpenTrace: (tool: string) => void;
   onOpenTx: (txId: string) => void;
 }) {
   const { meta, detail } = app;
   const recentTx = app.transactions.slice(0, 4);
-  const recentEvents = app.logs.filter((log) => log.kind === "event").slice(0, 4);
+  const recentEvents = app.logs
+    .filter((log) => log.kind === "event")
+    .slice(0, 4);
   return (
     <div className="mx-auto flex w-full max-w-7xl flex-col gap-4 px-4 py-6 sm:px-6 lg:px-8">
       {/* Header */}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-3">
-          <button type="button" onClick={onBack} className="border-border bg-surface hover:bg-accent-hover rounded-md border p-2">
+          <button
+            type="button"
+            aria-label="Back to observability"
+            onClick={onBack}
+            className="border-border bg-surface hover:bg-accent-hover rounded-md border p-2"
+          >
             <ArrowLeft className="size-4" />
           </button>
           <div>
             <div className="flex items-center gap-2">
-              <h1 className="text-xl font-semibold">{meta.name}</h1>
+              <h1 className="text-xl font-semibold">
+                {displayName ?? meta.name}
+              </h1>
+              {example ? (
+                <span
+                  title="Live data for this view isn't connected yet — showing example data."
+                  className="border-border bg-surface-subtle text-dim rounded-full border px-2 py-0.5 text-xs"
+                >
+                  Example data
+                </span>
+              ) : null}
               <span className="flex items-center gap-1.5 text-xs">
-                <span className={`size-2 rounded-full ${STATUS_DOT[meta.status] ?? "bg-zinc-400"}`} /> {meta.status}
+                <span
+                  className={`size-2 rounded-full ${STATUS_DOT[meta.status] ?? "bg-zinc-400"}`}
+                />{" "}
+                {meta.status}
               </span>
               {meta.families.map((family) => (
                 <span
@@ -136,7 +207,8 @@ export function AppDetailMock({
               ))}
             </div>
             <div className="text-dim text-xs">
-              {meta.releaseTag ?? "No release"} · SDK {meta.sdkVersion ?? "—"} · {meta.repo}
+              {meta.releaseTag ?? "No release"} · SDK {meta.sdkVersion ?? "—"} ·{" "}
+              {meta.repo}
             </div>
           </div>
         </div>
@@ -152,9 +224,16 @@ export function AppDetailMock({
               </button>
             ))}
           </div>
-          <a href="https://grafana.example.com/d/app" target="_blank" rel="noreferrer" className="border-border bg-surface hover:bg-accent-hover flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs">
-            Grafana <ExternalLink className="size-3" />
-          </a>
+          {dashboardHref ? (
+            <a
+              href={dashboardHref}
+              target="_blank"
+              rel="noreferrer"
+              className="border-border bg-surface hover:bg-accent-hover flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs"
+            >
+              Grafana <ExternalLink className="size-3" />
+            </a>
+          ) : null}
         </div>
       </div>
 
@@ -190,7 +269,13 @@ export function AppDetailMock({
       {/* KPI tiles */}
       <div className="grid grid-cols-2 gap-2 md:grid-cols-4 xl:grid-cols-8">
         {detail.kpis.map((kpi) => (
-          <Tile key={kpi.label} label={kpi.label} value={kpi.value} sub={kpi.sub} tone={kpi.tone} />
+          <Tile
+            key={kpi.label}
+            label={kpi.label}
+            value={kpi.value}
+            sub={kpi.sub}
+            tone={kpi.tone}
+          />
         ))}
       </div>
 
@@ -200,14 +285,22 @@ export function AppDetailMock({
           title="Activity by hour"
           right={
             <span className="text-dim flex items-center gap-3 text-xs">
-              <span className="flex items-center gap-1"><span className="size-2 rounded-sm bg-emerald-500/80" /> chats</span>
-              <span className="flex items-center gap-1"><span className="bg-foreground/30 size-2 rounded-sm" /> tool calls</span>
+              <span className="flex items-center gap-1">
+                <span className="size-2 rounded-sm bg-emerald-500/80" /> chats
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="bg-foreground/30 size-2 rounded-sm" /> tool
+                calls
+              </span>
             </span>
           }
         >
           <BarChart
             series={[
-              { values: detail.toolCallsHourly, className: "fill-foreground/25" },
+              {
+                values: detail.toolCallsHourly,
+                className: "fill-foreground/25",
+              },
               { values: detail.chatsHourly, className: "fill-emerald-500/80" },
             ]}
           />
@@ -217,7 +310,10 @@ export function AppDetailMock({
             ))}
           </div>
         </Panel>
-        <Panel title="P95 turn latency" right={<span className="text-dim text-xs">seconds</span>}>
+        <Panel
+          title="P95 turn latency"
+          right={<span className="text-dim text-xs">seconds</span>}
+        >
           <LineChart values={detail.p95Hourly} />
           <div className="text-dim mt-1 flex justify-between text-[10px]">
             <span>00:00</span>
@@ -225,19 +321,39 @@ export function AppDetailMock({
             <span>23:00</span>
           </div>
         </Panel>
-        <Panel title="Credits per day" right={<span className="text-dim text-xs">7d · from usage ledger</span>}>
-          <BarChart series={[{ values: detail.creditsDaily.values, className: "fill-amber-500/70" }]} />
+        <Panel
+          title="Credits per day"
+          right={
+            <span className="text-dim text-xs">7d · from usage ledger</span>
+          }
+        >
+          <BarChart
+            series={[
+              {
+                values: detail.creditsDaily.values,
+                className: "fill-amber-500/70",
+              },
+            ]}
+          />
           <div className="text-dim mt-1 flex justify-between text-[10px]">
             <span>{detail.creditsDaily.days[0]}</span>
             <span>
-              {detail.creditsDaily.days.at(-1)} · {detail.creditsDaily.values.at(-1)}
+              {detail.creditsDaily.days.at(-1)} ·{" "}
+              {detail.creditsDaily.values.at(-1)}
             </span>
           </div>
         </Panel>
       </div>
 
       {/* Tools table → click a row to open its trace in Logs */}
-      <Panel title="Tools · 24h" right={<span className="text-dim text-xs">{detail.toolsSummary} · click a row to open its trace in Logs</span>}>
+      <Panel
+        title="Tools · 24h"
+        right={
+          <span className="text-dim text-xs">
+            {detail.toolsSummary} · click a row to open its trace in Logs
+          </span>
+        }
+      >
         <div className="overflow-x-auto">
           <table className="min-w-full text-sm">
             <thead className="text-dim text-left text-xs uppercase">
@@ -260,7 +376,11 @@ export function AppDetailMock({
                   <td className="py-2 pr-3 font-mono text-xs">{row.tool}</td>
                   <td className="py-2 pr-3">{row.calls}</td>
                   <td className="py-2 pr-3">{row.errors}</td>
-                  <td className={`py-2 pr-3 font-medium ${row.bad ? "text-red-500" : ""}`}>{row.errorRate}</td>
+                  <td
+                    className={`py-2 pr-3 font-medium ${row.bad ? "text-red-500" : ""}`}
+                  >
+                    {row.errorRate}
+                  </td>
                   <td className="py-2 pr-3">{row.p95}</td>
                   <td className="text-dim py-2 text-xs">{row.last}</td>
                 </tr>
@@ -274,7 +394,11 @@ export function AppDetailMock({
       <div className="grid gap-2 lg:grid-cols-[1fr_340px]">
         <Panel
           title="Recent transactions"
-          right={<span className="text-dim text-xs">{detail.fees24h} · click a row to open it in Transactions</span>}
+          right={
+            <span className="text-dim text-xs">
+              {detail.fees24h} · click a row to open it in Transactions
+            </span>
+          }
         >
           {recentTx.length ? (
             <div className="overflow-x-auto">
@@ -296,14 +420,26 @@ export function AppDetailMock({
                       onClick={() => onOpenTx(tx.id)}
                       className="hover:bg-surface-subtle cursor-pointer"
                     >
-                      <td className="text-dim py-2 pr-3 text-xs">{clockOf(tx)}</td>
-                      <td className="max-w-64 truncate py-2 pr-3">{tx.description}</td>
+                      <td className="text-dim py-2 pr-3 text-xs">
+                        {clockOf(tx)}
+                      </td>
+                      <td className="max-w-64 truncate py-2 pr-3">
+                        {tx.description}
+                      </td>
                       <td className="py-2 pr-3">{tx.chain}</td>
                       <td className="py-2 pr-3">
-                        <span className={`rounded-full border px-2 py-0.5 text-xs ${STATUS_CHIP[tx.status]}`}>{tx.status}</span>
+                        <span
+                          className={`rounded-full border px-2 py-0.5 text-xs ${STATUS_CHIP[tx.status]}`}
+                        >
+                          {tx.status}
+                        </span>
                       </td>
-                      <td className="py-2 pr-3 font-mono text-xs">{tx.txFee ?? "—"}</td>
-                      <td className="py-2 font-mono text-xs">{tx.platformFee ?? "—"}</td>
+                      <td className="py-2 pr-3 font-mono text-xs">
+                        {tx.txFee ?? "—"}
+                      </td>
+                      <td className="py-2 font-mono text-xs">
+                        {tx.platformFee ?? "—"}
+                      </td>
                     </tr>
                   ))}
                 </tbody>
@@ -330,11 +466,18 @@ export function AppDetailMock({
           <Panel title="Releases">
             <div className="space-y-2 text-sm">
               {detail.releases.map((release) => (
-                <div key={release.tag} className="flex items-center justify-between gap-2">
-                  <span className="min-w-0 truncate font-mono text-xs">{release.tag}</span>
+                <div
+                  key={release.tag}
+                  className="flex items-center justify-between gap-2"
+                >
+                  <span className="min-w-0 truncate font-mono text-xs">
+                    {release.tag}
+                  </span>
                   <span className="text-dim text-xs">{release.when}</span>
                   {release.current ? (
-                    <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-xs text-emerald-500">current</span>
+                    <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-xs text-emerald-500">
+                      current
+                    </span>
                   ) : (
                     <span className="text-dim text-xs">{release.note}</span>
                   )}
@@ -346,19 +489,35 @@ export function AppDetailMock({
       </div>
 
       {/* Events */}
-      <Panel title="Recent events" right={<span className="text-dim text-xs">app-filtered · full stream in Logs</span>}>
+      <Panel
+        title="Recent events"
+        right={
+          <span className="text-dim text-xs">
+            app-filtered · full stream in Logs
+          </span>
+        }
+      >
         <div className="space-y-2">
           {recentEvents.length ? (
             recentEvents.map((entry) => (
-              <div key={`${entry.at}-${entry.eventType}`} className="flex items-baseline justify-between gap-3 text-sm">
-                <span className={`min-w-0 truncate ${entry.status === "error" ? "text-red-500" : ""}`}>{entry.summary}</span>
+              <div
+                key={`${entry.at}-${entry.eventType}`}
+                className="flex items-baseline justify-between gap-3 text-sm"
+              >
+                <span
+                  className={`min-w-0 truncate ${entry.status === "error" ? "text-red-500" : ""}`}
+                >
+                  {entry.summary}
+                </span>
                 <span className="text-dim shrink-0 text-xs">
                   {entry.eventType} · {entry.at}
                 </span>
               </div>
             ))
           ) : (
-            <div className="text-dim py-4 text-center text-sm">No recent events.</div>
+            <div className="text-dim py-4 text-center text-sm">
+              No recent events.
+            </div>
           )}
         </div>
       </Panel>

--- a/apps/aomi-build/src/features/operate/fixtures/wire.test.ts
+++ b/apps/aomi-build/src/features/operate/fixtures/wire.test.ts
@@ -49,6 +49,18 @@ describe("withExampleTrends", () => {
     expect(apps[0].metrics?.p95LatencyMs).toBe(1200); // real value kept
     expect(apps[0].metrics?.chats24h).toBeGreaterThan(0); // example filled
     expect(apps[0].metrics?.chatsHourly).toHaveLength(24); // example filled
+    expect(apps[0].exampleFixture).toBe("goal-digger");
+  });
+
+  it("matches a known live app to its own fixture instead of array order", () => {
+    const { apps } = withExampleTrends([
+      { application: "playground-example", metrics: null },
+      { application: "goal-digger", metrics: null },
+    ]);
+    expect(apps[0].exampleFixture).toBe("playground-example");
+    expect(apps[0].metrics?.chats24h).toBe(9);
+    expect(apps[1].exampleFixture).toBe("goal-digger");
+    expect(apps[1].metrics?.chats24h).toBe(47);
   });
 
   it("leaves cards that already report live trend data untouched", () => {
@@ -59,10 +71,7 @@ describe("withExampleTrends", () => {
   });
 
   it("cycles fixture metric sets per card index", () => {
-    const { apps } = withExampleTrends([
-      { metrics: null },
-      { metrics: null },
-    ]);
+    const { apps } = withExampleTrends([{ metrics: null }, { metrics: null }]);
     expect(apps[0].metrics?.chats24h).not.toBe(apps[1].metrics?.chats24h);
   });
 });
@@ -73,6 +82,7 @@ describe("exampleAppCards", () => {
     expect(cards.length).toBeGreaterThanOrEqual(3);
     for (const card of cards) {
       expect(card.application).toBeTruthy();
+      expect(card.exampleFixture).toBe(card.application);
       expect(card.source).toBe(EXAMPLE_SOURCE);
       expect(card.metrics.chats24h).not.toBeNull();
       expect(card.metrics.trendWindowSeconds).toBe(86_400);

--- a/apps/aomi-build/src/features/operate/fixtures/wire.ts
+++ b/apps/aomi-build/src/features/operate/fixtures/wire.ts
@@ -29,7 +29,12 @@ const CHARGE_SUBJECTS = new Set(["model", "hosting"]);
  * everything.
  */
 export function exampleStatement(source: object) {
-  const summary = { grossRevenue: 0, platformFees: 0, serviceCharges: 0, net: 0 };
+  const summary = {
+    grossRevenue: 0,
+    platformFees: 0,
+    serviceCharges: 0,
+    net: 0,
+  };
   for (const fixture of FIXTURES) {
     for (const row of fixture.statement.entries) {
       summary.net += row.net;
@@ -41,7 +46,7 @@ export function exampleStatement(source: object) {
       }
     }
   }
-  const withApp = <T,>(rows: T[], fixture: (typeof FIXTURES)[number]) =>
+  const withApp = <T>(rows: T[], fixture: (typeof FIXTURES)[number]) =>
     rows.map((row) => ({
       ...row,
       application: fixture.meta.name,
@@ -55,14 +60,26 @@ export function exampleStatement(source: object) {
     charges: FIXTURES.flatMap((f) => withApp(f.statement.charges, f)),
     entries: FIXTURES.flatMap((f) => withApp(f.statement.entries, f)).sort(
       (a, b) =>
-        b.day.localeCompare(a.day) || a.application.localeCompare(b.application),
+        b.day.localeCompare(a.day) ||
+        a.application.localeCompare(b.application),
     ),
   };
 }
 
-/** Full metrics block (live tiles + 24h trend) for the fixture at `index`. */
-export function exampleAppMetrics(index: number): Record<string, any> {
-  const fixture = FIXTURES[index % FIXTURES.length];
+function exampleFixture(application: unknown, index: number) {
+  const name = typeof application === "string" ? application : "";
+  return (
+    FIXTURES.find((fixture) => fixture.meta.name === name) ??
+    FIXTURES[index % FIXTURES.length]
+  );
+}
+
+/** Full metrics block (live tiles + 24h trend) for the matching fixture. */
+export function exampleAppMetrics(
+  index: number,
+  application?: unknown,
+): Record<string, any> {
+  const fixture = exampleFixture(application, index);
   return {
     provider: "grafana_prometheus",
     windowSeconds: 900,
@@ -83,7 +100,8 @@ export function exampleAppCards(source: object) {
     sdkVersion: fixture.meta.sdkVersion,
     status: fixture.meta.status,
     source,
-    metrics: exampleAppMetrics(index),
+    exampleFixture: fixture.meta.name,
+    metrics: exampleAppMetrics(index, fixture.meta.name),
   }));
 }
 
@@ -92,9 +110,14 @@ export function exampleAppCards(source: object) {
  * the backend actually reported wins; only null/missing fields are filled.
  * `filled` reports whether any card needed example data.
  */
-export function withExampleTrends<T extends { metrics?: Record<string, any> | null }>(
+export function withExampleTrends<
+  T extends {
+    application?: unknown;
+    metrics?: Record<string, any> | null;
+  },
+>(
   apps: T[],
-): { apps: T[]; filled: boolean } {
+): { apps: Array<T & { exampleFixture?: string }>; filled: boolean } {
   let filled = false;
   const out = apps.map((app, index) => {
     const metrics = app.metrics ?? {};
@@ -104,10 +127,15 @@ export function withExampleTrends<T extends { metrics?: Record<string, any> | nu
       metrics.transactions24h != null;
     if (hasTrend) return app;
     filled = true;
+    const fixture = exampleFixture(app.application, index);
     const real = Object.fromEntries(
       Object.entries(metrics).filter(([, value]) => value != null),
     );
-    return { ...app, metrics: { ...exampleAppMetrics(index), ...real } };
+    return {
+      ...app,
+      exampleFixture: fixture.meta.name,
+      metrics: { ...exampleAppMetrics(index, app.application), ...real },
+    };
   });
   return { apps: out, filled };
 }

--- a/apps/aomi-build/src/features/operate/operate-view.test.tsx
+++ b/apps/aomi-build/src/features/operate/operate-view.test.tsx
@@ -49,7 +49,8 @@ describe("OperateView transactions", () => {
           toAddress: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
           value: "1000000000000000000",
           description: "Swap USDC",
-          txHash: "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          txHash:
+            "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
           createdAt: 1_700_000_000,
         },
       ],
@@ -84,10 +85,9 @@ describe("OperateView transactions", () => {
     await waitFor(() => {
       expect(screen.getByText(/no transactions yet/i)).toBeInTheDocument();
     });
-    expect(screen.getByRole("link", { name: /open projects/i })).toHaveAttribute(
-      "href",
-      "/projects",
-    );
+    expect(
+      screen.getByRole("link", { name: /open projects/i }),
+    ).toHaveAttribute("href", "/projects");
   });
 
   it("renders 24h trend tiles and error split when the manager emits them", async () => {
@@ -140,7 +140,40 @@ describe("OperateView transactions", () => {
     expect(screen.getByText("12.0%")).toBeInTheDocument();
     expect(screen.getByText("Tx failures")).toBeInTheDocument();
     // Lifecycle footer.
-    expect(screen.getByText(/SDK 3\.0\.2 · cold start 1250 ms · 4\.5 MB/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/SDK 3\.0\.2 · cold start 1250 ms · 4\.5 MB/),
+    ).toBeInTheDocument();
+  });
+
+  it("links an example-filled app card to its fixture detail", async () => {
+    operateFetch.mockResolvedValue({
+      sources: [],
+      example: true,
+      monitoring: { status: "unconfigured", windowSeconds: 300 },
+      apps: [
+        {
+          applicationId: 2_937_099,
+          application: "playground-example",
+          exampleFixture: "goal-digger",
+          source: { id: 1586 },
+          status: "healthy",
+          metrics: { chats24h: 47 },
+        },
+      ],
+      dashboardLinks: [],
+      platformMetrics: [],
+    });
+
+    render(<OperateView kind="observability" />);
+
+    expect(
+      await screen.findByRole("link", {
+        name: "Open playground-example observability details",
+      }),
+    ).toHaveAttribute(
+      "href",
+      "/operate/observability/playground-example?fixture=goal-digger&project=1586",
+    );
   });
 
   it("falls back to the legacy live tiles when trend data is absent", async () => {
@@ -197,7 +230,8 @@ describe("OperateView transactions", () => {
           txFee: "0.000012 SOL",
           computeUnits: "41,022",
           computeLimit: "200,000",
-          revertReason: "custom program error 0x1771 — SlippageToleranceExceeded",
+          revertReason:
+            "custom program error 0x1771 — SlippageToleranceExceeded",
           createdAt: 1_700_000_000,
         },
       ],
@@ -254,7 +288,9 @@ describe("OperateView transactions", () => {
       expect(screen.getAllByText("swap_quote").length).toBeGreaterThan(0);
     });
     expect(screen.getByText("1840ms")).toBeInTheDocument();
-    expect(screen.getByText("Activated release r1dac12ad71")).toBeInTheDocument();
+    expect(
+      screen.getByText("Activated release r1dac12ad71"),
+    ).toBeInTheDocument();
     // Expand the invocation record.
     fireEvent.click(screen.getByText("SOL → USDC 2.5 · out 412.34"));
     expect(screen.getByText(/token_in/)).toBeInTheDocument();
@@ -331,7 +367,13 @@ describe("OperateView transactions", () => {
     operateFetch.mockResolvedValue({
       sources: [],
       daily: [
-        { periodUtcDay: "2026-07-15", application: "demo", inputTokens: 412000, outputTokens: 58400, creditsUsed: 3.4182 },
+        {
+          periodUtcDay: "2026-07-15",
+          application: "demo",
+          inputTokens: 412000,
+          outputTokens: 58400,
+          creditsUsed: 3.4182,
+        },
       ],
       breakdown: [],
       statement: null,

--- a/apps/aomi-build/src/features/operate/operate-view.tsx
+++ b/apps/aomi-build/src/features/operate/operate-view.tsx
@@ -30,7 +30,11 @@ import {
   unitLabel,
 } from "./format";
 import { TransactionRows } from "./tx-rows";
-import { EMPTY_LOGS_PAGE_FILTER, LogRows, type LogsPageFilter } from "./log-rows";
+import {
+  EMPTY_LOGS_PAGE_FILTER,
+  LogRows,
+  type LogsPageFilter,
+} from "./log-rows";
 import { UsageRows } from "./usage-rows";
 
 export { truncateAddress };
@@ -93,7 +97,9 @@ function EmptyState({
 }) {
   return (
     <div className="border-border bg-surface-subtle text-dim rounded-md border px-4 py-10 text-center text-sm">
-      <p className="text-foreground font-medium">No {title.toLowerCase()} yet</p>
+      <p className="text-foreground font-medium">
+        No {title.toLowerCase()} yet
+      </p>
       {description ? (
         <p className="mt-2 text-xs leading-5">{description}</p>
       ) : null}
@@ -109,6 +115,20 @@ function EmptyState({
   );
 }
 
+function mockedAppDetailHref(app: Record<string, any>): string | null {
+  const fixture =
+    typeof app.exampleFixture === "string" ? app.exampleFixture.trim() : "";
+  const application =
+    typeof app.application === "string" ? app.application.trim() : "";
+  if (!fixture || !application) return null;
+  const params = new URLSearchParams({ fixture });
+  const sourceId = Number(app.source?.id);
+  if (Number.isSafeInteger(sourceId) && sourceId > 0) {
+    params.set("project", String(sourceId));
+  }
+  return `/operate/observability/${encodeURIComponent(application)}?${params}`;
+}
+
 const STATUS_DOT: Record<string, string> = {
   healthy: "bg-emerald-500",
   not_loaded: "bg-amber-500",
@@ -120,8 +140,7 @@ function Sparkline({ points }: { points: number[] }) {
   const step = points.length > 1 ? 100 / (points.length - 1) : 100;
   const path = points
     .map(
-      (p, i) =>
-        `${(i * step).toFixed(1)},${(23 - (p / max) * 20).toFixed(1)}`,
+      (p, i) => `${(i * step).toFixed(1)},${(23 - (p / max) * 20).toFixed(1)}`,
     )
     .join(" ");
   return (
@@ -234,9 +253,7 @@ function Rows({
     const apps = [...new Set(rows.map((row) => String(row.application)))];
     const tools = [
       ...new Set(
-        rows
-          .filter((row) => row.tool != null)
-          .map((row) => String(row.tool)),
+        rows.filter((row) => row.tool != null).map((row) => String(row.tool)),
       ),
     ];
     return (
@@ -312,11 +329,9 @@ function Rows({
               : null,
             bytesLabel(metrics.dylibBytes),
           ].filter(Boolean);
-          return (
-            <div
-              key={`${app.source?.id}-${app.applicationId}`}
-              className="border-border bg-surface rounded-md border px-3 py-3"
-            >
+          const detailHref = mockedAppDetailHref(app);
+          const card = (
+            <>
               <div className="flex items-center justify-between gap-3">
                 <div className="min-w-0">
                   <div className="truncate text-sm font-medium">
@@ -403,6 +418,23 @@ function Rows({
                   {lifecycle.join(" · ")}
                 </div>
               ) : null}
+            </>
+          );
+          const key = `${app.source?.id}-${app.applicationId}`;
+          const className =
+            "border-border bg-surface rounded-md border px-3 py-3";
+          return detailHref ? (
+            <Link
+              key={key}
+              href={detailHref}
+              aria-label={`Open ${app.application} observability details`}
+              className={`${className} hover:bg-accent-hover focus-visible:ring-ring transition focus-visible:outline-none focus-visible:ring-1`}
+            >
+              {card}
+            </Link>
+          ) : (
+            <div key={key} className={className}>
+              {card}
             </div>
           );
         })}
@@ -493,8 +525,8 @@ export function OperateView({ kind }: { kind: ViewKind }) {
     () => (initialCacheKey ? operateCache.get(initialCacheKey) : null) ?? null,
   );
   const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(
-    () => (initialCacheKey ? !operateCache.has(initialCacheKey) : true),
+  const [loading, setLoading] = useState(() =>
+    initialCacheKey ? !operateCache.has(initialCacheKey) : true,
   );
   const [loadingMore, setLoadingMore] = useState(false);
   const Icon = meta[kind].icon;


### PR DESCRIPTION
## Summary
- make example-filled observability cards link to a real per-app detail route
- graduate the existing detail design from the dev harness into the product surface
- preserve source context across Back, Logs, and Transactions deep links
- align known apps with their matching fixture metrics instead of array order

## Verification
- `pnpm --filter aomi-build exec vitest run` (291 passed)
- `pnpm --filter aomi-build type-check`
- `pnpm --filter aomi-build lint` (existing warnings only)
- `pnpm --filter aomi-build build`
- Playwright: mocked card -> detail route -> Back to source-filtered observability