### PR TITLE
feat(build): durable run registry, system-owned sandbox lifetime, live-files sidecar on the official bearer path

### DIFF
--- a/apps/aomi-build/service.portal.production.toml
+++ b/apps/aomi-build/service.portal.production.toml
@@ -8,7 +8,7 @@
 name = "aomi-bff"
 kid = "aomi-bff-prod-1"
 issues = ["user", "service"]
-audiences = ["aomi-backend"]
+audiences = ["aomi-backend", "aomi-sidecar"]
 public_key = """
 -----BEGIN PUBLIC KEY-----
 MCowBQYDK2VwAyEAyaIwzD82igAdhA3xw9Tkr5yJEpaRU3SY73bVqjE7Ajc=

--- a/apps/aomi-build/service.portal.staging.toml
+++ b/apps/aomi-build/service.portal.staging.toml
@@ -8,7 +8,7 @@
 name = "aomi-bff"
 kid = "aomi-bff-staging-1"
 issues = ["user", "service"]
-audiences = ["aomi-backend"]
+audiences = ["aomi-backend", "aomi-sidecar"]
 public_key = """
 -----BEGIN PUBLIC KEY-----
 MCowBQYDK2VwAyEAgLSENuOGsWvaeM+7eU6BWSp9tY61HF7Ml4Vv/fxaupY=

--- a/apps/aomi-build/service.portal.toml
+++ b/apps/aomi-build/service.portal.toml
@@ -15,7 +15,7 @@
 name = "aomi-bff"           # the Aomi Build BFF — mints user + service bearers
 kid = "aomi-bff-dev-1"
 issues = ["user", "service"]
-audiences = ["aomi-backend"]
+audiences = ["aomi-backend", "aomi-sidecar"]
 public_key = """
 -----BEGIN PUBLIC KEY-----
 MCowBQYDK2VwAyEAcz9wTX8DsJmDChhmt02UIhv9LCceCsJBSlsBgJlExc4=

--- a/apps/aomi-build/src/app/api/bff/build/runs/file/route.ts
+++ b/apps/aomi-build/src/app/api/bff/build/runs/file/route.ts
@@ -1,0 +1,3 @@
+import { buildRunFileRoute } from "@build/server/bff/build/routes";
+
+export const GET = buildRunFileRoute;

--- a/apps/aomi-build/src/app/api/bff/build/supervise/route.ts
+++ b/apps/aomi-build/src/app/api/bff/build/supervise/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { superviseOnce } from "@build/server/bff/build/supervisor";
+
+export const runtime = "nodejs";
+
+/**
+ * Supervisor tick — wire a Vercel Cron to this route (every minute) in
+ * deployed envs; the dev server also ticks in-process. Guarded by
+ * CRON_SECRET (Vercel injects the Authorization header for cron calls).
+ */
+export async function GET(req: Request) {
+  const secret = process.env.CRON_SECRET;
+  const anonDev =
+    process.env.AOMI_BUILD_ALLOW_ANON === "1" &&
+    process.env.NODE_ENV !== "production";
+  if (!anonDev) {
+    if (!secret || req.headers.get("authorization") !== `Bearer ${secret}`) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 });
+    }
+  }
+  try {
+    const actions = await superviseOnce();
+    return NextResponse.json({ actions });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/aomi-build/src/features/build/build-view.tsx
+++ b/apps/aomi-build/src/features/build/build-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import * as FileDialog from "@radix-ui/react-dialog";
 import {
   Files,
   ListChecks,
@@ -108,6 +109,10 @@ function ContextPanelSection({
  */
 export function BuildView() {
   const [input, setInput] = useState("");
+  const [fileView, setFileView] = useState<{
+    path: string;
+    content: string;
+  } | null>(null);
   // SSR-safe false; restore preference after mount to avoid hydration mismatch.
   const [recentOpen, setRecentOpen] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -293,6 +298,39 @@ export function BuildView() {
       tone: "success",
     });
   }, [activeSessionId, engineRunId, fileTree, toast]);
+
+  /** Source viewer — engine runs only (mock files have no contents). */
+  const handleFileSelect = useCallback(
+    (path: string) => {
+      if (!engineRunId) return;
+      void (async () => {
+        try {
+          const res = await fetch(
+            `/api/bff/build/runs/file?id=${encodeURIComponent(engineRunId)}&path=${encodeURIComponent(path)}`,
+          );
+          if (!res.ok) {
+            const body = (await res.json().catch(() => ({}))) as {
+              error?: string;
+            };
+            toast({
+              title: "Could not open file",
+              description: body.error ?? `request failed (${res.status})`,
+              tone: "error",
+            });
+            return;
+          }
+          setFileView({ path, content: await res.text() });
+        } catch (error) {
+          toast({
+            title: "Could not open file",
+            description: error instanceof Error ? error.message : String(error),
+            tone: "error",
+          });
+        }
+      })();
+    },
+    [engineRunId, toast],
+  );
 
   const handleTemplateSelect = useCallback(
     (template: (typeof BUILD_TEMPLATES)[0]) => {
@@ -542,12 +580,37 @@ export function BuildView() {
               </ContextPanelSection>
 
               <ContextPanelSection title="Files" icon={Files}>
-                <FileTreePreview tree={fileTree} />
+                <FileTreePreview
+                  tree={fileTree}
+                  onFileSelect={
+                    BUILD_ENGINE_ACTIVE && engineRunId
+                      ? handleFileSelect
+                      : undefined
+                  }
+                />
               </ContextPanelSection>
             </aside>
           ) : null}
         </div>
       </section>
+      <FileDialog.Root
+        open={fileView !== null}
+        onOpenChange={(open) => {
+          if (!open) setFileView(null);
+        }}
+      >
+        <FileDialog.Portal>
+          <FileDialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
+          <FileDialog.Content className="border-border bg-background fixed top-1/2 left-1/2 z-50 max-h-[80vh] w-[min(760px,92vw)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-lg border shadow-lg">
+            <FileDialog.Title className="text-subtle border-border border-b px-4 py-2 font-mono text-[12px]">
+              {fileView?.path}
+            </FileDialog.Title>
+            <pre className="max-h-[70vh] overflow-auto px-4 py-3 text-[12px] leading-relaxed whitespace-pre">
+              {fileView?.content}
+            </pre>
+          </FileDialog.Content>
+        </FileDialog.Portal>
+      </FileDialog.Root>
     </div>
   );
 }

--- a/apps/aomi-build/src/features/build/components/file-tree-preview.tsx
+++ b/apps/aomi-build/src/features/build/components/file-tree-preview.tsx
@@ -9,23 +9,28 @@ import { cn } from "@build/lib/utils";
 function FileTreeNode({
   node,
   depth = 0,
+  onFileSelect,
 }: {
   node: BuildFileNode;
   depth?: number;
+  onFileSelect?: (path: string) => void;
 }) {
   const isFolder = node.type === "folder";
   const [open, setOpen] = useState(depth < 2);
   const name = node.path.split("/").pop() ?? node.path;
+  const clickable = isFolder || onFileSelect !== undefined;
 
   return (
     <div>
       <button
         type="button"
-        disabled={!isFolder}
-        onClick={() => isFolder && setOpen((v) => !v)}
+        disabled={!clickable}
+        onClick={() =>
+          isFolder ? setOpen((v) => !v) : onFileSelect?.(node.path)
+        }
         className={cn(
           "flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-left text-[12px] transition-colors",
-          isFolder ? "hover:bg-accent/40 cursor-pointer" : "cursor-default",
+          clickable ? "hover:bg-accent/40 cursor-pointer" : "cursor-default",
         )}
         style={{ paddingLeft: depth * 12 + 6 }}
         title={node.path}
@@ -55,7 +60,12 @@ function FileTreeNode({
       </button>
       {isFolder && open
         ? node.children?.map((child) => (
-            <FileTreeNode key={child.path} node={child} depth={depth + 1} />
+            <FileTreeNode
+              key={child.path}
+              node={child}
+              depth={depth + 1}
+              onFileSelect={onFileSelect}
+            />
           ))
         : null}
     </div>
@@ -65,9 +75,15 @@ function FileTreeNode({
 type FileTreePreviewProps = {
   tree: BuildFileNode[];
   className?: string;
+  /** When set, files become clickable (source viewer). */
+  onFileSelect?: (path: string) => void;
 };
 
-export function FileTreePreview({ tree, className }: FileTreePreviewProps) {
+export function FileTreePreview({
+  tree,
+  className,
+  onFileSelect,
+}: FileTreePreviewProps) {
   if (!tree.length) {
     return (
       <div className={cn("panel-inset p-4 text-center", className)}>
@@ -84,7 +100,7 @@ export function FileTreePreview({ tree, className }: FileTreePreviewProps) {
         Generated files
       </p>
       {tree.map((node) => (
-        <FileTreeNode key={node.path} node={node} />
+        <FileTreeNode key={node.path} node={node} onFileSelect={onFileSelect} />
       ))}
     </div>
   );

--- a/apps/aomi-build/src/features/build/contracts.ts
+++ b/apps/aomi-build/src/features/build/contracts.ts
@@ -69,6 +69,10 @@ export type BuildSession = {
   id: string;
   title: string;
   status: BuildSessionStatus;
+  /** Engine-mode linkage: the durable run behind this session. Lets a reload
+   *  reattach to a live run and keep Download working after settle. */
+  runId?: string;
+  app?: string;
   model: string;
   updatedAt: string;
   runtime: string;

--- a/apps/aomi-build/src/features/build/hooks/use-build-session.ts
+++ b/apps/aomi-build/src/features/build/hooks/use-build-session.ts
@@ -111,6 +111,95 @@ export function useBuildSession() {
     }
   }, []);
 
+  /** Fold a run snapshot into view state + the session draft. Stops the poll
+   *  loop and persists the session once the run settles. */
+  const applyRunSnapshot = useCallback(
+    (
+      snapshot: BuildRunSnapshot,
+      onAssistantReady?: (msg: BuildMessage) => void,
+    ) => {
+      const draft = sessionDraftRef.current;
+      if (!draft) return;
+      const nodes = nodesFromSnapshot(snapshot);
+      const streamEvents = streamEventsFromSnapshot(snapshot);
+      const flags = flagsFromSnapshot(snapshot);
+      const fileTree = snapshot.fileTree as BuildFileNode[];
+      setNodes(nodes);
+      setStreamEvents(streamEvents);
+      setFileTree(fileTree);
+      setCompileDone(flags.compileDone);
+      setTestDone(flags.testDone);
+      const active = streamEvents.find((e) => e.status === "active");
+      if (active) setStageId(STREAM_TO_JOURNEY[active.stage]);
+      draft.nodes = nodes;
+      draft.streamEvents = streamEvents;
+      draft.fileTree = fileTree;
+
+      const settled =
+        snapshot.status === "completed" || snapshot.status === "failed";
+      if (!settled) return;
+      if (pollRef.current !== null) {
+        window.clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+      setIsGenerating(false);
+      setShipReady(flags.shipReady);
+      if (flags.shipReady) setStageId("ship");
+      const assistantMsg: BuildMessage = {
+        id: `a_${Date.now()}`,
+        role: "assistant",
+        content: completionMessage(snapshot),
+        timestamp: nowTime(),
+        model: "Aomi",
+      };
+      setMessages((prev) => {
+        const next = [...prev, assistantMsg];
+        draft.messages = next;
+        return next;
+      });
+      onAssistantReady?.(assistantMsg);
+      savePersistedSession({
+        id: draft.id,
+        title: draft.title,
+        status: flags.failed ? "failed" : "healthy",
+        model: "Aomi",
+        updatedAt: "just now",
+        runtime: snapshot.app,
+        runId: snapshot.runId,
+        app: snapshot.app,
+        stageId: flags.shipReady ? "ship" : "generate",
+        messages: [...draft.messages],
+        streamEvents,
+        fileTree,
+        nodes,
+      });
+    },
+    [],
+  );
+
+  /** Start (or restart) the poll loop for a run; it stops itself on settle. */
+  const beginRunPolling = useCallback(
+    (runId: string, onAssistantReady?: (msg: BuildMessage) => void) => {
+      if (pollRef.current !== null) {
+        window.clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+      const poll = async () => {
+        const res = await fetch(
+          `/api/bff/build/runs?id=${encodeURIComponent(runId)}`,
+        );
+        if (!res.ok) return;
+        applyRunSnapshot(
+          (await res.json()) as BuildRunSnapshot,
+          onAssistantReady,
+        );
+      };
+      void poll();
+      pollRef.current = window.setInterval(() => void poll(), RUN_POLL_MS);
+    },
+    [applyRunSnapshot],
+  );
+
   const loadSession = useCallback(
     (sessionId: string) => {
       clearTimers();
@@ -144,7 +233,7 @@ export function useBuildSession() {
         });
       }
       setActiveSessionId(sessionId);
-      setEngineRunId(null);
+      setEngineRunId(clean.runId ?? null);
       setStageId(healthy ? "ship" : needsVerify ? "compile_test" : clean.stageId);
       setMessages(clean.messages);
       setStreamEvents(streamEvents);
@@ -166,8 +255,16 @@ export function useBuildSession() {
         fileTree: clean.fileTree,
         nodes: clean.nodes ?? [],
       };
+      // A reload mid-build reattaches to the live run instead of freezing on
+      // the last persisted frame.
+      if (ENGINE_MODE && clean.runId && clean.status === "running") {
+        setIsGenerating(true);
+        setShowStreamInThread(true);
+        setAwaitingVerify(false);
+        beginRunPolling(clean.runId);
+      }
     },
-    [clearTimers, persistedSessions],
+    [beginRunPolling, clearTimers, persistedSessions],
   );
 
   const startNewSession = useCallback(() => {
@@ -290,63 +387,6 @@ export function useBuildSession() {
         ]);
       };
 
-      const applySnapshot = (snapshot: BuildRunSnapshot) => {
-        const draft = sessionDraftRef.current;
-        const nodes = nodesFromSnapshot(snapshot);
-        const streamEvents = streamEventsFromSnapshot(snapshot);
-        const flags = flagsFromSnapshot(snapshot);
-        const fileTree = snapshot.fileTree as BuildFileNode[];
-        setNodes(nodes);
-        setStreamEvents(streamEvents);
-        setFileTree(fileTree);
-        setCompileDone(flags.compileDone);
-        setTestDone(flags.testDone);
-        const active = streamEvents.find((e) => e.status === "active");
-        if (active) setStageId(STREAM_TO_JOURNEY[active.stage]);
-        if (draft) {
-          draft.nodes = nodes;
-          draft.streamEvents = streamEvents;
-          draft.fileTree = fileTree;
-        }
-
-        const settled =
-          snapshot.status === "completed" || snapshot.status === "failed";
-        if (!settled) return;
-        if (pollRef.current !== null) {
-          window.clearInterval(pollRef.current);
-          pollRef.current = null;
-        }
-        setIsGenerating(false);
-        setShipReady(flags.shipReady);
-        if (flags.shipReady) setStageId("ship");
-        const assistantMsg: BuildMessage = {
-          id: `a_${Date.now()}`,
-          role: "assistant",
-          content: completionMessage(snapshot),
-          timestamp: nowTime(),
-          model: "Aomi",
-        };
-        setMessages((prev) => {
-          const next = [...prev, assistantMsg];
-          if (draft) draft.messages = next;
-          return next;
-        });
-        onAssistantReady(assistantMsg);
-        savePersistedSession({
-          id: sessionId,
-          title,
-          status: flags.failed ? "failed" : "healthy",
-          model: "Aomi",
-          updatedAt: "just now",
-          runtime: snapshot.app,
-          stageId: flags.shipReady ? "ship" : "generate",
-          messages: [...(draft?.messages ?? [userMsg])],
-          streamEvents,
-          fileTree,
-          nodes,
-        });
-      };
-
       void (async () => {
         try {
           const res = await fetch("/api/bff/build/runs", {
@@ -361,23 +401,31 @@ export function useBuildSession() {
             fail(body.error ?? `request failed (${res.status})`);
             return;
           }
-          const created = (await res.json()) as { runId: string };
+          const created = (await res.json()) as { runId: string; app: string };
           setEngineRunId(created.runId);
-          const poll = async () => {
-            const statusRes = await fetch(
-              `/api/bff/build/runs?id=${encodeURIComponent(created.runId)}`,
-            );
-            if (!statusRes.ok) return;
-            applySnapshot((await statusRes.json()) as BuildRunSnapshot);
-          };
-          await poll();
-          pollRef.current = window.setInterval(() => void poll(), RUN_POLL_MS);
+          // Persist immediately so a reload mid-build can reattach.
+          savePersistedSession({
+            id: sessionId,
+            title,
+            status: "running",
+            model: "Aomi",
+            updatedAt: "just now",
+            runtime: created.app,
+            runId: created.runId,
+            app: created.app,
+            stageId: "plan",
+            messages: [userMsg],
+            streamEvents: initial,
+            fileTree: [],
+            nodes: [],
+          });
+          beginRunPolling(created.runId, onAssistantReady);
         } catch (error) {
           fail(error instanceof Error ? error.message : String(error));
         }
       })();
     },
-    [clearTimers, recentSessions],
+    [beginRunPolling, clearTimers, recentSessions],
   );
 
   const runBuildPipeline = useCallback(

--- a/apps/aomi-build/src/features/build/run-contracts.ts
+++ b/apps/aomi-build/src/features/build/run-contracts.ts
@@ -81,6 +81,9 @@ export type CreateBuildRunRequest = {
   app?: string;
   /** Skip approval gates (defaults to true until the UI renders approvals). */
   autoApprove?: boolean;
+  /** Curation/repair agent; "none" runs the deterministic pipeline only
+   *  (codegen + cargo validate — no LLM). Defaults to "claude". */
+  builder?: "claude" | "codex" | "none";
 };
 
 export type CreateBuildRunResponse = {

--- a/apps/aomi-build/src/features/build/smither-run-mapper.test.ts
+++ b/apps/aomi-build/src/features/build/smither-run-mapper.test.ts
@@ -119,6 +119,19 @@ describe("flagsFromSnapshot", () => {
       flagsFromSnapshot(snapshot([stage("codegen", "failed")], "failed")),
     ).toMatchObject({ shipReady: false, failed: true, isGenerating: false });
   });
+
+  it("trusts the run status over stale failed stage rows", () => {
+    // A quota-retried or recomposed run can settle green while an old
+    // attempt's stage row still reads failed.
+    const flags = flagsFromSnapshot(
+      snapshot(
+        [stage("curate", "failed", "agent"), stage("result", "complete")],
+        "completed",
+      ),
+    );
+    expect(flags.failed).toBe(false);
+    expect(flags.shipReady).toBe(true);
+  });
 });
 
 describe("streamEventsFromSnapshot times", () => {

--- a/apps/aomi-build/src/features/build/smither-run-mapper.ts
+++ b/apps/aomi-build/src/features/build/smither-run-mapper.ts
@@ -127,10 +127,11 @@ export type RunViewFlags = {
 };
 
 export function flagsFromSnapshot(snapshot: BuildRunSnapshot): RunViewFlags {
-  const failed =
-    snapshot.status === "failed" ||
-    snapshot.stages.some((s) => s.status === "failed");
-  const done = snapshot.status === "completed" && !failed;
+  // The run-level status is authoritative: a stage row can stay "failed" from
+  // an earlier attempt (quota retry, repaired fix round, a resume that
+  // recomposed the plan) while the run itself settled green.
+  const failed = snapshot.status === "failed";
+  const done = snapshot.status === "completed";
   const validateStages = snapshot.stages.filter(
     (s) => laneFor(s) === "validate" && s.kind !== "parallel",
   );

--- a/apps/aomi-build/src/features/build/storage/build-session-storage.ts
+++ b/apps/aomi-build/src/features/build/storage/build-session-storage.ts
@@ -7,7 +7,10 @@ import {
   sessionsNeedSanitize,
 } from "@build/features/build/storage/sanitize-session-copy";
 
-const STORAGE_KEY = "aomi-build-sessions-v1";
+// v2: artifacts became Rust-crate shaped (P0) — v1 sessions carry the old
+// TypeScript-mock trees/copy and would resurface stale fiction on load.
+const STORAGE_KEY = "aomi-build-sessions-v2";
+const LEGACY_STORAGE_KEYS = ["aomi-build-sessions-v1"];
 const sessionListeners = new Set<() => void>();
 let didRewriteSanitized = false;
 
@@ -39,6 +42,13 @@ let sessionsCache: { raw: string | null; value: BuildSession[] } | null = null;
 
 export function loadPersistedSessions(): BuildSession[] {
   if (typeof window === "undefined") return emptySessions;
+  for (const key of LEGACY_STORAGE_KEYS) {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Best-effort cleanup; a blocked removal just leaves dead data behind.
+    }
+  }
   const raw = localStorage.getItem(STORAGE_KEY);
   if (sessionsCache && sessionsCache.raw === raw) return sessionsCache.value;
 

--- a/apps/aomi-build/src/server/bff/build/engine.ts
+++ b/apps/aomi-build/src/server/bff/build/engine.ts
@@ -1,8 +1,9 @@
 import "server-only";
 
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import {
+  crateFileTree,
   createAomiSmither,
   decideApproval,
   defaultSdkRoot,
@@ -21,16 +22,30 @@ import {
   type RunView,
 } from "@aomi-labs/smither";
 import {
+  artifactFromOutputs,
   curationFromOutputs,
   resultFromOutputs,
   runStatusFromView,
   stageStatusesFromView,
 } from "./run-view";
 import {
+  findRunById,
+  findRunByOwnerApp,
+  registerRun,
+  updateRun,
+  type BuildRunRecord,
+} from "./registry";
+import { ensureSupervisorInterval } from "./supervisor";
+import {
+  mintSidecarBearer,
+  sidecarVerifierPublicKeyPem,
+} from "./sidecar-auth";
+import {
   dispatchSandboxRun,
   maybeExtendSandbox,
   sandboxRunnerConfig,
   stopSandbox,
+  stopSandboxById,
   type SandboxDispatch,
 } from "./sandbox-runner";
 import type {
@@ -71,6 +86,8 @@ type EngineEvent = {
 type RunHandle = {
   runId: string;
   app: string;
+  /** GitHub login that owns this run ("dev" in anonymous local mode). */
+  owner: string;
   plan: BuildPlan;
   api: AomiSmitherApi;
   /** Present on handles this process executes; absent on observer handles
@@ -170,43 +187,6 @@ function nowStamp(): string {
   return new Date().toTimeString().slice(0, 8);
 }
 
-const TREE_SKIP = new Set(["target", "node_modules", ".git", "Cargo.lock"]);
-
-/** The generated crate as the page's file-tree shape. Paths are prefixed with
- *  the app name, matching the mock's convention ("<app>/src/tool.rs"). */
-function crateFileTree(appDir: string, app: string): BuildRunFileNode[] {
-  const walk = (dir: string, rel: string, depth: number): BuildRunFileNode[] => {
-    if (depth > 4) return [];
-    let entries;
-    try {
-      entries = readdirSync(dir, { withFileTypes: true });
-    } catch {
-      return [];
-    }
-    return entries
-      .filter((e) => !TREE_SKIP.has(e.name) && !e.name.startsWith("."))
-      .sort((a, b) =>
-        a.isDirectory() === b.isDirectory()
-          ? a.name.localeCompare(b.name)
-          : a.isDirectory()
-            ? -1
-            : 1,
-      )
-      .map((e) => {
-        const childRel = `${rel}/${e.name}`;
-        return e.isDirectory()
-          ? {
-              path: childRel,
-              type: "folder" as const,
-              children: walk(path.join(dir, e.name), childRel, depth + 1),
-            }
-          : { path: childRel, type: "file" as const };
-      });
-  };
-  if (!existsSync(appDir)) return [];
-  return [{ path: app, type: "folder", children: walk(appDir, app, 0) }];
-}
-
 /** Same folding as the TUI's reduceEvent: node events light plan stages,
  *  approval events maintain the pending-approval list. */
 function reduceEvent(handle: RunHandle, event: EngineEvent) {
@@ -300,7 +280,7 @@ function execute(handle: RunHandle, prepared: PreparedRun) {
   void executeRunUntilSettled(prepared, {
     onEvent: (event) => reduceEvent(handle, event as EngineEvent),
   })
-    .then((result) => {
+    .then(async (result) => {
       // Snapshot reads derive statuses/outputs from the durable store; here
       // we only keep the in-memory garnish coherent.
       const status = String(result.status);
@@ -322,11 +302,19 @@ function execute(handle: RunHandle, prepared: PreparedRun) {
         handle,
         `run settled: ${status}${handle.error ? ` — ${handle.error.slice(0, 400)}` : ""}`,
       );
+      if (handle.status === "completed" || handle.status === "failed") {
+        await updateRun(handle.api, handle.runId, {
+          status: handle.status,
+        }).catch(() => {});
+      }
     })
-    .catch((error: unknown) => {
+    .catch(async (error: unknown) => {
       handle.status = "failed";
       handle.error = error instanceof Error ? error.message : String(error);
       pushLine(handle, `run failed: ${handle.error}`);
+      await updateRun(handle.api, handle.runId, { status: "failed" }).catch(
+        () => {},
+      );
     });
 }
 
@@ -340,6 +328,7 @@ function composePlan(
   userStory: string,
   autoApprove = true,
   sdkRootOverride?: string,
+  builder: "claude" | "codex" | "none" = "claude",
 ): BuildPlan {
   const root = sdkRootOverride ?? sdkRoot();
   // An app that already carries a discovered/curated spec resumes idempotently
@@ -352,6 +341,7 @@ function composePlan(
     sdkRoot: root,
     source: hasSpec ? "existing" : "discover",
     userStory,
+    builder,
     // No web surface answers gates yet — run unattended by default. The
     // decision route exists, so callers can opt back in per run.
     autoApprove,
@@ -367,19 +357,34 @@ function composePlan(
 
 export async function startBuildRun(options: {
   prompt: string;
+  owner: string;
   app?: string;
   autoApprove?: boolean;
+  builder?: "claude" | "codex" | "none";
 }): Promise<RunHandle> {
   const app = options.app ?? appSlugFromPrompt(options.prompt);
-  const existing = registry().byApp.get(app);
-  // Reuse a live handle; a settled one gets a fresh execution (the durable
-  // backend replays completed work, so this is a resume, not a redo).
+  const api = await apiFor(app);
+  // Identity lives in the registry: (owner, app) → run. Alice's arb-bot and
+  // Bob's arb-bot are distinct rows, distinct runs, distinct sandboxes.
+  const record = await findRunByOwnerApp(api, options.owner, app);
+
+  const inMemory = record && registry().byRunId.get(record.runId);
   if (
-    existing &&
-    existing.status !== "completed" &&
-    existing.status !== "failed"
+    inMemory &&
+    inMemory.status !== "completed" &&
+    inMemory.status !== "failed"
   ) {
-    return existing;
+    return inMemory;
+  }
+  if (record?.status === "running") {
+    // Another instance (or a past life of this one) is executing. Trust the
+    // store: still live → observe, don't double-dispatch; dead → resume.
+    const view = await readRunView(api, record.runId).catch(() => undefined);
+    const live = view && runStatusFromView(view.status) === "running";
+    if (live) {
+      const observer = await observerHandle(record, api);
+      if (observer) return observer;
+    }
   }
 
   const now = new Date().toISOString();
@@ -394,21 +399,23 @@ export async function startBuildRun(options: {
       options.prompt,
       options.autoApprove ?? true,
       config.sdkRoot,
+      options.builder,
     );
     const runId =
-      existing?.runId ??
-      `smither-${sanitizeAppName(app)}-${crypto.randomUUID()}`;
+      record?.runId ?? `smither-${sanitizeAppName(app)}-${crypto.randomUUID()}`;
     const dispatch = await dispatchSandboxRun({
       planJson: JSON.stringify(plan),
       app,
       runId,
       config,
+      sidecarPublicKeyPem: sidecarVerifierPublicKeyPem(),
     });
     handle = {
       runId,
       app,
+      owner: options.owner,
       plan,
-      api: await apiFor(app),
+      api,
       dispatch,
       status: "running",
       stageStatus: {},
@@ -418,17 +425,36 @@ export async function startBuildRun(options: {
       createdAt: now,
       updatedAt: now,
     };
+    await registerRun(api, {
+      runId,
+      ownerLogin: options.owner,
+      app,
+      runner: "vercel-sandbox",
+      status: "running",
+      sandboxId: dispatch.sandbox.sandboxId,
+      sidecarUrl: dispatch.sidecarUrl ?? "",
+      planJson: JSON.stringify(plan),
+    });
+    // The system, not the page, owns sandbox lifetime from here.
+    ensureSupervisorInterval();
   } else {
-    const plan = composePlan(app, options.prompt, options.autoApprove ?? true);
+    const plan = composePlan(
+      app,
+      options.prompt,
+      options.autoApprove ?? true,
+      undefined,
+      options.builder,
+    );
     const prepared = await prepareRun({
       plan,
       deps: { env: process.env },
       runsRoot: runsRoot(),
-      api: await apiFor(app),
+      api,
     });
     handle = {
       runId: prepared.runId,
       app,
+      owner: options.owner,
       plan,
       api: prepared.api,
       prepared,
@@ -442,6 +468,16 @@ export async function startBuildRun(options: {
       createdAt: now,
       updatedAt: now,
     };
+    await registerRun(api, {
+      runId: prepared.runId,
+      ownerLogin: options.owner,
+      app,
+      runner: "local",
+      status: "running",
+      sandboxId: "",
+      sidecarUrl: "",
+      planJson: JSON.stringify(plan),
+    });
     execute(handle, prepared);
   }
 
@@ -460,35 +496,158 @@ export async function cancelBuildRun(runId: string): Promise<void> {
   }
   await requestRunCancel(handle.api, handle.runId);
   pushLine(handle, "cancel requested");
-  if (handle.dispatch) await stopSandbox(handle.dispatch);
+  // Registry status flips regardless of whether the engine ever observes the
+  // cancel (a dead sandbox can't), so the run never wedges as "running".
+  await updateRun(handle.api, handle.runId, { status: "cancelled" }).catch(
+    () => {},
+  );
+  if (handle.dispatch) {
+    await stopSandbox(handle.dispatch);
+  } else {
+    const record = await findRunById(handle.api, handle.runId).catch(
+      () => undefined,
+    );
+    if (record?.sandboxId) await stopSandboxById(record.sandboxId);
+  }
+  handle.status = "failed";
 }
 
 export function getBuildRun(runId: string): RunHandle | undefined {
   return registry().byRunId.get(runId);
 }
 
+/** The crate tarball persisted by the result phase, for runs whose crate
+ *  directory this process cannot see (sandbox runs). Null when the run has
+ *  no embedded artifact (not settled yet, packaging failed, or over-cap). */
+export async function storedCrateTarball(
+  handle: RunHandle,
+): Promise<Buffer | null> {
+  const view = await readRunView(handle.api, handle.runId);
+  const artifact = artifactFromOutputs(view.outputs ?? {});
+  if (!artifact || artifact.crateTarB64.length === 0) return null;
+  return Buffer.from(artifact.crateTarB64, "base64");
+}
+
+const MAX_SERVED_FILE_BYTES = 256 * 1024;
+
+/**
+ * One file of the generated crate, from the freshest available source:
+ * local disk (local runner) → live sidecar (sandbox mid-run) → the store's
+ * embedded tarball (after the sandbox is gone). Paths use the display shape
+ * ("<app>/src/tool.rs"). Null = not found anywhere.
+ */
+export async function readRunFile(
+  handle: RunHandle,
+  relPath: string,
+): Promise<Buffer | null> {
+  const prefix = `${handle.app}/`;
+  if (!relPath.startsWith(prefix)) return null;
+  // Local disk, path-jailed.
+  const appDir = path.join(handle.plan.sdkRoot, "apps", handle.app);
+  const resolved = path.resolve(appDir, relPath.slice(prefix.length));
+  if (
+    (resolved === appDir || resolved.startsWith(appDir + path.sep)) &&
+    existsSync(resolved)
+  ) {
+    const { readFileSync, statSync } = await import("node:fs");
+    const stats = statSync(resolved);
+    if (stats.isFile() && stats.size <= MAX_SERVED_FILE_BYTES) {
+      return readFileSync(resolved);
+    }
+  }
+  // Live sidecar.
+  const record = await findRunById(handle.api, handle.runId).catch(
+    () => undefined,
+  );
+  if (record?.sidecarUrl && record.status === "running") {
+    try {
+      // Official service-bearer path: fresh short-lived EdDSA bearer per
+      // request (sidecar-auth.ts) — no stored sidecar secret anywhere.
+      const bearer = await mintSidecarBearer(handle.runId);
+      const res = await fetch(
+        `https://${record.sidecarUrl.replace(/^https?:\/\//, "")}/file?path=${encodeURIComponent(relPath)}`,
+        {
+          headers: { authorization: `Bearer ${bearer}` },
+          signal: AbortSignal.timeout(4000),
+        },
+      );
+      if (res.ok) return Buffer.from(await res.arrayBuffer());
+    } catch {
+      // Sidecar unreachable — fall through to the store.
+    }
+  }
+  // Store artifact.
+  const tarball = await storedCrateTarball(handle).catch(() => null);
+  if (!tarball) return null;
+  const { extractFileFromTarGz } = await import("./tar");
+  return extractFileFromTarGz(tarball, relPath);
+}
+
 const RUN_ID = /^smither-(.+)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/** Exact plan from a registry row, falling back to recomposition for rows
+ *  written before plan_json existed. */
+function planFromRecord(record: BuildRunRecord): BuildPlan {
+  try {
+    const { plan } = finalizePlan(JSON.parse(record.planJson));
+    if (plan) return plan;
+  } catch {
+    // Fall through to recomposition.
+  }
+  return composePlan(record.app, "observed run");
+}
+
+/** Handle that observes a run without executing it (used for runs another
+ *  instance — or a past life of this one — is executing). */
+async function observerHandle(
+  record: BuildRunRecord,
+  api: AomiSmitherApi,
+): Promise<RunHandle | undefined> {
+  const view = await readRunView(api, record.runId).catch(() => undefined);
+  if (!view || view.status === null) return undefined;
+  const now = new Date().toISOString();
+  const handle: RunHandle = {
+    runId: record.runId,
+    app: record.app,
+    owner: record.ownerLogin,
+    plan: planFromRecord(record),
+    api,
+    status: runStatusFromView(view.status) ?? "running",
+    stageStatus: {},
+    stageTimes: {},
+    approvals: [],
+    lines: [`observing run ${record.runId}`],
+    createdAt: now,
+    updatedAt: now,
+  };
+  registry().byRunId.set(record.runId, handle);
+  return handle;
+}
 
 /**
  * Serve a run this process never executed (another instance started it, or a
- * restart dropped the registry): recompose the plan from the app name and
- * read everything else from the durable store. The handle observes; it does
- * not execute.
+ * restart dropped the in-memory maps): registry row first (exact plan and
+ * owner); the legacy run-id parse covers pre-registry runs. The handle
+ * observes; it does not execute.
  */
 export async function reconstructBuildRun(
   runId: string,
 ): Promise<RunHandle | undefined> {
+  // Registry rows are keyed by run id but the api connection is keyed by
+  // app, which we don't know yet — parse the id for the app either way.
   const app = RUN_ID.exec(runId)?.[1];
   if (!app || sanitizeAppName(app) !== app) return undefined;
-  let handle: RunHandle;
   try {
     const api = await apiFor(app);
+    const record = await findRunById(api, runId);
+    if (record) return observerHandle(record, api);
     const view = await readRunView(api, runId);
     if (view.status === null) return undefined;
     const now = new Date().toISOString();
-    handle = {
+    const handle: RunHandle = {
       runId,
       app,
+      owner: "unknown",
       plan: composePlan(app, "observed run"),
       api,
       status: runStatusFromView(view.status) ?? "running",
@@ -499,6 +658,8 @@ export async function reconstructBuildRun(
       createdAt: now,
       updatedAt: now,
     };
+    registry().byRunId.set(runId, handle);
+    return handle;
   } catch (error) {
     console.warn(
       `could not reconstruct run ${runId}:`,
@@ -506,8 +667,6 @@ export async function reconstructBuildRun(
     );
     return undefined;
   }
-  registry().byRunId.set(runId, handle);
-  return handle;
 }
 
 export async function decideBuildRun(options: {
@@ -578,13 +737,18 @@ export async function snapshotBuildRun(
     ...(stage.branchOf ? { branchOf: stage.branchOf } : {}),
     ...(stage.clarify ? { clarify: stage.clarify } : {}),
   }));
-  // The crate appears once codegen ran; a completed replay has it too.
+  // Files: prefer a live local walk (fresh mid-run on local runners); fall
+  // back to the artifact persisted by the result phase — the only source for
+  // sandbox runs, whose filesystem this process never sees.
   const codegenDone =
     stageStatus[`${handle.app}:codegen`] === "complete" ||
     status === "completed";
-  const fileTree = codegenDone
+  let fileTree = codegenDone
     ? crateFileTree(path.join(handle.plan.sdkRoot, "apps", handle.app), handle.app)
     : [];
+  if (fileTree.length === 0) {
+    fileTree = artifactFromOutputs(outputs)?.fileTree ?? [];
+  }
   return {
     runId: handle.runId,
     app: handle.app,

--- a/apps/aomi-build/src/server/bff/build/registry.ts
+++ b/apps/aomi-build/src/server/bff/build/registry.ts
@@ -144,9 +144,11 @@ export async function registerRun(
       record.app,
       record.runner,
       record.status,
-      record.sandboxId,
-      record.sidecarUrl,
-      record.planJson,
+      // NOT NULL columns: coerce runtime undefined (e.g. an SDK field
+      // going missing) to '' instead of failing the whole dispatch.
+      record.sandboxId ?? "",
+      record.sidecarUrl ?? "",
+      record.planJson ?? "",
       now,
       now,
     ],

--- a/apps/aomi-build/src/server/bff/build/registry.ts
+++ b/apps/aomi-build/src/server/bff/build/registry.ts
@@ -1,0 +1,184 @@
+import "server-only";
+
+import { storeQuery, type AomiSmitherApi } from "@aomi-labs/smither";
+
+/**
+ * Durable run registry, keyed by (owner, app): the identity layer the
+ * smithers store deliberately doesn't have. Alice's "arb-bot" and Bob's
+ * "arb-bot" are distinct rows pointing at distinct runs; a BFF restart looks
+ * runs up here instead of minting new ids; the supervisor reads sandbox ids
+ * from here to extend or reap.
+ *
+ * Lives in the same store as the run state (created idempotently on first
+ * use) — the embedded PGlite backend cannot be opened twice in one process,
+ * so all access rides the run api's connection via storeQuery.
+ */
+
+export type BuildRunRecord = {
+  runId: string;
+  ownerLogin: string;
+  app: string;
+  runner: "local" | "vercel-sandbox";
+  status: "running" | "completed" | "failed" | "cancelled";
+  sandboxId: string;
+  sidecarUrl: string;
+  planJson: string;
+  createdAtMs: number;
+  updatedAtMs: number;
+};
+
+const ENSURED = new WeakSet<object>();
+
+async function ensureRegistry(api: AomiSmitherApi): Promise<void> {
+  if (ENSURED.has(api as object)) return;
+  await storeQuery(
+    api,
+    `CREATE TABLE IF NOT EXISTS aomi_build_runs (
+       run_id TEXT PRIMARY KEY,
+       owner_login TEXT NOT NULL,
+       app TEXT NOT NULL,
+       runner TEXT NOT NULL,
+       status TEXT NOT NULL,
+       sandbox_id TEXT NOT NULL DEFAULT '',
+       sidecar_url TEXT NOT NULL DEFAULT '',
+       plan_json TEXT NOT NULL,
+       created_at_ms BIGINT NOT NULL,
+       updated_at_ms BIGINT NOT NULL
+     )`,
+  );
+  await storeQuery(
+    api,
+    `CREATE UNIQUE INDEX IF NOT EXISTS aomi_build_runs_owner_app
+       ON aomi_build_runs (owner_login, app)`,
+  );
+  ENSURED.add(api as object);
+}
+
+function toRecord(row: Record<string, unknown>): BuildRunRecord {
+  return {
+    runId: String(row.run_id),
+    ownerLogin: String(row.owner_login),
+    app: String(row.app),
+    runner: (row.runner === "vercel-sandbox" ? "vercel-sandbox" : "local"),
+    status: ["completed", "failed", "cancelled"].includes(String(row.status))
+      ? (String(row.status) as BuildRunRecord["status"])
+      : "running",
+    sandboxId: String(row.sandbox_id ?? ""),
+    sidecarUrl: String(row.sidecar_url ?? ""),
+    planJson: String(row.plan_json ?? ""),
+    createdAtMs: Number(row.created_at_ms ?? 0),
+    updatedAtMs: Number(row.updated_at_ms ?? 0),
+  };
+}
+
+export async function findRunByOwnerApp(
+  api: AomiSmitherApi,
+  ownerLogin: string,
+  app: string,
+): Promise<BuildRunRecord | undefined> {
+  await ensureRegistry(api);
+  const rows = await storeQuery(
+    api,
+    `SELECT * FROM aomi_build_runs WHERE owner_login = ? AND app = ? LIMIT 1`,
+    [ownerLogin, app],
+  );
+  return rows[0] ? toRecord(rows[0]) : undefined;
+}
+
+export async function findRunById(
+  api: AomiSmitherApi,
+  runId: string,
+): Promise<BuildRunRecord | undefined> {
+  await ensureRegistry(api);
+  const rows = await storeQuery(
+    api,
+    `SELECT * FROM aomi_build_runs WHERE run_id = ? LIMIT 1`,
+    [runId],
+  );
+  return rows[0] ? toRecord(rows[0]) : undefined;
+}
+
+export async function listRunningRuns(
+  api: AomiSmitherApi,
+): Promise<BuildRunRecord[]> {
+  await ensureRegistry(api);
+  const rows = await storeQuery(
+    api,
+    `SELECT * FROM aomi_build_runs WHERE status = 'running'`,
+  );
+  return rows.map(toRecord);
+}
+
+/** Insert or replace the (owner, app) slot with a run. One registry row per
+ *  (owner, app); re-registering the same run refreshes runner/plan fields. */
+export async function registerRun(
+  api: AomiSmitherApi,
+  record: Omit<BuildRunRecord, "createdAtMs" | "updatedAtMs">,
+): Promise<void> {
+  await ensureRegistry(api);
+  const now = Date.now();
+  // One row per (owner, app): a re-mint (fresh run id for the same slot)
+  // replaces the previous run rather than colliding on the unique index.
+  await storeQuery(
+    api,
+    `DELETE FROM aomi_build_runs
+      WHERE owner_login = ? AND app = ? AND run_id <> ?`,
+    [record.ownerLogin, record.app, record.runId],
+  );
+  await storeQuery(
+    api,
+    `INSERT INTO aomi_build_runs
+       (run_id, owner_login, app, runner, status, sandbox_id, sidecar_url,
+        plan_json, created_at_ms, updated_at_ms)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT (run_id) DO UPDATE SET
+       runner = excluded.runner,
+       status = excluded.status,
+       sandbox_id = excluded.sandbox_id,
+       sidecar_url = excluded.sidecar_url,
+       plan_json = excluded.plan_json,
+       updated_at_ms = excluded.updated_at_ms`,
+    [
+      record.runId,
+      record.ownerLogin,
+      record.app,
+      record.runner,
+      record.status,
+      record.sandboxId,
+      record.sidecarUrl,
+      record.planJson,
+      now,
+      now,
+    ],
+  );
+}
+
+export async function updateRun(
+  api: AomiSmitherApi,
+  runId: string,
+  patch: Partial<
+    Pick<BuildRunRecord, "status" | "sandboxId" | "sidecarUrl">
+  >,
+): Promise<void> {
+  await ensureRegistry(api);
+  const sets: string[] = ["updated_at_ms = ?"];
+  const params: unknown[] = [Date.now()];
+  if (patch.status !== undefined) {
+    sets.push("status = ?");
+    params.push(patch.status);
+  }
+  if (patch.sandboxId !== undefined) {
+    sets.push("sandbox_id = ?");
+    params.push(patch.sandboxId);
+  }
+  if (patch.sidecarUrl !== undefined) {
+    sets.push("sidecar_url = ?");
+    params.push(patch.sidecarUrl);
+  }
+  params.push(runId);
+  await storeQuery(
+    api,
+    `UPDATE aomi_build_runs SET ${sets.join(", ")} WHERE run_id = ?`,
+    params,
+  );
+}

--- a/apps/aomi-build/src/server/bff/build/routes.ts
+++ b/apps/aomi-build/src/server/bff/build/routes.ts
@@ -17,9 +17,11 @@ import {
   cancelBuildRun,
   decideBuildRun,
   getBuildRun,
+  readRunFile,
   reconstructBuildRun,
   snapshotBuildRun,
   startBuildRun,
+  storedCrateTarball,
 } from "./engine";
 
 function rateLimited(req: Request): NextResponse | null {
@@ -52,6 +54,13 @@ async function requireSession(): Promise<NextResponse | null> {
     { error: "not signed in with GitHub" },
     { status: 401 },
   );
+}
+
+/** Run owner for registry namespacing — the GitHub login, or "dev" in the
+ *  anonymous local-testing mode. */
+async function sessionOwner(): Promise<string> {
+  const session = await getGitHubSession();
+  return session?.githubLogin || "dev";
 }
 
 function errorResponse(error: unknown): NextResponse {
@@ -89,12 +98,23 @@ export async function createBuildRunRoute(req: Request): Promise<NextResponse> {
       { status: 400 },
     );
   }
+  if (
+    body.builder !== undefined &&
+    !["claude", "codex", "none"].includes(body.builder)
+  ) {
+    return NextResponse.json(
+      { error: "builder must be claude, codex, or none" },
+      { status: 400 },
+    );
+  }
 
   try {
     const handle = await startBuildRun({
       prompt,
+      owner: await sessionOwner(),
       app: body.app,
       autoApprove: body.autoApprove,
+      builder: body.builder,
     });
     const snapshot = await snapshotBuildRun(handle);
     return NextResponse.json({
@@ -170,6 +190,21 @@ export async function buildRunDownloadRoute(
   }
   const appsDir = path.join(handle.plan.sdkRoot, "apps");
   if (!existsSync(path.join(appsDir, handle.app))) {
+    // No local crate (sandbox runs — the crate lives in the sandbox's
+    // filesystem): serve the artifact the result phase embedded in the store.
+    try {
+      const stored = await storedCrateTarball(handle);
+      if (stored) {
+        return new Response(new Uint8Array(stored), {
+          headers: {
+            "Content-Type": "application/gzip",
+            "Content-Disposition": `attachment; filename="${handle.app}.tar.gz"`,
+          },
+        });
+      }
+    } catch (error) {
+      console.error("stored crate read failed:", error);
+    }
     return NextResponse.json(
       { error: "no generated crate yet — run the build first" },
       { status: 409 },
@@ -193,6 +228,39 @@ export async function buildRunDownloadRoute(
       "Content-Disposition": `attachment; filename="${handle.app}.tar.gz"`,
     },
   });
+}
+
+/** One generated-crate file (display path "<app>/src/tool.rs") — live disk,
+ *  live sidecar, or the store's embedded tarball, whichever is freshest. */
+export async function buildRunFileRoute(
+  req: Request,
+): Promise<NextResponse | Response> {
+  const limited = rateLimited(req);
+  if (limited) return limited;
+  const denied = await requireSession();
+  if (denied) return denied;
+
+  const url = new URL(req.url);
+  const runId = url.searchParams.get("id");
+  const filePath = url.searchParams.get("path");
+  if (!runId || !filePath) {
+    return NextResponse.json({ error: "missing id or path" }, { status: 400 });
+  }
+  const handle = getBuildRun(runId) ?? (await reconstructBuildRun(runId));
+  if (!handle) {
+    return NextResponse.json({ error: "unknown run" }, { status: 404 });
+  }
+  try {
+    const body = await readRunFile(handle, filePath);
+    if (!body) {
+      return NextResponse.json({ error: "file not found" }, { status: 404 });
+    }
+    return new Response(new Uint8Array(body), {
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
 }
 
 export async function buildRunDecisionRoute(

--- a/apps/aomi-build/src/server/bff/build/run-view.test.ts
+++ b/apps/aomi-build/src/server/bff/build/run-view.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  artifactFromOutputs,
   curationFromOutputs,
   runStatusFromView,
   stageStatusesFromView,
@@ -89,5 +90,34 @@ describe("curationFromOutputs", () => {
       }),
     ).toEqual({ summary: "did things", changedFiles: "", followUps: "next" });
     expect(curationFromOutputs({})).toBeUndefined();
+  });
+});
+
+describe("artifactFromOutputs", () => {
+  const tree = [{ path: "app", type: "folder", children: [] }];
+
+  it("parses the embedded tree and tarball", () => {
+    expect(
+      artifactFromOutputs({
+        result: [
+          {
+            summary: "done",
+            fileTreeJson: JSON.stringify(tree),
+            crateTarB64: "dGFy",
+            artifactWarning: "",
+          },
+        ],
+      }),
+    ).toEqual({ fileTree: tree, crateTarB64: "dGFy", warning: "" });
+  });
+
+  it("degrades malformed tree JSON to empty and absent artifacts to undefined", () => {
+    expect(
+      artifactFromOutputs({
+        result: [{ summary: "done", fileTreeJson: "{oops", crateTarB64: "dGFy" }],
+      }),
+    ).toEqual({ fileTree: [], crateTarB64: "dGFy", warning: "" });
+    expect(artifactFromOutputs({ result: [{ summary: "done" }] })).toBeUndefined();
+    expect(artifactFromOutputs({})).toBeUndefined();
   });
 });

--- a/apps/aomi-build/src/server/bff/build/run-view.ts
+++ b/apps/aomi-build/src/server/bff/build/run-view.ts
@@ -5,6 +5,7 @@
  */
 
 import type {
+  BuildRunFileNode,
   BuildRunStageStatus,
   BuildRunStatus,
 } from "@build/features/build/run-contracts";
@@ -118,4 +119,30 @@ export function resultFromOutputs(
   const row = outputs.result?.[0];
   if (!row || typeof row.summary !== "string") return undefined;
   return { status: String(row.status ?? "complete"), summary: row.summary };
+}
+
+/** Crate artifact persisted by the result phase — the Files/Download source
+ *  for runs whose filesystem this process cannot see (sandbox runs). */
+export function artifactFromOutputs(
+  outputs: Record<string, ReadonlyArray<Record<string, unknown>>>,
+): { fileTree: BuildRunFileNode[]; crateTarB64: string; warning: string } | undefined {
+  const row = outputs.result?.[0];
+  if (!row) return undefined;
+  let fileTree: BuildRunFileNode[] = [];
+  if (typeof row.fileTreeJson === "string" && row.fileTreeJson.length > 0) {
+    try {
+      const parsed = JSON.parse(row.fileTreeJson);
+      if (Array.isArray(parsed)) fileTree = parsed as BuildRunFileNode[];
+    } catch {
+      // Malformed tree JSON degrades to an empty Files panel, not an error.
+    }
+  }
+  const crateTarB64 =
+    typeof row.crateTarB64 === "string" ? row.crateTarB64 : "";
+  if (fileTree.length === 0 && crateTarB64.length === 0) return undefined;
+  return {
+    fileTree,
+    crateTarB64,
+    warning: String(row.artifactWarning ?? ""),
+  };
 }

--- a/apps/aomi-build/src/server/bff/build/sandbox-runner.test.ts
+++ b/apps/aomi-build/src/server/bff/build/sandbox-runner.test.ts
@@ -35,7 +35,10 @@ const CONFIG = {
   databaseUrl: "postgresql://x",
   sdkRoot: "/workspace/aomi-sdk",
   smitherDir: "/workspace/aomi/packages/smither",
+  sidecarPath: "/workspace/sidecar.ts",
   builderApiKey: "sk-test",
+  openrouterApiKey: "sk-or-test",
+  openrouterModel: "moonshotai/kimi-k2.7-code",
 };
 
 describe("sandboxRunnerConfig", () => {
@@ -68,6 +71,7 @@ describe("dispatchSandboxRun", () => {
       runId: "smither-my-app-0000",
       config: CONFIG,
       client,
+      sidecarPublicKeyPem: "-----BEGIN PUBLIC KEY-----\nAAAA\n-----END PUBLIC KEY-----",
     });
 
     expect(created[0]).toMatchObject({
@@ -77,9 +81,24 @@ describe("dispatchSandboxRun", () => {
         SMITHER_DATABASE_URL: "postgresql://x",
         AOMI_ALLOW_STALE_SDK: "1",
         SMITHER_ANTHROPIC_API_KEY: "sk-test",
+        SMITHER_OPENROUTER_API_KEY: "sk-or-test",
+        SMITHER_OPENROUTER_MODEL: "moonshotai/kimi-k2.7-code",
       },
     });
-    const cmd = calls.runCommand[0] as {
+    // The sidecar's verification anchor rides the env — public key + run id,
+    // never a secret; bearers are minted per request by the BFF.
+    const createdEnv = (created[0] as { env: Record<string, string> }).env;
+    expect(createdEnv.AOMI_SIDECAR_PUBKEY).toContain("BEGIN PUBLIC KEY");
+    expect(createdEnv.AOMI_SIDECAR_RUN_ID).toBe("smither-my-app-0000");
+    expect(createdEnv.AOMI_SIDECAR_TOKEN).toBeUndefined();
+    expect(createdEnv.AOMI_SIDECAR_APP).toBe("my-app");
+    expect((created[0] as { ports?: number[] }).ports).toEqual([8722]);
+
+    // First command boots the live-files sidecar, second the runner.
+    const sidecar = calls.runCommand[0] as { cmd: string; args: string[] };
+    expect(sidecar.cmd).toBe("bun");
+    expect(sidecar.args[0]).toContain("sidecar");
+    const cmd = calls.runCommand[1] as {
       cmd: string;
       args: string[];
       cwd: string;

--- a/apps/aomi-build/src/server/bff/build/sandbox-runner.ts
+++ b/apps/aomi-build/src/server/bff/build/sandbox-runner.ts
@@ -33,6 +33,8 @@ export type SandboxLike = {
   }): Promise<unknown>;
   extendTimeout(durationMs: number): Promise<unknown>;
   stop(): Promise<unknown>;
+  /** Public URL for an exposed port (SDK: sandbox.domain(port)). */
+  domain?(port: number): string;
 };
 
 export type SandboxClientLike = {
@@ -40,6 +42,7 @@ export type SandboxClientLike = {
     image: string;
     timeout: number;
     resources: { vcpus: number };
+    ports?: number[];
     env: Record<string, string>;
     tags: Record<string, string>;
   }): Promise<SandboxLike>;
@@ -53,11 +56,18 @@ export type SandboxRunnerConfig = {
   sdkRoot: string;
   /** packages/smither dir inside the image (where dist/cli.js lives). */
   smitherDir: string;
+  /** Live-files sidecar script inside the image. */
+  sidecarPath: string;
   builderApiKey?: string;
+  openrouterApiKey?: string;
+  openrouterModel?: string;
 };
 
 /** Create-time ceiling per Vercel; extensions carry the sandbox beyond it. */
 const CREATE_TIMEOUT_MS = 5 * 60_000;
+
+/** Exposed port for the live-files sidecar inside the runner image. */
+const SIDECAR_PORT = 8722;
 const EXTEND_STEP_MS = 10 * 60_000;
 const EXTEND_MIN_INTERVAL_MS = 2 * 60_000;
 
@@ -78,7 +88,10 @@ export function sandboxRunnerConfig(
     databaseUrl,
     sdkRoot: env.AOMI_SANDBOX_SDK_ROOT ?? "/workspace/aomi-sdk",
     smitherDir: env.AOMI_SANDBOX_SMITHER_DIR ?? "/workspace/aomi/packages/smither",
+    sidecarPath: env.AOMI_SANDBOX_SIDECAR ?? "/workspace/sidecar.ts",
     builderApiKey: env.SMITHER_ANTHROPIC_API_KEY,
+    openrouterApiKey: env.SMITHER_OPENROUTER_API_KEY,
+    openrouterModel: env.SMITHER_OPENROUTER_MODEL,
   };
 }
 
@@ -95,6 +108,7 @@ async function defaultClient(): Promise<SandboxClientLike> {
 export type SandboxDispatch = {
   sandbox: SandboxLike;
   lastExtendMs: number;
+  sidecarUrl?: string;
 };
 
 /** Boot a sandbox and launch the headless runner for (plan, runId). */
@@ -104,6 +118,10 @@ export async function dispatchSandboxRun(options: {
   runId: string;
   config: SandboxRunnerConfig;
   client?: SandboxClientLike;
+  /** aomi-bff's SPKI public key: the sidecar's bearer-verification anchor
+   *  (official service-bearer path — see sidecar-auth.ts). Public material,
+   *  so safe in the VM env; empty = the sidecar fails closed. */
+  sidecarPublicKeyPem?: string;
 }): Promise<SandboxDispatch> {
   const { config } = options;
   const client = options.client ?? (await defaultClient());
@@ -111,9 +129,17 @@ export async function dispatchSandboxRun(options: {
     image: config.image,
     timeout: CREATE_TIMEOUT_MS,
     resources: { vcpus: config.vcpus },
+    ports: [SIDECAR_PORT],
     env: {
       SMITHER_DATABASE_URL: config.databaseUrl,
       AOMI_ALLOW_STALE_SDK: "1",
+      // The exposed sidecar port is public; requests carry service bearers
+      // the BFF mints per request (PORTAL_SERVICE_PRIVATE_KEY), which the
+      // sidecar verifies against this public key + run id.
+      AOMI_SIDECAR_PUBKEY: options.sidecarPublicKeyPem ?? "",
+      AOMI_SIDECAR_RUN_ID: options.runId,
+      AOMI_SIDECAR_PORT: String(SIDECAR_PORT),
+      AOMI_SIDECAR_APP: options.app,
       // The image runs as root and the claude CLI refuses its
       // skip-permissions flags under root unless it knows it's inside a
       // sandbox. The microVM is exactly that.
@@ -121,8 +147,24 @@ export async function dispatchSandboxRun(options: {
       ...(config.builderApiKey
         ? { SMITHER_ANTHROPIC_API_KEY: config.builderApiKey }
         : {}),
+      // OpenRouter wins inside the workflow when present (resolveAgentBilling);
+      // the Anthropic key rides along as the env-only rollback path.
+      ...(config.openrouterApiKey
+        ? { SMITHER_OPENROUTER_API_KEY: config.openrouterApiKey }
+        : {}),
+      ...(config.openrouterModel
+        ? { SMITHER_OPENROUTER_MODEL: config.openrouterModel }
+        : {}),
     },
     tags: { app: options.app.slice(0, 64) },
+  });
+  // Live-files sidecar first (serves apps/<app> while the run works), then
+  // the runner. Older images without the sidecar script just log an error
+  // for the first command; the run itself is unaffected.
+  await sandbox.runCommand({
+    cmd: "bun",
+    args: [config.sidecarPath, config.sdkRoot],
+    detached: true,
   });
   await sandbox.runCommand({
     cmd: "bun",
@@ -137,7 +179,13 @@ export async function dispatchSandboxRun(options: {
     cwd: config.smitherDir,
     detached: true,
   });
-  return { sandbox, lastExtendMs: Date.now() };
+  let sidecarUrl = "";
+  try {
+    sidecarUrl = sandbox.domain?.(SIDECAR_PORT) ?? "";
+  } catch {
+    sidecarUrl = "";
+  }
+  return { sandbox, lastExtendMs: Date.now(), sidecarUrl };
 }
 
 /** Lazily extend the sandbox from the poll path while the run is live. */
@@ -161,5 +209,44 @@ export async function stopSandbox(dispatch: SandboxDispatch): Promise<void> {
     await dispatch.sandbox.stop();
   } catch {
     // Best-effort: durable cancel already reached the store.
+  }
+}
+
+/** By-id sandbox handle for processes that never held the dispatch (the
+ *  supervisor, cancel-after-restart). */
+async function getSandboxById(sandboxId: string): Promise<SandboxLike | null> {
+  try {
+    const { Sandbox } = await import("@vercel/sandbox");
+    const get = (
+      Sandbox as unknown as {
+        get(params: { sandboxId: string }): Promise<SandboxLike>;
+      }
+    ).get;
+    return await get.call(Sandbox, { sandboxId });
+  } catch {
+    return null;
+  }
+}
+
+export async function stopSandboxById(sandboxId: string): Promise<void> {
+  const sandbox = await getSandboxById(sandboxId);
+  if (!sandbox) return;
+  try {
+    await sandbox.stop();
+  } catch {
+    // Already stopped/expired — the goal state.
+  }
+}
+
+/** Supervisor-side keepalive: extend a running sandbox by id. Returns false
+ *  when the sandbox is unreachable (stopped, expired, or never healthy). */
+export async function extendSandboxById(sandboxId: string): Promise<boolean> {
+  const sandbox = await getSandboxById(sandboxId);
+  if (!sandbox) return false;
+  try {
+    await sandbox.extendTimeout(EXTEND_STEP_MS);
+    return true;
+  } catch {
+    return false;
   }
 }

--- a/apps/aomi-build/src/server/bff/build/sandbox-runner.ts
+++ b/apps/aomi-build/src/server/bff/build/sandbox-runner.ts
@@ -95,13 +95,37 @@ export function sandboxRunnerConfig(
   };
 }
 
+/** The SDK surface we consume. Sandboxes are identified by `name` — the
+ *  Sandbox class has no `sandboxId`/`id` getter, and `Sandbox.get` takes
+ *  `{name}` — so the adapter maps `name` onto SandboxLike.sandboxId. */
+type SdkSandbox = {
+  name: string;
+  runCommand(params: unknown): Promise<unknown>;
+  extendTimeout(durationMs: number): Promise<unknown>;
+  stop(): Promise<unknown>;
+  domain(port: number): string;
+};
+
+function adaptSdkSandbox(sandbox: SdkSandbox): SandboxLike {
+  return {
+    sandboxId: sandbox.name,
+    runCommand: (params) =>
+      sandbox.runCommand(params) as Promise<unknown>,
+    extendTimeout: (durationMs) => sandbox.extendTimeout(durationMs),
+    stop: () => sandbox.stop(),
+    domain: (port) => sandbox.domain(port),
+  };
+}
+
 async function defaultClient(): Promise<SandboxClientLike> {
   const { Sandbox } = await import("@vercel/sandbox");
-  // The SDK's Sandbox is a superset of SandboxLike; the seam keeps tests
-  // SDK-free, so narrow through unknown.
   return {
-    create: (params) =>
-      Sandbox.create(params) as unknown as Promise<SandboxLike>,
+    create: async (params) =>
+      adaptSdkSandbox(
+        (await Sandbox.create(
+          params as never,
+        )) as unknown as SdkSandbox,
+      ),
   };
 }
 
@@ -219,10 +243,13 @@ async function getSandboxById(sandboxId: string): Promise<SandboxLike | null> {
     const { Sandbox } = await import("@vercel/sandbox");
     const get = (
       Sandbox as unknown as {
-        get(params: { sandboxId: string }): Promise<SandboxLike>;
+        get(params: { name: string; resume: boolean }): Promise<SdkSandbox>;
       }
     ).get;
-    return await get.call(Sandbox, { sandboxId });
+    // resume:false — never resurrect a lapsed sandbox just to manage it.
+    return adaptSdkSandbox(
+      await get.call(Sandbox, { name: sandboxId, resume: false }),
+    );
   } catch {
     return null;
   }

--- a/apps/aomi-build/src/server/bff/build/sidecar-auth.test.ts
+++ b/apps/aomi-build/src/server/bff/build/sidecar-auth.test.ts
@@ -1,0 +1,84 @@
+import { generateKeyPairSync, sign as edSign } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import { verifyBearer } from "../../../../../../infra/build-runner/sidecar";
+
+/**
+ * Round-trips the official service-bearer convention against the in-VM
+ * verifier: sign an EdDSA JWT exactly the way `AomiService.mint` does
+ * (jose `SignJWT`, alg EdDSA over `header.payload`) and check the sidecar's
+ * dependency-free WebCrypto verification accepts it — and rejects every
+ * tampered variant.
+ */
+
+const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+const otherKeys = generateKeyPairSync("ed25519");
+const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
+
+const RUN_ID = "smither-my-app-0db9a0f6-0000-0000-0000-000000000000";
+
+const b64url = (data: Buffer | string) =>
+  Buffer.from(data).toString("base64url");
+
+function mintJwt(
+  claims: Record<string, unknown>,
+  key: typeof privateKey = privateKey,
+): string {
+  const header = b64url(JSON.stringify({ alg: "EdDSA", kid: "aomi-bff-dev-1" }));
+  const payload = b64url(JSON.stringify(claims));
+  const signature = edSign(null, Buffer.from(`${header}.${payload}`), key);
+  return `${header}.${payload}.${b64url(signature)}`;
+}
+
+function claims(overrides: Record<string, unknown> = {}) {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    role: "service",
+    sub: RUN_ID,
+    iss: "aomi-bff",
+    aud: "aomi-sidecar",
+    iat: now,
+    exp: now + 300,
+    ...overrides,
+  };
+}
+
+const expected = { publicKeyPem, runId: RUN_ID };
+
+describe("verifyBearer", () => {
+  it("accepts a well-formed bearer for this run", async () => {
+    const jwt = mintJwt(claims());
+    expect(await verifyBearer(`Bearer ${jwt}`, expected)).toBe(true);
+  });
+
+  it("rejects wrong audience, issuer, subject, and expiry", async () => {
+    for (const bad of [
+      claims({ aud: "aomi-backend" }),
+      claims({ iss: "aomi-admin" }),
+      claims({ sub: "smither-other-run" }),
+      claims({ exp: Math.floor(Date.now() / 1000) - 10 }),
+    ]) {
+      expect(await verifyBearer(`Bearer ${mintJwt(bad)}`, expected)).toBe(false);
+    }
+  });
+
+  it("rejects signatures from a different key", async () => {
+    const jwt = mintJwt(claims(), otherKeys.privateKey);
+    expect(await verifyBearer(`Bearer ${jwt}`, expected)).toBe(false);
+  });
+
+  it("rejects tampered payloads", async () => {
+    const [h, , s] = mintJwt(claims()).split(".");
+    const forged = `${h}.${b64url(JSON.stringify(claims({ sub: RUN_ID })))}x.${s}`;
+    expect(await verifyBearer(`Bearer ${forged}`, expected)).toBe(false);
+  });
+
+  it("fails closed on missing config or malformed headers", async () => {
+    const jwt = mintJwt(claims());
+    expect(await verifyBearer(`Bearer ${jwt}`, { publicKeyPem: "", runId: RUN_ID })).toBe(false);
+    expect(await verifyBearer(`Bearer ${jwt}`, { publicKeyPem, runId: "" })).toBe(false);
+    expect(await verifyBearer(null, expected)).toBe(false);
+    expect(await verifyBearer("Bearer not.a.jwt", expected)).toBe(false);
+    expect(await verifyBearer(jwt, expected)).toBe(false);
+  });
+});

--- a/apps/aomi-build/src/server/bff/build/sidecar-auth.ts
+++ b/apps/aomi-build/src/server/bff/build/sidecar-auth.ts
@@ -1,0 +1,45 @@
+import "server-only";
+
+import { portalService } from "@aomi-labs/account";
+
+/**
+ * Sidecar auth rides the official service-bearer path (the same
+ * PORTAL_SERVICE_PRIVATE_KEY + committed-topology signing that backend
+ * bearers use — packages/account): the BFF mints a short-lived EdDSA JWT per
+ * proxied request, and the in-VM sidecar verifies it against aomi-bff's
+ * committed *public* key, which is safe to ship into a sandbox that runs
+ * agent-generated code. No shared secret is stored anywhere — not in the
+ * registry, not in the VM env.
+ *
+ * The audience is "aomi-sidecar", never "aomi-backend", so a bearer that
+ * leaks out of the VM is useless against the backend (its verifier rejects
+ * the audience); `sub` pins the bearer to one run id, which the sidecar
+ * checks against its own AOMI_SIDECAR_RUN_ID.
+ */
+export const SIDECAR_AUDIENCE = "aomi-sidecar";
+
+const SIDECAR_BEARER_TTL_SECONDS = 5 * 60;
+
+/** Fresh bearer for one run's sidecar — minted per request, never stored. */
+export async function mintSidecarBearer(runId: string): Promise<string> {
+  const { accessToken } = await portalService().mint({
+    role: "service",
+    subject: runId,
+    audience: SIDECAR_AUDIENCE,
+    ttlSeconds: SIDECAR_BEARER_TTL_SECONDS,
+  });
+  return accessToken;
+}
+
+/**
+ * aomi-bff's committed SPKI public key — the sidecar's verification anchor,
+ * passed into the sandbox env at dispatch. Empty string when the topology is
+ * unavailable; the sidecar then fails closed (rejects every request).
+ */
+export function sidecarVerifierPublicKeyPem(): string {
+  try {
+    return portalService().self.publicKey;
+  } catch {
+    return "";
+  }
+}

--- a/apps/aomi-build/src/server/bff/build/supervisor.ts
+++ b/apps/aomi-build/src/server/bff/build/supervisor.ts
@@ -1,0 +1,193 @@
+import "server-only";
+
+import {
+  createAomiSmither,
+  resolveRunBackend,
+  storeQuery,
+  type AomiSmitherApi,
+} from "@aomi-labs/smither";
+import { listRunningRuns, updateRun, type BuildRunRecord } from "./registry";
+import { extendSandboxById, stopSandboxById } from "./sandbox-runner";
+
+/**
+ * System-owned sandbox lifetime: the build lives exactly as long as the
+ * engine is doing work — not as long as someone watches the page. A periodic
+ * tick (Vercel Cron in prod, an in-process interval in the long-lived dev
+ * server) reads the registry, joins the engine's own heartbeat from the run
+ * store, and extends, reaps, or releases each sandbox.
+ */
+
+/** No first store write within this window ⇒ the VM died silently (the
+ *  stale-OIDC failure mode) — kill it instead of letting it idle to timeout. */
+const FIRST_HEARTBEAT_GRACE_MS = 2 * 60_000;
+/** Engine heartbeat older than this on a "running" run ⇒ engine is dead. */
+const HEARTBEAT_STALE_MS = 3 * 60_000;
+
+export type SuperviseDecision =
+  | "extend"
+  | "reap-silent"
+  | "reap-stale"
+  | "release-completed"
+  | "release-failed"
+  | "release-cancelled"
+  | "none";
+
+/** Pure decision for one running registry row. `storeStatus`/`heartbeatAtMs`
+ *  come from _smithers_runs; null storeStatus means the engine never wrote. */
+export function superviseDecision(input: {
+  storeStatus: string | null;
+  heartbeatAtMs: number | null;
+  registeredAtMs: number;
+  nowMs: number;
+}): SuperviseDecision {
+  const { storeStatus, heartbeatAtMs, registeredAtMs, nowMs } = input;
+  switch (storeStatus) {
+    case "finished":
+    case "continued":
+      return "release-completed";
+    case "failed":
+    case "waiting-quota":
+      return "release-failed";
+    case "cancelled":
+      return "release-cancelled";
+    case null:
+      return nowMs - registeredAtMs > FIRST_HEARTBEAT_GRACE_MS
+        ? "reap-silent"
+        : "none";
+    default: {
+      // running / waiting-approval / waiting-event / waiting-timer.
+      const beat = heartbeatAtMs ?? 0;
+      if (nowMs - beat > HEARTBEAT_STALE_MS) return "reap-stale";
+      return "extend";
+    }
+  }
+}
+
+const SUPERVISOR_KEY = Symbol.for("aomi-build.supervisor");
+
+type SupervisorState = {
+  api?: Promise<AomiSmitherApi>;
+  interval?: ReturnType<typeof setInterval>;
+};
+
+function state(): SupervisorState {
+  const holder = globalThis as { [SUPERVISOR_KEY]?: SupervisorState };
+  holder[SUPERVISOR_KEY] ??= {};
+  return holder[SUPERVISOR_KEY];
+}
+
+function supervisorApi(): Promise<AomiSmitherApi> {
+  const s = state();
+  s.api ??= createAomiSmither(resolveRunBackend("supervisor"));
+  return s.api;
+}
+
+export type SuperviseAction = {
+  runId: string;
+  app: string;
+  decision: SuperviseDecision;
+};
+
+async function applyDecision(
+  api: AomiSmitherApi,
+  record: BuildRunRecord,
+  decision: SuperviseDecision,
+): Promise<void> {
+  const stop = async () => {
+    if (record.sandboxId) await stopSandboxById(record.sandboxId);
+  };
+  switch (decision) {
+    case "extend":
+      if (record.sandboxId) {
+        const ok = await extendSandboxById(record.sandboxId);
+        if (!ok) {
+          // Healthy engine but unreachable sandbox: it lapsed or was stopped
+          // out-of-band. The run will die shortly; mark it now.
+          await updateRun(api, record.runId, { status: "failed" });
+        }
+      }
+      break;
+    case "reap-silent":
+    case "reap-stale":
+      await stop();
+      await updateRun(api, record.runId, { status: "failed" });
+      break;
+    case "release-completed":
+      await stop();
+      await updateRun(api, record.runId, { status: "completed" });
+      break;
+    case "release-failed":
+      await stop();
+      await updateRun(api, record.runId, { status: "failed" });
+      break;
+    case "release-cancelled":
+      await stop();
+      await updateRun(api, record.runId, { status: "cancelled" });
+      break;
+    case "none":
+      break;
+  }
+}
+
+/** One supervision pass over every registry row still marked running. */
+export async function superviseOnce(): Promise<SuperviseAction[]> {
+  const api = await supervisorApi();
+  const running = await listRunningRuns(api);
+  const actions: SuperviseAction[] = [];
+  for (const record of running) {
+    let storeStatus: string | null = null;
+    let heartbeatAtMs: number | null = null;
+    try {
+      const row = (
+        await storeQuery(
+          api,
+          `SELECT status, heartbeat_at_ms FROM _smithers_runs WHERE run_id = ? LIMIT 1`,
+          [record.runId],
+        )
+      )[0];
+      if (row) {
+        storeStatus = String(row.status ?? "") || null;
+        heartbeatAtMs =
+          row.heartbeat_at_ms === null || row.heartbeat_at_ms === undefined
+            ? null
+            : Number(row.heartbeat_at_ms);
+      }
+    } catch {
+      // Store hiccup: decide "none" this tick rather than reaping blind.
+      actions.push({ runId: record.runId, app: record.app, decision: "none" });
+      continue;
+    }
+    const decision = superviseDecision({
+      storeStatus,
+      heartbeatAtMs,
+      registeredAtMs: record.updatedAtMs || record.createdAtMs,
+      nowMs: Date.now(),
+    });
+    try {
+      await applyDecision(api, record, decision);
+    } catch (error) {
+      console.warn(
+        `supervisor: applying ${decision} to ${record.runId} failed:`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+    actions.push({ runId: record.runId, app: record.app, decision });
+  }
+  return actions;
+}
+
+const TICK_MS = 60_000;
+
+/** In-process tick for long-lived servers (next dev / self-hosted). On
+ *  Vercel, functions don't outlive requests — the cron route is the tick. */
+export function ensureSupervisorInterval(): void {
+  const s = state();
+  if (s.interval) return;
+  s.interval = setInterval(() => {
+    void superviseOnce().catch(() => {});
+  }, TICK_MS);
+  // Never hold the process open just to supervise.
+  if (typeof s.interval === "object" && "unref" in s.interval) {
+    s.interval.unref();
+  }
+}

--- a/apps/aomi-build/src/server/bff/build/tar.test.ts
+++ b/apps/aomi-build/src/server/bff/build/tar.test.ts
@@ -1,0 +1,32 @@
+import { execSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { extractFileFromTarGz } from "./tar";
+
+const root = mkdtempSync(path.join(tmpdir(), "tar-test-"));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+describe("extractFileFromTarGz", () => {
+  it("round-trips a file out of a real tar.gz", () => {
+    mkdirSync(path.join(root, "my-app", "src"), { recursive: true });
+    writeFileSync(path.join(root, "my-app", "src", "tool.rs"), "// tools\n");
+    writeFileSync(path.join(root, "my-app", "Cargo.toml"), "[package]\n");
+    execSync(`tar -czf out.tar.gz my-app`, { cwd: root });
+    const tarGz = readFileSync(path.join(root, "out.tar.gz"));
+
+    expect(extractFileFromTarGz(tarGz, "my-app/src/tool.rs")?.toString()).toBe(
+      "// tools\n",
+    );
+    expect(extractFileFromTarGz(tarGz, "my-app/Cargo.toml")?.toString()).toBe(
+      "[package]\n",
+    );
+    expect(extractFileFromTarGz(tarGz, "my-app/nope.rs")).toBeNull();
+  });
+
+  it("rejects garbage input gracefully", () => {
+    expect(extractFileFromTarGz(Buffer.from("not gzip"), "x")).toBeNull();
+  });
+});

--- a/apps/aomi-build/src/server/bff/build/tar.ts
+++ b/apps/aomi-build/src/server/bff/build/tar.ts
@@ -1,0 +1,45 @@
+import { gunzipSync } from "node:zlib";
+
+/**
+ * Minimal ustar reader for the crate tarballs the result phase embeds —
+ * enough to pull one file back out of the store after the sandbox is gone.
+ * No dependency: headers are 512-byte blocks, name in [0,100) (+ optional
+ * prefix in [345,500)), size as octal in [124,136), payload padded to 512.
+ */
+
+function headerString(block: Buffer, offset: number, length: number): string {
+  const raw = block.subarray(offset, offset + length);
+  const nul = raw.indexOf(0);
+  return raw.subarray(0, nul === -1 ? raw.length : nul).toString("utf8");
+}
+
+export function extractFileFromTarGz(
+  tarGz: Buffer,
+  wantedPath: string,
+): Buffer | null {
+  let tar: Buffer;
+  try {
+    tar = gunzipSync(tarGz);
+  } catch {
+    return null;
+  }
+  let offset = 0;
+  while (offset + 512 <= tar.length) {
+    const block = tar.subarray(offset, offset + 512);
+    const name = headerString(block, 0, 100);
+    if (!name) break; // Two empty blocks terminate the archive.
+    const prefix = headerString(block, 345, 155);
+    const fullName = prefix ? `${prefix}/${name}` : name;
+    const size = parseInt(headerString(block, 124, 12).trim() || "0", 8);
+    const type = String.fromCharCode(block[156] ?? 48);
+    offset += 512;
+    const isFile = type === "0" || type === "\0";
+    // Some tars prefix entries with "./".
+    const normalized = fullName.replace(/^\.\//, "");
+    if (isFile && normalized === wantedPath) {
+      return tar.subarray(offset, offset + size);
+    }
+    offset += Math.ceil(size / 512) * 512;
+  }
+  return null;
+}

--- a/infra/build-runner/Dockerfile
+++ b/infra/build-runner/Dockerfile
@@ -108,5 +108,9 @@ RUN bun /workspace/aomi/packages/smither/dist/cli.js --help >/dev/null \
     && test -x /workspace/aomi-sdk/target/release/aomi-build \
     && test -x /workspace/aomi-sdk/target/release/aomi-run
 
+# Live-files sidecar: serves apps/<app> on the exposed sandbox port so the
+# BFF can show Files/file contents mid-run (dispatch launches it detached).
+COPY sidecar.ts /workspace/sidecar.ts
+
 ENV AOMI_SDK_ROOT=/workspace/aomi-sdk
 WORKDIR /workspace/aomi/packages/smither

--- a/infra/build-runner/README.md
+++ b/infra/build-runner/README.md
@@ -38,7 +38,9 @@ releases are the freshness mechanism; runs execute with
 | `AOMI_BUILD_RUNNER` | `vercel-sandbox` |
 | `AOMI_RUNNER_IMAGE` | `build-runner:v1` (or fully-qualified VCR URL) |
 | `SMITHER_DATABASE_URL` | shared Postgres for run state |
-| `SMITHER_ANTHROPIC_API_KEY` | Anthropic key billed for curate/repair agents |
+| `SMITHER_OPENROUTER_API_KEY` | OpenRouter key billed for curate/repair agents (default path — cheap Kimi via OpenRouter's Anthropic-compatible endpoint) |
+| `SMITHER_OPENROUTER_MODEL` | optional, default `moonshotai/kimi-k2.7-code` |
+| `SMITHER_ANTHROPIC_API_KEY` | Anthropic key — backup billing path, used only when the OpenRouter key is absent |
 | `AOMI_SANDBOX_VCPUS` | optional, default 4 |
 | `AOMI_SANDBOX_SDK_ROOT` | optional, default `/workspace/aomi-sdk` |
 | `AOMI_SANDBOX_SMITHER_DIR` | optional, default `/workspace/aomi/packages/smither` |

--- a/infra/build-runner/sidecar.ts
+++ b/infra/build-runner/sidecar.ts
@@ -1,0 +1,196 @@
+/**
+ * Live-files sidecar for the build-runner image. Serves the generated crate
+ * (apps/<app> under the SDK root) over the sandbox's exposed port so the BFF
+ * can show Files/file contents while the run works — the microVM's disk is
+ * otherwise invisible to the web tier.
+ *
+ * Runs on Bun (`bun sidecar.ts <sdkRoot>`). Auth rides the official AOMI
+ * service-bearer path: every request must carry an `Authorization: Bearer`
+ * EdDSA JWT that aomi-bff minted with PORTAL_SERVICE_PRIVATE_KEY (audience
+ * "aomi-sidecar", subject = this run's id). The sidecar verifies it against
+ * aomi-bff's committed *public* key ($AOMI_SIDECAR_PUBKEY) — the VM holds no
+ * secret, and a leaked bearer is short-lived, run-scoped, and rejected by
+ * every other audience in the mesh. The exposed port is public and this VM
+ * executes agent-generated code, so the browser never talks to this
+ * directly; only the BFF does.
+ *
+ * Routes:
+ *   GET /healthz                 → 200 "ok"
+ *   GET /tree                    → CrateFileNode[] of apps/$AOMI_SIDECAR_APP
+ *   GET /file?path=<rel>         → raw file body (path-jailed, 256 KB cap)
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const TREE_SKIP = new Set(["target", "node_modules", ".git", "Cargo.lock"]);
+const MAX_FILE_BYTES = 256 * 1024;
+
+export type SidecarBearerExpectations = {
+  /** aomi-bff's SPKI public key (PEM). Empty = fail closed. */
+  publicKeyPem: string;
+  /** The run this sidecar belongs to; the bearer's `sub` must match. */
+  runId: string;
+};
+
+const EXPECTED_ISSUER = "aomi-bff";
+const EXPECTED_AUDIENCE = "aomi-sidecar";
+
+function b64urlDecode(part: string): Buffer {
+  return Buffer.from(part.replace(/-/g, "+").replace(/_/g, "/"), "base64");
+}
+
+function pemToDer(pem: string): Buffer {
+  const body = pem
+    .replace(/-----BEGIN PUBLIC KEY-----/g, "")
+    .replace(/-----END PUBLIC KEY-----/g, "")
+    .replace(/\\n/g, "\n")
+    .replace(/\s+/g, "");
+  return Buffer.from(body, "base64");
+}
+
+/**
+ * Verify an `Authorization` header value against the expectations. Same JWT
+ * convention as `AomiService.verify` (packages/service), reimplemented on
+ * WebCrypto so this file stays dependency-free inside the image.
+ */
+export async function verifyBearer(
+  authorization: string | null,
+  expected: SidecarBearerExpectations,
+  nowMs = Date.now(),
+): Promise<boolean> {
+  if (!expected.publicKeyPem.trim() || !expected.runId) return false;
+  if (!authorization?.startsWith("Bearer ")) return false;
+  const parts = authorization.slice("Bearer ".length).trim().split(".");
+  if (parts.length !== 3) return false;
+  try {
+    const header = JSON.parse(b64urlDecode(parts[0]).toString("utf8"));
+    if (header.alg !== "EdDSA") return false;
+    const payload = JSON.parse(b64urlDecode(parts[1]).toString("utf8"));
+    if (payload.iss !== EXPECTED_ISSUER) return false;
+    if (payload.aud !== EXPECTED_AUDIENCE) return false;
+    if (payload.sub !== expected.runId) return false;
+    if (typeof payload.exp !== "number" || payload.exp * 1000 <= nowMs) {
+      return false;
+    }
+    const key = await crypto.subtle.importKey(
+      "spki",
+      pemToDer(expected.publicKeyPem),
+      { name: "Ed25519" },
+      false,
+      ["verify"],
+    );
+    return await crypto.subtle.verify(
+      { name: "Ed25519" },
+      key,
+      b64urlDecode(parts[2]),
+      new TextEncoder().encode(`${parts[0]}.${parts[1]}`),
+    );
+  } catch {
+    return false;
+  }
+}
+
+type Node = { path: string; type: "file" | "folder"; children?: Node[] };
+
+function walk(dir: string, rel: string, depth: number): Node[] {
+  if (depth > 4) return [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((e) => !TREE_SKIP.has(e.name) && !e.name.startsWith("."))
+    .sort((a, b) =>
+      a.isDirectory() === b.isDirectory()
+        ? a.name.localeCompare(b.name)
+        : a.isDirectory()
+          ? -1
+          : 1,
+    )
+    .map((e) => {
+      const childRel = `${rel}/${e.name}`;
+      return e.isDirectory()
+        ? {
+            path: childRel,
+            type: "folder" as const,
+            children: walk(path.join(dir, e.name), childRel, depth + 1),
+          }
+        : { path: childRel, type: "file" as const };
+    });
+}
+
+declare const Bun: {
+  serve(options: {
+    port: number;
+    hostname: string;
+    fetch(req: Request): Promise<Response> | Response;
+  }): unknown;
+};
+
+if ((import.meta as { main?: boolean }).main) {
+  const sdkRoot = process.argv[2] ?? "/workspace/aomi-sdk";
+  const app = process.env.AOMI_SIDECAR_APP ?? "";
+  const expected: SidecarBearerExpectations = {
+    publicKeyPem: process.env.AOMI_SIDECAR_PUBKEY ?? "",
+    runId: process.env.AOMI_SIDECAR_RUN_ID ?? "",
+  };
+  const port = Number(process.env.AOMI_SIDECAR_PORT) || 8722;
+  const appDir = path.join(sdkRoot, "apps", app);
+
+  const tree = (): Node[] => {
+    if (!app || !existsSync(appDir)) return [];
+    return [{ path: app, type: "folder", children: walk(appDir, app, 0) }];
+  };
+
+  /** Resolve a display path ("<app>/src/tool.rs") inside the jail, or null. */
+  const jailedFile = (relPath: string): string | null => {
+    if (!app) return null;
+    const prefix = `${app}/`;
+    if (relPath !== app && !relPath.startsWith(prefix)) return null;
+    const inside = relPath === app ? "" : relPath.slice(prefix.length);
+    const resolved = path.resolve(appDir, inside);
+    if (resolved !== appDir && !resolved.startsWith(appDir + path.sep)) {
+      return null;
+    }
+    return resolved;
+  };
+
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+
+  Bun.serve({
+    port,
+    hostname: "0.0.0.0",
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/healthz") return new Response("ok");
+      if (!(await verifyBearer(req.headers.get("authorization"), expected))) {
+        return json({ error: "forbidden" }, 403);
+      }
+      if (url.pathname === "/tree") return json(tree());
+      if (url.pathname === "/file") {
+        const target = jailedFile(url.searchParams.get("path") ?? "");
+        if (!target || !existsSync(target)) {
+          return json({ error: "not found" }, 404);
+        }
+        const stats = statSync(target);
+        if (!stats.isFile()) return json({ error: "not a file" }, 400);
+        if (stats.size > MAX_FILE_BYTES) {
+          return json({ error: `file exceeds ${MAX_FILE_BYTES} bytes` }, 413);
+        }
+        return new Response(readFileSync(target), {
+          headers: { "content-type": "text/plain; charset=utf-8" },
+        });
+      }
+      return json({ error: "not found" }, 404);
+    },
+  });
+
+  console.log(`sidecar serving apps/${app} on :${port}`);
+}

--- a/packages/account/src/topology-data.ts
+++ b/packages/account/src/topology-data.ts
@@ -11,7 +11,7 @@ export const PORTAL_TOPOLOGIES: Record<PortalTopologyName, string> = {
 name = "aomi-bff"
 kid = "aomi-bff-dev-1"
 issues = ["user", "service"]
-audiences = ["aomi-backend"]
+audiences = ["aomi-backend", "aomi-sidecar"]
 public_key = """
 -----BEGIN PUBLIC KEY-----
 MCowBQYDK2VwAyEARK6H6nByUxFk68PqBKJocX11IX+9zKFFne0rXKdW94M=
@@ -43,7 +43,7 @@ public_key = ""
 name = "aomi-bff"
 kid = "aomi-bff-staging-1"
 issues = ["user", "service"]
-audiences = ["aomi-backend"]
+audiences = ["aomi-backend", "aomi-sidecar"]
 public_key = """
 -----BEGIN PUBLIC KEY-----
 MCowBQYDK2VwAyEAgLSENuOGsWvaeM+7eU6BWSp9tY61HF7Ml4Vv/fxaupY=
@@ -75,7 +75,7 @@ public_key = ""
 name = "aomi-bff"
 kid = "aomi-bff-prod-1"
 issues = ["user", "service"]
-audiences = ["aomi-backend"]
+audiences = ["aomi-backend", "aomi-sidecar"]
 public_key = """
 -----BEGIN PUBLIC KEY-----
 MCowBQYDK2VwAyEAyaIwzD82igAdhA3xw9Tkr5yJEpaRU3SY73bVqjE7Ajc=

--- a/packages/account/src/topology.test.ts
+++ b/packages/account/src/topology.test.ts
@@ -33,6 +33,20 @@ describe("account topology", () => {
     expect(portalTopologyName()).toBe("production");
   });
 
+  it("authorizes aomi-bff for the sidecar audience in every topology", async () => {
+    // The aomi-build live-files sidecar verifies bearers minted by aomi-bff
+    // with audience "aomi-sidecar" (never "aomi-backend", so a bearer leaked
+    // from the sandbox is useless at the backend).
+    const { PORTAL_TOPOLOGIES } = await import("./topology-data");
+    const { parseTopology } = await import("@aomi-labs/service");
+    for (const toml of Object.values(PORTAL_TOPOLOGIES)) {
+      const bff = parseTopology(toml).services.find(
+        (node) => node.name === "aomi-bff",
+      );
+      expect(bff?.audiences).toContain("aomi-sidecar");
+    }
+  });
+
   it("constructs the service without app-root topology files", async () => {
     chdir(tempDir);
     const testGlobal = globalThis as typeof globalThis & {

--- a/packages/smither/dist/index.d.cts
+++ b/packages/smither/dist/index.d.cts
@@ -25,6 +25,35 @@ type ResolvedBinaries = {
     warning?: string;
 };
 
+/**
+ * Crate artifact packaging for the result phase. The generated app's file
+ * tree and a small tarball ride the durable result row, so surfaces that
+ * cannot see the run's filesystem (the web BFF observing a sandbox run)
+ * still serve real Files and Download.
+ */
+type CrateFileNode = {
+    path: string;
+    type: "file" | "folder";
+    children?: CrateFileNode[];
+};
+/** The generated crate as a display tree. Paths are prefixed with the app
+ *  name ("<app>/src/tool.rs") — the shape the /build page renders. */
+declare function crateFileTree(appDir: string, app: string): CrateFileNode[];
+type CrateArtifact = {
+    /** JSON-encoded CrateFileNode[]; "" when the crate directory is absent. */
+    fileTreeJson: string;
+    /** Base64 .tar.gz of apps/<app> (target/ and Cargo.lock excluded); "" when
+     *  packaging failed or the crate exceeds the embed cap. */
+    crateTarB64: string;
+    /** Human-readable reason whenever crateTarB64 is empty. */
+    warning: string;
+};
+declare function packageCrate(options: {
+    sdkRoot: string;
+    app: string;
+    runner?: CommandRunner;
+}): Promise<CrateArtifact>;
+
 declare const defaultRunner: CommandRunner;
 declare function defaultSdkRoot(cwd?: string): string;
 declare function targetBinaryPaths(sdkRoot: string): Pick<ResolvedBinaries, "aomiBuild" | "aomiRun">;
@@ -1325,6 +1354,9 @@ declare const smitherSchemas: {
             blocked: "blocked";
         }>;
         summary: z.ZodString;
+        fileTreeJson: z.ZodDefault<z.ZodString>;
+        crateTarB64: z.ZodDefault<z.ZodString>;
+        artifactWarning: z.ZodDefault<z.ZodString>;
     }, z.core.$strip>;
 };
 type SmitherSchemas = typeof smitherSchemas;
@@ -1526,6 +1558,40 @@ declare function savePlan(plan: BuildPlan, root?: string): Promise<void>;
 declare function loadPlan(app: string, root?: string): Promise<BuildPlan | null>;
 
 type AgentKind = "claude" | "codex";
+/** OpenRouter's Anthropic-compatible endpoint ("Anthropic Skin") — the claude
+ *  CLI speaks its native Messages protocol straight to it. */
+declare const OPENROUTER_BASE_URL = "https://openrouter.ai/api";
+/** Latest cheap coding Kimi. Deliberately NOT kimi-k3 (Sonnet-priced, no
+ *  savings); k2.7-code is ~$0.72/$3.50 per M tokens. Ops override via
+ *  SMITHER_OPENROUTER_MODEL. */
+declare const DEFAULT_OPENROUTER_MODEL = "moonshotai/kimi-k2.7-code";
+type AgentBilling = {
+    kind: "openrouter";
+    apiKey: string;
+    model: string;
+} | {
+    kind: "anthropic";
+    apiKey: string;
+} | {
+    kind: "none";
+};
+/**
+ * Pick who pays for claude work agents. OpenRouter is the default whenever its
+ * key is present (build runs are expensive on first-party Anthropic); the
+ * Anthropic key is the backup path, kept for a quick rollback via env alone.
+ * Not user-selectable — pure deployment config.
+ */
+declare function resolveAgentBilling(env: NodeJS.ProcessEnv | undefined): AgentBilling;
+/**
+ * Env overrides that point the claude CLI at OpenRouter. ANTHROPIC_API_KEY is
+ * pinned to "" (not merely unset) so the CLI can never fall back to Anthropic
+ * first-party auth; both model slots route to the same slug so background/fast
+ * tasks don't silently bill a Claude model.
+ */
+declare function openrouterAgentEnv(billing: {
+    apiKey: string;
+    model: string;
+}): Record<string, string>;
 /**
  * CLI work agent for curation/review/repair tasks. Runs inside the SDK
  * checkout in non-interactive mode with edits allowed — Smithers owns the
@@ -1536,9 +1602,10 @@ declare function makeWorkAgent(kind: AgentKind, options: {
     cwd: string;
     env?: NodeJS.ProcessEnv;
     timeoutMs?: number;
-    /** Bill an API key instead of the local CLI login — required on headless
-     *  runners (sandboxes, CI) where no personal subscription is signed in. */
-    apiKey?: string;
+    /** Who pays. Headless runners (sandboxes, CI) have no CLI login, so
+     *  "none" only works where a personal subscription is signed in. Codex
+     *  agents ignore this — they bill their own auth. */
+    billing?: AgentBilling;
 }): Promise<AgentLike>;
 
 type AomiSmitherApi = CreateSmithersApi<SmitherSchemas>;
@@ -1693,6 +1760,14 @@ declare function executeRunUntilSettled(prepared: PreparedRun, options?: {
     approvalPollMs?: number;
 }): Promise<RunResult>;
 /**
+ * Narrow raw-SQL door into the run store, for host-app tables that must live
+ * on the same connection (the embedded PGlite backend cannot be opened twice
+ * in one process). Statements use `?` placeholders on every backend — the
+ * storage layer translates for Postgres. Rows come back with on-disk column
+ * names (no snake→camel transform).
+ */
+declare function storeQuery(api: AomiSmitherApi, sql: string, params?: unknown[]): Promise<Array<Record<string, unknown>>>;
+/**
  * All persisted output rows for a run, keyed by table name ("curation",
  * "result", …). Lets surfaces outside the workflow render (the web BFF, the
  * console) read what a run produced — including replayed resumes that emit no
@@ -1759,4 +1834,4 @@ declare function decideApproval(options: {
     };
 }): Promise<void>;
 
-export { type ActivationCredential, type AgentKind, type AgentPhase, type AgentRole, type AomiBuildCommand, type AomiSmitherApi, type AomiWorkflow, type BinariesRow, type BuildPlan, type ClarifyOption, type ClarifyRow, type CodegenRow, type CommandResult, type CommandRunner, type ComputeOp, type ConsoleHandle, type ConsoleOptions, DEFAULT_CONSOLE_PORT, type DeploymentRow, type EvalPhase, type EvaluationRow, type GateRow, type InnerPhase, type IntakePhase, type IntakeServerHandle, type IntakeState, type IntentAgent, type IntentDraft, type IntentTurn, type Phase, type PlanStage, type PreparedRun, type PromptContext, type ResolvedBinaries, type ResultRow, type RollbackClient, type RollbackPlanSummary, type RollbackTarget, type RunNodeView, type RunState, type RunView, type SdkFreshness, type SmitherBackend, type SmitherSchemas, type SmokeRow, type ValidationRow, WORKFLOW_NAME, type WorkflowDeps, activationConfigPath, agentPhaseSchema, agentRoleSchema, agentSpecsFor, assertBunRuntime, boundedLog, buildAppWorkflow, buildPlanSchema, clarifyOptionSchema, clarifyPhaseSchema, classicComposition, compositionIssues, computeOpSchema, computePhaseSchema, createAomiSmither, createRunState, curatePrompt, decideApproval, defaultRunner, defaultRunsRoot, defaultSdkRoot, describeBackend, describePlan, designPrompt, distillIntent, draftSpecPrompt, ensureFreshSdkCheckout, evalJudge, evalPhaseSchema, executeRollback, executeRun, executeRunUntilSettled, extractJsonObject, finalizePlan, fixPrompt, gatePhaseSchema, innerPhaseSchema, innerPhasesOf, intentDraftSchema, intentPlanFields, intentPrompt, isBunRuntime, judgePrompt, loadPlan, loadRunOutputs, loadRunState, loopPhaseSchema, makeWorkAgent, mergePlanDraft, newAppArgs, nodeId, packageRoot, parallelPhaseSchema, phaseAgent, phaseSchema, planPath, planRollback, pluginLibraryFileName, prepareRun, readRunView, requestRunCancel, researchPrompt, resetRunState, resolveActivationCredential, resolveAgentCwd, resolveAomiBinaries, resolveComposition, resolveFreshAomiBinaries, resolveRunBackend, reviewPrompt, rolePrompt, rollbackClientFromEnv, runAomiBuild, runAomiRun, runAppCargoChecks, runDir, runEvalStep, runStatePath, sanitizeAppName, savePlan, sendSignal, smitherDbPath, smitherSchemas, stageKeyForNode, stagesFor, startConsole, startConsoleForApp, startIntakeServer, synthesizePrompt, targetBinaryPaths, waitExternalPhaseSchema };
+export { type ActivationCredential, type AgentBilling, type AgentKind, type AgentPhase, type AgentRole, type AomiBuildCommand, type AomiSmitherApi, type AomiWorkflow, type BinariesRow, type BuildPlan, type ClarifyOption, type ClarifyRow, type CodegenRow, type CommandResult, type CommandRunner, type ComputeOp, type ConsoleHandle, type ConsoleOptions, type CrateArtifact, type CrateFileNode, DEFAULT_CONSOLE_PORT, DEFAULT_OPENROUTER_MODEL, type DeploymentRow, type EvalPhase, type EvaluationRow, type GateRow, type InnerPhase, type IntakePhase, type IntakeServerHandle, type IntakeState, type IntentAgent, type IntentDraft, type IntentTurn, OPENROUTER_BASE_URL, type Phase, type PlanStage, type PreparedRun, type PromptContext, type ResolvedBinaries, type ResultRow, type RollbackClient, type RollbackPlanSummary, type RollbackTarget, type RunNodeView, type RunState, type RunView, type SdkFreshness, type SmitherBackend, type SmitherSchemas, type SmokeRow, type ValidationRow, WORKFLOW_NAME, type WorkflowDeps, activationConfigPath, agentPhaseSchema, agentRoleSchema, agentSpecsFor, assertBunRuntime, boundedLog, buildAppWorkflow, buildPlanSchema, clarifyOptionSchema, clarifyPhaseSchema, classicComposition, compositionIssues, computeOpSchema, computePhaseSchema, crateFileTree, createAomiSmither, createRunState, curatePrompt, decideApproval, defaultRunner, defaultRunsRoot, defaultSdkRoot, describeBackend, describePlan, designPrompt, distillIntent, draftSpecPrompt, ensureFreshSdkCheckout, evalJudge, evalPhaseSchema, executeRollback, executeRun, executeRunUntilSettled, extractJsonObject, finalizePlan, fixPrompt, gatePhaseSchema, innerPhaseSchema, innerPhasesOf, intentDraftSchema, intentPlanFields, intentPrompt, isBunRuntime, judgePrompt, loadPlan, loadRunOutputs, loadRunState, loopPhaseSchema, makeWorkAgent, mergePlanDraft, newAppArgs, nodeId, openrouterAgentEnv, packageCrate, packageRoot, parallelPhaseSchema, phaseAgent, phaseSchema, planPath, planRollback, pluginLibraryFileName, prepareRun, readRunView, requestRunCancel, researchPrompt, resetRunState, resolveActivationCredential, resolveAgentBilling, resolveAgentCwd, resolveAomiBinaries, resolveComposition, resolveFreshAomiBinaries, resolveRunBackend, reviewPrompt, rolePrompt, rollbackClientFromEnv, runAomiBuild, runAomiRun, runAppCargoChecks, runDir, runEvalStep, runStatePath, sanitizeAppName, savePlan, sendSignal, smitherDbPath, smitherSchemas, stageKeyForNode, stagesFor, startConsole, startConsoleForApp, startIntakeServer, storeQuery, synthesizePrompt, targetBinaryPaths, waitExternalPhaseSchema };

--- a/packages/smither/dist/index.d.ts
+++ b/packages/smither/dist/index.d.ts
@@ -25,6 +25,35 @@ type ResolvedBinaries = {
     warning?: string;
 };
 
+/**
+ * Crate artifact packaging for the result phase. The generated app's file
+ * tree and a small tarball ride the durable result row, so surfaces that
+ * cannot see the run's filesystem (the web BFF observing a sandbox run)
+ * still serve real Files and Download.
+ */
+type CrateFileNode = {
+    path: string;
+    type: "file" | "folder";
+    children?: CrateFileNode[];
+};
+/** The generated crate as a display tree. Paths are prefixed with the app
+ *  name ("<app>/src/tool.rs") — the shape the /build page renders. */
+declare function crateFileTree(appDir: string, app: string): CrateFileNode[];
+type CrateArtifact = {
+    /** JSON-encoded CrateFileNode[]; "" when the crate directory is absent. */
+    fileTreeJson: string;
+    /** Base64 .tar.gz of apps/<app> (target/ and Cargo.lock excluded); "" when
+     *  packaging failed or the crate exceeds the embed cap. */
+    crateTarB64: string;
+    /** Human-readable reason whenever crateTarB64 is empty. */
+    warning: string;
+};
+declare function packageCrate(options: {
+    sdkRoot: string;
+    app: string;
+    runner?: CommandRunner;
+}): Promise<CrateArtifact>;
+
 declare const defaultRunner: CommandRunner;
 declare function defaultSdkRoot(cwd?: string): string;
 declare function targetBinaryPaths(sdkRoot: string): Pick<ResolvedBinaries, "aomiBuild" | "aomiRun">;
@@ -1325,6 +1354,9 @@ declare const smitherSchemas: {
             blocked: "blocked";
         }>;
         summary: z.ZodString;
+        fileTreeJson: z.ZodDefault<z.ZodString>;
+        crateTarB64: z.ZodDefault<z.ZodString>;
+        artifactWarning: z.ZodDefault<z.ZodString>;
     }, z.core.$strip>;
 };
 type SmitherSchemas = typeof smitherSchemas;
@@ -1526,6 +1558,40 @@ declare function savePlan(plan: BuildPlan, root?: string): Promise<void>;
 declare function loadPlan(app: string, root?: string): Promise<BuildPlan | null>;
 
 type AgentKind = "claude" | "codex";
+/** OpenRouter's Anthropic-compatible endpoint ("Anthropic Skin") — the claude
+ *  CLI speaks its native Messages protocol straight to it. */
+declare const OPENROUTER_BASE_URL = "https://openrouter.ai/api";
+/** Latest cheap coding Kimi. Deliberately NOT kimi-k3 (Sonnet-priced, no
+ *  savings); k2.7-code is ~$0.72/$3.50 per M tokens. Ops override via
+ *  SMITHER_OPENROUTER_MODEL. */
+declare const DEFAULT_OPENROUTER_MODEL = "moonshotai/kimi-k2.7-code";
+type AgentBilling = {
+    kind: "openrouter";
+    apiKey: string;
+    model: string;
+} | {
+    kind: "anthropic";
+    apiKey: string;
+} | {
+    kind: "none";
+};
+/**
+ * Pick who pays for claude work agents. OpenRouter is the default whenever its
+ * key is present (build runs are expensive on first-party Anthropic); the
+ * Anthropic key is the backup path, kept for a quick rollback via env alone.
+ * Not user-selectable — pure deployment config.
+ */
+declare function resolveAgentBilling(env: NodeJS.ProcessEnv | undefined): AgentBilling;
+/**
+ * Env overrides that point the claude CLI at OpenRouter. ANTHROPIC_API_KEY is
+ * pinned to "" (not merely unset) so the CLI can never fall back to Anthropic
+ * first-party auth; both model slots route to the same slug so background/fast
+ * tasks don't silently bill a Claude model.
+ */
+declare function openrouterAgentEnv(billing: {
+    apiKey: string;
+    model: string;
+}): Record<string, string>;
 /**
  * CLI work agent for curation/review/repair tasks. Runs inside the SDK
  * checkout in non-interactive mode with edits allowed — Smithers owns the
@@ -1536,9 +1602,10 @@ declare function makeWorkAgent(kind: AgentKind, options: {
     cwd: string;
     env?: NodeJS.ProcessEnv;
     timeoutMs?: number;
-    /** Bill an API key instead of the local CLI login — required on headless
-     *  runners (sandboxes, CI) where no personal subscription is signed in. */
-    apiKey?: string;
+    /** Who pays. Headless runners (sandboxes, CI) have no CLI login, so
+     *  "none" only works where a personal subscription is signed in. Codex
+     *  agents ignore this — they bill their own auth. */
+    billing?: AgentBilling;
 }): Promise<AgentLike>;
 
 type AomiSmitherApi = CreateSmithersApi<SmitherSchemas>;
@@ -1693,6 +1760,14 @@ declare function executeRunUntilSettled(prepared: PreparedRun, options?: {
     approvalPollMs?: number;
 }): Promise<RunResult>;
 /**
+ * Narrow raw-SQL door into the run store, for host-app tables that must live
+ * on the same connection (the embedded PGlite backend cannot be opened twice
+ * in one process). Statements use `?` placeholders on every backend — the
+ * storage layer translates for Postgres. Rows come back with on-disk column
+ * names (no snake→camel transform).
+ */
+declare function storeQuery(api: AomiSmitherApi, sql: string, params?: unknown[]): Promise<Array<Record<string, unknown>>>;
+/**
  * All persisted output rows for a run, keyed by table name ("curation",
  * "result", …). Lets surfaces outside the workflow render (the web BFF, the
  * console) read what a run produced — including replayed resumes that emit no
@@ -1759,4 +1834,4 @@ declare function decideApproval(options: {
     };
 }): Promise<void>;
 
-export { type ActivationCredential, type AgentKind, type AgentPhase, type AgentRole, type AomiBuildCommand, type AomiSmitherApi, type AomiWorkflow, type BinariesRow, type BuildPlan, type ClarifyOption, type ClarifyRow, type CodegenRow, type CommandResult, type CommandRunner, type ComputeOp, type ConsoleHandle, type ConsoleOptions, DEFAULT_CONSOLE_PORT, type DeploymentRow, type EvalPhase, type EvaluationRow, type GateRow, type InnerPhase, type IntakePhase, type IntakeServerHandle, type IntakeState, type IntentAgent, type IntentDraft, type IntentTurn, type Phase, type PlanStage, type PreparedRun, type PromptContext, type ResolvedBinaries, type ResultRow, type RollbackClient, type RollbackPlanSummary, type RollbackTarget, type RunNodeView, type RunState, type RunView, type SdkFreshness, type SmitherBackend, type SmitherSchemas, type SmokeRow, type ValidationRow, WORKFLOW_NAME, type WorkflowDeps, activationConfigPath, agentPhaseSchema, agentRoleSchema, agentSpecsFor, assertBunRuntime, boundedLog, buildAppWorkflow, buildPlanSchema, clarifyOptionSchema, clarifyPhaseSchema, classicComposition, compositionIssues, computeOpSchema, computePhaseSchema, createAomiSmither, createRunState, curatePrompt, decideApproval, defaultRunner, defaultRunsRoot, defaultSdkRoot, describeBackend, describePlan, designPrompt, distillIntent, draftSpecPrompt, ensureFreshSdkCheckout, evalJudge, evalPhaseSchema, executeRollback, executeRun, executeRunUntilSettled, extractJsonObject, finalizePlan, fixPrompt, gatePhaseSchema, innerPhaseSchema, innerPhasesOf, intentDraftSchema, intentPlanFields, intentPrompt, isBunRuntime, judgePrompt, loadPlan, loadRunOutputs, loadRunState, loopPhaseSchema, makeWorkAgent, mergePlanDraft, newAppArgs, nodeId, packageRoot, parallelPhaseSchema, phaseAgent, phaseSchema, planPath, planRollback, pluginLibraryFileName, prepareRun, readRunView, requestRunCancel, researchPrompt, resetRunState, resolveActivationCredential, resolveAgentCwd, resolveAomiBinaries, resolveComposition, resolveFreshAomiBinaries, resolveRunBackend, reviewPrompt, rolePrompt, rollbackClientFromEnv, runAomiBuild, runAomiRun, runAppCargoChecks, runDir, runEvalStep, runStatePath, sanitizeAppName, savePlan, sendSignal, smitherDbPath, smitherSchemas, stageKeyForNode, stagesFor, startConsole, startConsoleForApp, startIntakeServer, synthesizePrompt, targetBinaryPaths, waitExternalPhaseSchema };
+export { type ActivationCredential, type AgentBilling, type AgentKind, type AgentPhase, type AgentRole, type AomiBuildCommand, type AomiSmitherApi, type AomiWorkflow, type BinariesRow, type BuildPlan, type ClarifyOption, type ClarifyRow, type CodegenRow, type CommandResult, type CommandRunner, type ComputeOp, type ConsoleHandle, type ConsoleOptions, type CrateArtifact, type CrateFileNode, DEFAULT_CONSOLE_PORT, DEFAULT_OPENROUTER_MODEL, type DeploymentRow, type EvalPhase, type EvaluationRow, type GateRow, type InnerPhase, type IntakePhase, type IntakeServerHandle, type IntakeState, type IntentAgent, type IntentDraft, type IntentTurn, OPENROUTER_BASE_URL, type Phase, type PlanStage, type PreparedRun, type PromptContext, type ResolvedBinaries, type ResultRow, type RollbackClient, type RollbackPlanSummary, type RollbackTarget, type RunNodeView, type RunState, type RunView, type SdkFreshness, type SmitherBackend, type SmitherSchemas, type SmokeRow, type ValidationRow, WORKFLOW_NAME, type WorkflowDeps, activationConfigPath, agentPhaseSchema, agentRoleSchema, agentSpecsFor, assertBunRuntime, boundedLog, buildAppWorkflow, buildPlanSchema, clarifyOptionSchema, clarifyPhaseSchema, classicComposition, compositionIssues, computeOpSchema, computePhaseSchema, crateFileTree, createAomiSmither, createRunState, curatePrompt, decideApproval, defaultRunner, defaultRunsRoot, defaultSdkRoot, describeBackend, describePlan, designPrompt, distillIntent, draftSpecPrompt, ensureFreshSdkCheckout, evalJudge, evalPhaseSchema, executeRollback, executeRun, executeRunUntilSettled, extractJsonObject, finalizePlan, fixPrompt, gatePhaseSchema, innerPhaseSchema, innerPhasesOf, intentDraftSchema, intentPlanFields, intentPrompt, isBunRuntime, judgePrompt, loadPlan, loadRunOutputs, loadRunState, loopPhaseSchema, makeWorkAgent, mergePlanDraft, newAppArgs, nodeId, openrouterAgentEnv, packageCrate, packageRoot, parallelPhaseSchema, phaseAgent, phaseSchema, planPath, planRollback, pluginLibraryFileName, prepareRun, readRunView, requestRunCancel, researchPrompt, resetRunState, resolveActivationCredential, resolveAgentBilling, resolveAgentCwd, resolveAomiBinaries, resolveComposition, resolveFreshAomiBinaries, resolveRunBackend, reviewPrompt, rolePrompt, rollbackClientFromEnv, runAomiBuild, runAomiRun, runAppCargoChecks, runDir, runEvalStep, runStatePath, sanitizeAppName, savePlan, sendSignal, smitherDbPath, smitherSchemas, stageKeyForNode, stagesFor, startConsole, startConsoleForApp, startIntakeServer, storeQuery, synthesizePrompt, targetBinaryPaths, waitExternalPhaseSchema };

--- a/packages/smither/src/__tests__/agents.test.ts
+++ b/packages/smither/src/__tests__/agents.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_OPENROUTER_MODEL,
+  OPENROUTER_BASE_URL,
+  openrouterAgentEnv,
+  resolveAgentBilling,
+} from "../agents";
+
+describe("resolveAgentBilling", () => {
+  it("defaults to openrouter when its key is present, even alongside the anthropic key", () => {
+    expect(
+      resolveAgentBilling({
+        SMITHER_OPENROUTER_API_KEY: "sk-or-key",
+        SMITHER_ANTHROPIC_API_KEY: "sk-ant-key",
+      } as NodeJS.ProcessEnv),
+    ).toEqual({
+      kind: "openrouter",
+      apiKey: "sk-or-key",
+      model: DEFAULT_OPENROUTER_MODEL,
+    });
+  });
+
+  it("honors the model override", () => {
+    expect(
+      resolveAgentBilling({
+        SMITHER_OPENROUTER_API_KEY: "sk-or-key",
+        SMITHER_OPENROUTER_MODEL: "moonshotai/kimi-k3",
+      } as NodeJS.ProcessEnv),
+    ).toMatchObject({ model: "moonshotai/kimi-k3" });
+  });
+
+  it("falls back to anthropic billing when only that key is set", () => {
+    expect(
+      resolveAgentBilling({
+        SMITHER_ANTHROPIC_API_KEY: "sk-ant-key",
+      } as NodeJS.ProcessEnv),
+    ).toEqual({ kind: "anthropic", apiKey: "sk-ant-key" });
+  });
+
+  it("resolves none for empty env — local CLI login pays", () => {
+    expect(resolveAgentBilling({} as NodeJS.ProcessEnv)).toEqual({ kind: "none" });
+    expect(resolveAgentBilling(undefined)).toEqual({ kind: "none" });
+  });
+
+  it("ignores blank keys", () => {
+    expect(
+      resolveAgentBilling({
+        SMITHER_OPENROUTER_API_KEY: "",
+        SMITHER_ANTHROPIC_API_KEY: "",
+      } as NodeJS.ProcessEnv),
+    ).toEqual({ kind: "none" });
+  });
+});
+
+describe("openrouterAgentEnv", () => {
+  it("points the claude CLI at OpenRouter and pins ANTHROPIC_API_KEY empty", () => {
+    const env = openrouterAgentEnv({ apiKey: "sk-or-key", model: "moonshotai/kimi-k2.7-code" });
+    expect(env).toEqual({
+      ANTHROPIC_BASE_URL: OPENROUTER_BASE_URL,
+      ANTHROPIC_AUTH_TOKEN: "sk-or-key",
+      // "" (not absent): the CLI must never fall back to first-party auth.
+      ANTHROPIC_API_KEY: "",
+      ANTHROPIC_MODEL: "moonshotai/kimi-k2.7-code",
+      ANTHROPIC_SMALL_FAST_MODEL: "moonshotai/kimi-k2.7-code",
+    });
+  });
+});

--- a/packages/smither/src/__tests__/artifacts.test.ts
+++ b/packages/smither/src/__tests__/artifacts.test.ts
@@ -1,0 +1,71 @@
+import { execSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { crateFileTree, packageCrate } from "../artifacts";
+
+let roots: string[] = [];
+
+function fixtureSdkRoot(app: string): string {
+  const root = mkdtempSync(path.join(tmpdir(), "artifacts-test-"));
+  roots.push(root);
+  const appDir = path.join(root, "apps", app);
+  mkdirSync(path.join(appDir, "src", "client"), { recursive: true });
+  mkdirSync(path.join(appDir, "target", "release"), { recursive: true });
+  writeFileSync(path.join(appDir, "Cargo.toml"), "[package]\n");
+  writeFileSync(path.join(appDir, "Cargo.lock"), "# lock\n");
+  writeFileSync(path.join(appDir, "src", "lib.rs"), "// lib\n");
+  writeFileSync(path.join(appDir, "src", "tool.rs"), "// tool\n");
+  writeFileSync(path.join(appDir, "src", "client", "client.rs"), "// client\n");
+  writeFileSync(path.join(appDir, "target", "release", "junk.bin"), "junk");
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+  roots = [];
+});
+
+describe("crateFileTree", () => {
+  it("walks the crate, folders first, skipping target and Cargo.lock", () => {
+    const root = fixtureSdkRoot("my-app");
+    const tree = crateFileTree(path.join(root, "apps", "my-app"), "my-app");
+    expect(tree).toHaveLength(1);
+    const paths = JSON.stringify(tree);
+    expect(paths).toContain("my-app/src/tool.rs");
+    expect(paths).toContain("my-app/src/client/client.rs");
+    expect(paths).not.toContain("target");
+    expect(paths).not.toContain("Cargo.lock");
+    // Folders sort before files.
+    expect(tree[0].children?.[0].path).toBe("my-app/src");
+  });
+
+  it("returns empty for a missing directory", () => {
+    expect(crateFileTree("/nonexistent/nowhere", "x")).toEqual([]);
+  });
+});
+
+describe("packageCrate", () => {
+  it("embeds a decodable tarball plus the tree", async () => {
+    const root = fixtureSdkRoot("my-app");
+    const artifact = await packageCrate({ sdkRoot: root, app: "my-app" });
+    expect(artifact.warning).toBe("");
+    expect(JSON.parse(artifact.fileTreeJson)).toHaveLength(1);
+    const tarPath = path.join(roots[0], "roundtrip.tar.gz");
+    writeFileSync(tarPath, Buffer.from(artifact.crateTarB64, "base64"));
+    const listing = execSync(`tar -tzf ${JSON.stringify(tarPath)}`).toString();
+    expect(listing).toContain("my-app/src/tool.rs");
+    expect(listing).not.toContain("target/");
+    expect(listing).not.toContain("Cargo.lock");
+  });
+
+  it("degrades to tree-only with a warning when the crate is missing", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "artifacts-test-"));
+    roots.push(root);
+    const artifact = await packageCrate({ sdkRoot: root, app: "ghost" });
+    expect(artifact.crateTarB64).toBe("");
+    expect(artifact.warning).toContain("no generated crate");
+  });
+});

--- a/packages/smither/src/agents.ts
+++ b/packages/smither/src/agents.ts
@@ -2,6 +2,59 @@ import type { AgentLike } from "smithers-orchestrator";
 
 export type AgentKind = "claude" | "codex";
 
+/** OpenRouter's Anthropic-compatible endpoint ("Anthropic Skin") — the claude
+ *  CLI speaks its native Messages protocol straight to it. */
+export const OPENROUTER_BASE_URL = "https://openrouter.ai/api";
+
+/** Latest cheap coding Kimi. Deliberately NOT kimi-k3 (Sonnet-priced, no
+ *  savings); k2.7-code is ~$0.72/$3.50 per M tokens. Ops override via
+ *  SMITHER_OPENROUTER_MODEL. */
+export const DEFAULT_OPENROUTER_MODEL = "moonshotai/kimi-k2.7-code";
+
+export type AgentBilling =
+  | { kind: "openrouter"; apiKey: string; model: string }
+  | { kind: "anthropic"; apiKey: string }
+  | { kind: "none" };
+
+/**
+ * Pick who pays for claude work agents. OpenRouter is the default whenever its
+ * key is present (build runs are expensive on first-party Anthropic); the
+ * Anthropic key is the backup path, kept for a quick rollback via env alone.
+ * Not user-selectable — pure deployment config.
+ */
+export function resolveAgentBilling(env: NodeJS.ProcessEnv | undefined): AgentBilling {
+  const openrouterKey = env?.SMITHER_OPENROUTER_API_KEY;
+  if (openrouterKey) {
+    return {
+      kind: "openrouter",
+      apiKey: openrouterKey,
+      model: env?.SMITHER_OPENROUTER_MODEL || DEFAULT_OPENROUTER_MODEL,
+    };
+  }
+  const anthropicKey = env?.SMITHER_ANTHROPIC_API_KEY;
+  if (anthropicKey) return { kind: "anthropic", apiKey: anthropicKey };
+  return { kind: "none" };
+}
+
+/**
+ * Env overrides that point the claude CLI at OpenRouter. ANTHROPIC_API_KEY is
+ * pinned to "" (not merely unset) so the CLI can never fall back to Anthropic
+ * first-party auth; both model slots route to the same slug so background/fast
+ * tasks don't silently bill a Claude model.
+ */
+export function openrouterAgentEnv(billing: {
+  apiKey: string;
+  model: string;
+}): Record<string, string> {
+  return {
+    ANTHROPIC_BASE_URL: OPENROUTER_BASE_URL,
+    ANTHROPIC_AUTH_TOKEN: billing.apiKey,
+    ANTHROPIC_API_KEY: "",
+    ANTHROPIC_MODEL: billing.model,
+    ANTHROPIC_SMALL_FAST_MODEL: billing.model,
+  };
+}
+
 function cleanEnv(env: NodeJS.ProcessEnv | undefined): Record<string, string> | undefined {
   if (!env) return undefined;
   const entries = Object.entries(env).filter(
@@ -22,12 +75,14 @@ export async function makeWorkAgent(
     cwd: string;
     env?: NodeJS.ProcessEnv;
     timeoutMs?: number;
-    /** Bill an API key instead of the local CLI login — required on headless
-     *  runners (sandboxes, CI) where no personal subscription is signed in. */
-    apiKey?: string;
+    /** Who pays. Headless runners (sandboxes, CI) have no CLI login, so
+     *  "none" only works where a personal subscription is signed in. Codex
+     *  agents ignore this — they bill their own auth. */
+    billing?: AgentBilling;
   },
 ): Promise<AgentLike> {
   const { ClaudeCodeAgent, CodexAgent } = await import("smithers-orchestrator");
+  const billing = options.billing ?? { kind: "none" as const };
   const env = cleanEnv(options.env);
   if (kind === "codex") {
     return new CodexAgent({
@@ -38,11 +93,22 @@ export async function makeWorkAgent(
       timeoutMs: options.timeoutMs,
     });
   }
+  if (billing.kind === "openrouter") {
+    // ClaudeCodeAgent merges caller env last, so these overrides survive its
+    // own ANTHROPIC_API_KEY-clearing pass.
+    return new ClaudeCodeAgent({
+      cwd: options.cwd,
+      env: { ...env, ...openrouterAgentEnv(billing) },
+      model: billing.model,
+      permissionMode: "acceptEdits",
+      timeoutMs: options.timeoutMs,
+    });
+  }
   return new ClaudeCodeAgent({
     cwd: options.cwd,
     env,
     permissionMode: "acceptEdits",
     timeoutMs: options.timeoutMs,
-    ...(options.apiKey ? { apiKey: options.apiKey } : {}),
+    ...(billing.kind === "anthropic" ? { apiKey: billing.apiKey } : {}),
   });
 }

--- a/packages/smither/src/artifacts.ts
+++ b/packages/smither/src/artifacts.ts
@@ -1,0 +1,146 @@
+import { execFile } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { CommandRunner } from "./types";
+
+/**
+ * Crate artifact packaging for the result phase. The generated app's file
+ * tree and a small tarball ride the durable result row, so surfaces that
+ * cannot see the run's filesystem (the web BFF observing a sandbox run)
+ * still serve real Files and Download.
+ */
+
+export type CrateFileNode = {
+  path: string;
+  type: "file" | "folder";
+  children?: CrateFileNode[];
+};
+
+const TREE_SKIP = new Set(["target", "node_modules", ".git", "Cargo.lock"]);
+
+/** The generated crate as a display tree. Paths are prefixed with the app
+ *  name ("<app>/src/tool.rs") — the shape the /build page renders. */
+export function crateFileTree(appDir: string, app: string): CrateFileNode[] {
+  const walk = (dir: string, rel: string, depth: number): CrateFileNode[] => {
+    if (depth > 4) return [];
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+    return entries
+      .filter((e) => !TREE_SKIP.has(e.name) && !e.name.startsWith("."))
+      .sort((a, b) =>
+        a.isDirectory() === b.isDirectory()
+          ? a.name.localeCompare(b.name)
+          : a.isDirectory()
+            ? -1
+            : 1,
+      )
+      .map((e) => {
+        const childRel = `${rel}/${e.name}`;
+        return e.isDirectory()
+          ? {
+              path: childRel,
+              type: "folder" as const,
+              children: walk(path.join(dir, e.name), childRel, depth + 1),
+            }
+          : { path: childRel, type: "file" as const };
+      });
+  };
+  if (!existsSync(appDir)) return [];
+  return [{ path: app, type: "folder", children: walk(appDir, app, 0) }];
+}
+
+/** Keep the embedded tarball comfortably under the run's maxOutputBytes
+ *  (executeRun raises it to 4 MB for exactly this row). */
+const MAX_TAR_B64_CHARS = 2_500_000;
+
+/** Plain child_process runner — packaging is a local tar spawn and must not
+ *  depend on the heavier workflow runner stack. Injectable for tests/TUI. */
+const localRunner: CommandRunner = (file, args, options) =>
+  new Promise((resolve) => {
+    execFile(
+      file,
+      args,
+      { cwd: options?.cwd, env: options?.env, maxBuffer: 16 * 1024 * 1024 },
+      (error, stdout, stderr) => {
+        const exitCode =
+          error && typeof (error as { code?: unknown }).code === "number"
+            ? ((error as { code: number }).code)
+            : error
+              ? 1
+              : 0;
+        resolve({ exitCode, stdout: String(stdout), stderr: String(stderr) });
+      },
+    );
+  });
+
+export type CrateArtifact = {
+  /** JSON-encoded CrateFileNode[]; "" when the crate directory is absent. */
+  fileTreeJson: string;
+  /** Base64 .tar.gz of apps/<app> (target/ and Cargo.lock excluded); "" when
+   *  packaging failed or the crate exceeds the embed cap. */
+  crateTarB64: string;
+  /** Human-readable reason whenever crateTarB64 is empty. */
+  warning: string;
+};
+
+export async function packageCrate(options: {
+  sdkRoot: string;
+  app: string;
+  runner?: CommandRunner;
+}): Promise<CrateArtifact> {
+  const appsDir = path.join(options.sdkRoot, "apps");
+  const appDir = path.join(appsDir, options.app);
+  if (!existsSync(appDir)) {
+    return {
+      fileTreeJson: "",
+      crateTarB64: "",
+      warning: `no generated crate at apps/${options.app}`,
+    };
+  }
+  const fileTreeJson = JSON.stringify(crateFileTree(appDir, options.app));
+  const runner = options.runner ?? localRunner;
+  const tmp = mkdtempSync(path.join(tmpdir(), "aomi-crate-"));
+  const tarPath = path.join(tmp, `${options.app}.tar.gz`);
+  try {
+    const tar = await runner("tar", [
+      "-czf",
+      tarPath,
+      "--exclude",
+      "target",
+      "--exclude",
+      "Cargo.lock",
+      "-C",
+      appsDir,
+      options.app,
+    ]);
+    if (tar.exitCode !== 0) {
+      return {
+        fileTreeJson,
+        crateTarB64: "",
+        warning: `tar failed: ${(tar.stderr || tar.stdout).slice(0, 300)}`,
+      };
+    }
+    const crateTarB64 = readFileSync(tarPath).toString("base64");
+    if (crateTarB64.length > MAX_TAR_B64_CHARS) {
+      return {
+        fileTreeJson,
+        crateTarB64: "",
+        warning: `crate too large to embed (${crateTarB64.length} base64 chars > ${MAX_TAR_B64_CHARS})`,
+      };
+    }
+    return { fileTreeJson, crateTarB64, warning: "" };
+  } catch (error) {
+    return {
+      fileTreeJson,
+      crateTarB64: "",
+      warning: `packaging failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}

--- a/packages/smither/src/index.ts
+++ b/packages/smither/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./artifacts";
 export * from "./binaries";
 export * from "./commands";
 export * from "./evals";

--- a/packages/smither/src/run.ts
+++ b/packages/smither/src/run.ts
@@ -149,6 +149,9 @@ export async function executeRun(
       // must not settle between a task finishing and that re-render, or it
       // ends "finished" with unmounted phases still ahead.
       requireRerenderOnOutputChange: true,
+      // The result row embeds the crate artifact (artifacts.ts); the engine's
+      // 200 KB default would reject it for any non-trivial app.
+      maxOutputBytes: 4_000_000,
     }),
   );
 }
@@ -188,6 +191,30 @@ export async function executeRunUntilSettled(
     attempt = { ...attempt, resume: true };
     await new Promise((wake) => setTimeout(wake, options.approvalPollMs ?? 2500));
   }
+}
+
+/**
+ * Narrow raw-SQL door into the run store, for host-app tables that must live
+ * on the same connection (the embedded PGlite backend cannot be opened twice
+ * in one process). Statements use `?` placeholders on every backend — the
+ * storage layer translates for Postgres. Rows come back with on-disk column
+ * names (no snake→camel transform).
+ */
+export async function storeQuery(
+  api: AomiSmitherApi,
+  sql: string,
+  params: unknown[] = [],
+): Promise<Array<Record<string, unknown>>> {
+  const { SmithersDb } = await import("smithers-orchestrator");
+  const adapter = new SmithersDb(api.db as never) as unknown as {
+    internalStorage: {
+      queryAllRaw(
+        sql: string,
+        params?: unknown[],
+      ): Promise<Array<Record<string, unknown>>>;
+    };
+  };
+  return adapter.internalStorage.queryAllRaw(sql, params);
 }
 
 /**

--- a/packages/smither/src/schemas.ts
+++ b/packages/smither/src/schemas.ts
@@ -90,6 +90,13 @@ export const smitherSchemas = {
   result: z.object({
     status: z.enum(["complete", "deploy-denied", "blocked"]),
     summary: z.string(),
+    /** Crate artifact (artifacts.ts): display tree + embedded tarball so
+     *  surfaces without this run's filesystem (web BFF observing a sandbox
+     *  run) serve real Files/Download. Empty when packaging was skipped,
+     *  failed, or over the embed cap — artifactWarning says why. */
+    fileTreeJson: z.string().default(""),
+    crateTarB64: z.string().default(""),
+    artifactWarning: z.string().default(""),
   }),
 };
 

--- a/packages/smither/src/workflow.tsx
+++ b/packages/smither/src/workflow.tsx
@@ -30,6 +30,7 @@ import {
   type SmokeRow,
   type ValidationRow,
 } from "./schemas";
+import { packageCrate } from "./artifacts";
 import { defaultRunner, resolveFreshAomiBinaries } from "./binaries";
 import {
   newAppArgs,
@@ -39,7 +40,7 @@ import {
   runAomiRun,
   runAppCargoChecks,
 } from "./commands";
-import { makeWorkAgent } from "./agents";
+import { makeWorkAgent, resolveAgentBilling } from "./agents";
 import { runEvalStep } from "./evals";
 import { rolePrompt, type PromptContext } from "./prompts";
 import type { CommandRunner, ResolvedBinaries } from "./types";
@@ -174,8 +175,10 @@ export async function buildAppWorkflow(
 
   // One CLI agent instance per distinct (agent, repo) used anywhere in the
   // composition — cross-repo agents run in another codebase entirely.
-  // SMITHER_ANTHROPIC_API_KEY switches claude agents to API billing (headless
-  // runners have no CLI login).
+  // Billing: SMITHER_OPENROUTER_API_KEY (default, cheap Kimi via OpenRouter's
+  // Anthropic-compatible endpoint) > SMITHER_ANTHROPIC_API_KEY (backup) >
+  // local CLI login.
+  const billing = resolveAgentBilling(deps.env);
   const agents = new Map<string, Awaited<ReturnType<typeof makeWorkAgent>>>();
   for (const spec of agentSpecsFor(plan)) {
     agents.set(
@@ -183,7 +186,7 @@ export async function buildAppWorkflow(
       await makeWorkAgent(spec.name, {
         cwd: spec.cwd,
         env: deps.env,
-        apiKey: deps.env?.SMITHER_ANTHROPIC_API_KEY,
+        billing,
       }),
     );
   }
@@ -508,7 +511,7 @@ export async function buildAppWorkflow(
         case "result":
           return (
             <Task id={id(phase.id)} label={label ?? "Summarize run"} output={outputs.result} noRetry>
-              {() => resultStep(plan, { gateDenied, deployment, smoke })}
+              {() => resultStep(plan, { gateDenied, deployment, smoke }, runner)}
             </Task>
           );
       }
@@ -756,23 +759,38 @@ async function deployStep(
   return { ok: true, log: boundedLog(deploy.stdout) };
 }
 
-function resultStep(
+async function resultStep(
   plan: BuildPlan,
   state: {
     gateDenied: boolean;
     deployment: DeploymentRow | undefined;
     smoke: SmokeRow | undefined;
   },
-): ResultRow {
+  runner: CommandRunner,
+): Promise<ResultRow> {
+  // Package the crate into the row either way — a deploy-denied run still
+  // produced reviewable sources.
+  const artifact = await packageCrate({
+    sdkRoot: plan.sdkRoot,
+    app: plan.app,
+    runner,
+  });
+  const artifactFields = {
+    fileTreeJson: artifact.fileTreeJson,
+    crateTarB64: artifact.crateTarB64,
+    artifactWarning: artifact.warning,
+  };
   if (state.gateDenied) {
     return {
       status: "deploy-denied",
       summary: `${plan.app} validated${plan.smoke ? " and smoked" : ""}; deploy was denied at the gate.`,
+      ...artifactFields,
     };
   }
   const shipped = plan.deploy && state.deployment?.ok;
   return {
     status: "complete",
     summary: `${plan.app} ${shipped ? "built, validated, and deployed" : "built and validated"}${plan.smoke && state.smoke?.ok ? " (smoke passed)" : ""}.`,
+    ...artifactFields,
   };
 }

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,109 @@
 
 ## Last Updated
 
+2026-07-20 — /build multi-user + lifecycle fixes (branch
+  claude/build-fe-artifacts, staged, uncommitted). Four design fixes from
+  the FE-gap discussion, all live-verified against the Supabase store:
+  (1) sessions persist runId/app — reloads reattach to live runs and
+  Download survives; localStorage v2. (2) aomi_build_runs registry keyed
+  (owner_login, app) in the run store (registry.ts; created idempotently
+  via new smither storeQuery raw-SQL seam): Alice/arb-bot ≠ Bob/arb-bot,
+  BFF restarts look runs up instead of minting ids (resilience finding #2
+  fixed), plan_json persisted so observers/sandbox runs stop recomposing
+  plans; owner = GitHub login ("dev" when AOMI_BUILD_ALLOW_ANON).
+  (3) system-owned sandbox lifetime: supervisor.ts joins registry rows to
+  the engine heartbeat in _smithers_runs — extends live work, reaps
+  silent-death VMs after 2min grace (the 18:06/$4 zombie class, finding
+  #1) and stale-heartbeat runs (finding #3), releases on settle; ticks via
+  GET /api/bff/build/supervise (CRON_SECRET-guarded — Vercel Cron wiring
+  is Phase-4) + in-process interval on long-lived servers; cancel now
+  flips the registry + stops the sandbox by id even after restarts.
+  (4) live files: infra/build-runner/sidecar.ts (Bun, bearer-auth,
+  path-jailed /tree + /file on exposed port 8722) baked into the image;
+  dispatch launches it; BFF GET /api/bff/build/runs/file serves file
+  contents from local disk → live sidecar → store tarball (minimal ustar
+  reader tar.ts — file contents readable even after the sandbox dies);
+  Files panel is now a click-to-view source browser (dialog in
+  build-view). NOTE: WebSocket ruled out (Vercel Functions can't host WS;
+  SSE relay is the later polish); sidecar needs the next image rebuild to
+  exist in VMs. 83 smither + 286 app tests green; typecheck/lint clean.
+  Live-verified: registry row (dev|geckoterminal|completed|local),
+  resume-not-remint, file route serving real lib.rs, supervise route
+  responding.
+
+  Addendum (Cecilia review): sidecar auth now rides the OFFICIAL
+  service-bearer path instead of a homegrown random-UUID token. The BFF
+  mints a fresh 5-min EdDSA JWT per proxied request via portalService()
+  (PORTAL_SERVICE_PRIVATE_KEY + committed topology; new module
+  apps/aomi-build/src/server/bff/build/sidecar-auth.ts), audience
+  "aomi-sidecar" (added to aomi-bff's audiences in packages/account
+  topology-data.ts and the three aomi-build service.portal*.toml — a
+  leaked bearer is useless at the backend), subject = run id. The sidecar
+  verifies the JWT with WebCrypto Ed25519 against aomi-bff's committed
+  PUBLIC key (AOMI_SIDECAR_PUBKEY env — no secret in the VM), pins
+  iss/aud/sub/exp, fails closed. sidecar_token is gone from the registry
+  (no stored secret anywhere; the Supabase column's DEFAULT '' absorbs
+  omitted inserts). Round-trip + tamper tests in sidecar-auth.test.ts;
+  live-verified: real PORTAL_SERVICE_PRIVATE_KEY (portal .env.local,
+  staging topology) → portalService().mint → sidecar verifyBearer OK,
+  wrong run id rejected. NOTE: apps/portal's service.portal*.toml were
+  NOT touched (portal never mints the sidecar audience) — flag if
+  topology views should stay byte-identical.
+
+2026-07-19 (night, 2nd session) — /build agent billing: OpenRouter is now the
+  DEFAULT, Anthropic the env-only backup (uncommitted, stacked on the
+  build-fe-artifacts working tree). Motivation: first-party Anthropic is too
+  expensive for builder runs. `resolveAgentBilling` (packages/smither/src/
+  agents.ts): SMITHER_OPENROUTER_API_KEY > SMITHER_ANTHROPIC_API_KEY > local
+  CLI login; not user-selectable, pure deployment config. OpenRouter path
+  drives the same claude CLI via OpenRouter's Anthropic-compatible endpoint
+  (https://openrouter.ai/api): ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN +
+  ANTHROPIC_API_KEY pinned "" (never fall back to first-party auth) +
+  ANTHROPIC_MODEL/ANTHROPIC_SMALL_FAST_MODEL both set. Default model
+  moonshotai/kimi-k2.7-code ($0.72/$3.50 per M) — deliberately NOT kimi-k3
+  (July 16 release, but Sonnet-priced $3/$15, defeats the point); override
+  via SMITHER_OPENROUTER_MODEL. dispatchSandboxRun passes both new vars into
+  the microVM; BFF local runner + run-plan CLI already forward process.env.
+  Caveat (OpenRouter's own docs): claude CLI is only *guaranteed* against the
+  Anthropic first-party provider — third-party-model tool-calling fidelity is
+  the risk, and regressions surface as validate-loop maxIterations failures.
+  Cloud verification of a Kimi-billed run still pending (needs the env set on
+  a dispatch). Phase-4 decisions recorded from Cecilia: 5 build chats/apps per
+  user; build tokens NEVER hit the cost dashboard (chat+project only); quotas
+  + sessions live in the separate aomi-build-smither Supabase DB; GitHub login
+  required + invite allowlist; image-SDK sync via GitHub Action (design in
+  convo: images tagged build-runner:sdk-<ver>, repository_dispatch from
+  aomi-sdk release, green-canary gate before activation). SECURITY: an
+  OpenRouter key was pasted into chat — must be rotated before any env setup
+  uses it. Verified: smither build + 83/83, aomi-build type-check + 284/284,
+  lint clean (3 pre-existing warnings).
+
+2026-07-19 (night) — /build FE gap: store-served crate artifacts, hosted
+  store provisioned (branch claude/build-fe-artifacts, uncommitted).
+  Supabase project "aomi-build-smither" (ref ijhknhtjabljnqwmimrv,
+  us-east-1, org aomi) is the hosted smithers store; engine bootstrapped
+  all 25 _smithers_* tables + synced new columns on first connect; URL in
+  apps/aomi-build/.env.smither.local (gitignored; session pooler :5432 —
+  NOT the :6543 transaction pooler). New artifact pipeline: the result
+  phase packages the crate (packages/smither/src/artifacts.ts — file-tree
+  JSON + base64 tar.gz ≤2.5MB, warning on skip; executeRun raises
+  maxOutputBytes to 4MB) into the durable result row; BFF serves Files
+  and Download from the store when the crate isn't on local disk
+  (run-view artifactFromOutputs, engine storedCrateTarball, download
+  route fallback) — sandbox runs get real artifacts. Also: builder
+  passthrough on POST /runs (claude|codex|none; "none" = deterministic
+  pipeline, no LLM), mapper trusts run-level status over stale failed
+  stage rows (cross-attempt resumes), localStorage sessions bumped to v2
+  (v1 TS-mock fiction purged on load). Verified E2E on Supabase:
+  builder:none run green (binaries/codegen/validate/result), artifact row
+  669B tree + 67KB tar, then a fresh observer instance with an EMPTY SDK
+  root served the tree + a decodable 50KB tarball purely from the store —
+  the deployed-Vercel shape. Quota lesson re-confirmed: local claude CLI
+  keychain subscription outranks SMITHER_ANTHROPIC_API_KEY (a geckoterminal
+  run sits waiting-quota in the store; resumable). Cloud sandbox proof of
+  the artifact path needs an image rebuild from a pushed sha — Cecilia's
+  go. 77 smither + 284 app tests green; typecheck/lint clean.
+
 2026-07-19 (evening) — /build sandbox-mode: FULLY GREEN CLOUD RUN.
   `smither-defillama-ea2a9cba…` completed all five stages in a real Vercel
   Sandbox booted from the rust-1.92 image: binaries ✓ codegen (kept
@@ -2361,6 +2464,25 @@ Controls disabled while isProcessing === true
 
 ## Pending
 
+- /build admin visibility page: an admin-only surface into the sandbox +
+  whole build system — live/settled runs across all users (from the
+  aomi-build-smither store + build_sessions), per-run sandbox id/status/
+  extend history, stage timeline + validate-loop iterations, agent billing
+  path + model + token spend per run, quota consumption per user, and
+  cancel/stop controls. (Cecilia, 2026-07-19; gates the staging soak.)
+- /build SDK-sync GitHub Action: build golden images tagged
+  build-runner:sdk-<version> on aomi-sdk release (repository_dispatch →
+  workflow in this repo), push to VCR, wait Ready, dispatch one canary
+  run-plan and require green before the tag goes active; build-staging /
+  build.aomi.dev resolve the image from their backend's SDK version, env
+  pin as override. (Approach approved 2026-07-19.)
+- /build quota + allowlist tables in aomi-build-smither DB: build_sessions
+  (github_login, app slug, run id, status) capped at 5 active per user;
+  invite allowlist table + env bootstrap; global concurrent-sandbox cap.
+  Build tokens stay OUT of the cost dashboard (experimental feature).
+- /build OpenRouter billing: verify one cloud sandbox run billed via
+  SMITHER_OPENROUTER_API_KEY (kimi-k2.7-code) before staging; rotate the
+  chat-pasted OpenRouter key first.
 - Aomi Build SDK-upgrade UX rebuilt (2026-07-16, PR aomi-labs/aomi#366): `use-sdk-upgrade` hook (confirm → open PR → poll-for-merge via the idempotent sdk-upgrade endpoint → merged → redeploy), `upgrade-rail.tsx` (5-step stepper with PLATFORM/YOU/YOU/GITHUB owners, hover hints on every step, build checklist driven by deployFlow), `deployment-detail.tsx` (per-row expansion: source repo / commit / SDK / deployed platform / platform branch / apps / build artifacts — all GitHub-linked; platform-side fields lazy-load from `deploymentHistory`), `hint-bubble.tsx`; `deployments-tab.tsx` wires the CTA swap (Upgrade → Review PR #N), redeploy gating while the PR is open, and the upgrade confirm dialog with don't-ask-again; rail state persists in localStorage per source. 218 tests + typecheck + lint green. Backend path verified against staging (sdk-upgrade for 1586 now returns `current`). Not yet verified against a live signed-in browser session — needs a preview deploy.
 - SDK upgrade 502 masking: FIXED. `SourceRepo::repo_route("")` trailing-slash 404 fixed in product-mono#815 (merged, staging-deployed); the remaining manager 502→500 conversions (OAuth exchange, GitHubAppError::Upstream, ActivationError gateway variants) are in product-mono#826 (open). Cloudflare replaces origin-502 bodies with branded HTML, so handler errors must never use 502/503.
 - Follow-up work spun off (background sessions 2026-07-16): lightweight manager PR-state endpoint to replace the 45s tarball-download merge poll; investigation of stale `app_source` installation bindings (duplicate 141779906/142228159 branches for playground-6).

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,36 @@
 
 ## Last Updated
 
+2026-07-20 — LIVE SANDBOX VERIFICATION GREEN (branch claude/build-fe-artifacts
+  pushed as c0449506; image build-runner:live-1 in VCR under the aomi-build
+  Vercel project, e2e-test untouched; AOMI_REF=c0449506,
+  AOMI_SDK_REF=b3c0c8b). Full chain proven on real infra with app "dune":
+  dispatch → registry row (run id, vercel-sandbox, sandbox name, sidecar
+  url) → sidecar /healthz ok + 403 on missing/bogus bearers → BFF file
+  route served dune/Cargo.toml FROM THE LIVE VM via a per-request
+  portalService() EdDSA bearer → supervise tick "extend" visibly bumped
+  the VM timeout 5→14 min → all five stages completed in ~6.5 min with
+  Kimi curate inside the VM (only SMITHER_OPENROUTER_API_KEY present, so
+  OpenRouter billing is conclusively the path) → supervise "release-
+  completed", registry completed, sandbox stopped → file route fell back
+  to the store tarball after VM death → download served the real 5.4 KB
+  crate tar.gz (Cargo.toml, src/lib.rs, src/tool.rs, test.json).
+  BUG FOUND+FIXED during verification (UNCOMMITTED, needs follow-up
+  commit): @vercel/sandbox identifies sandboxes by `name` — the Sandbox
+  class has NO sandboxId/id getter and Sandbox.get takes {name} — so
+  dispatch stored undefined (NOT NULL violation in the registry, one
+  orphan VM, stopped) and the supervisor/cancel by-id path could never
+  have worked. Fix: adaptSdkSandbox maps name→SandboxLike.sandboxId;
+  Sandbox.get({name, resume:false}) so managing a dead VM never
+  resurrects it; registry INSERT coerces NOT NULL columns. Two orphan
+  runs in the store from the broken first dispatch (smither-dune-a839ce90,
+  status running, dead heartbeat, no registry row — invisible to the
+  supervisor, harmless cruft). Live rig: worktree
+  .claude/worktrees/build-live-verify (detached at c0449506) on :3220 via
+  scratchpad run-build-dev.sh (launch.json entry aomi-build-live-sandbox);
+  staging topology + portal .env.local signing key so sidecar bearers
+  verify.
+
 2026-07-20 — /build multi-user + lifecycle fixes (branch
   claude/build-fe-artifacts, staged, uncommitted). Four design fixes from
   the FE-gap discussion, all live-verified against the Supabase store:


### PR DESCRIPTION
Stacked on #370. Closes the FE gap so /build runs the real aomi-smither engine end-to-end on Vercel Sandboxes — live-verified on real infra (see `specs/STATE.md`, 2026-07-20 entries).

## What's here

**1. Sessions persist `runId`/`app`** — reloads reattach to live runs and resume polling; Download survives reloads. localStorage bumped to v2.

**2. Durable `(owner_login, app)` run registry** (`aomi_build_runs`, in the run store via a raw-SQL `storeQuery` seam): Alice's `arb-bot` and Bob's `arb-bot` are distinct rows/runs/sandboxes; BFF restarts look up run ids instead of minting (fixes resilience finding #2); `plan_json` rides the row so observers and sandboxes use the exact plan.

**3. System-owned sandbox lifetime**: a supervisor joins registry rows to the engine heartbeat — extends live work, reaps silent-death VMs after a 2-min grace (the stale-OIDC zombie class, finding #1), reaps stale heartbeats, releases on settle (finding #3). Ticks via `GET /api/bff/build/supervise` (CRON_SECRET-guarded, for Vercel Cron) plus an in-process interval. Cancel stops sandboxes by id across restarts.

**4. Live files + source viewer**: a bearer-authed, path-jailed sidecar baked into the runner image serves `apps/<app>` on an exposed port; the BFF file route reads local disk → live sidecar → the store's crate tarball (dependency-free ustar reader), so file contents survive VM death. The Files panel becomes a click-to-view source browser; the result phase packages the crate (file tree + tar.gz ≤2.5 MB) into the result row.

**Sidecar auth rides the official service-bearer path**: the BFF mints a fresh 5-min EdDSA JWT per proxied request via `portalService()` (`PORTAL_SERVICE_PRIVATE_KEY` + committed topology; new audience `"aomi-sidecar"` so a leaked bearer is useless at the backend; `sub` = run id), and the in-VM sidecar verifies against aomi-bff's committed **public** key — no secret in the VM or the registry, ever.

**SDK-seam fix found during live verification**: `@vercel/sandbox` identifies sandboxes by `name` (no `sandboxId` getter; `Sandbox.get({name})`) — adapted at the seam, with `resume: false` so managing a dead VM never resurrects it.

## Live verification (real infra, app `dune`, image `build-runner:live-1`)

- dispatch → registry row with sandbox name + sidecar URL
- sidecar: `/healthz` ok; missing/bogus bearer → 403; BFF file route served `dune/Cargo.toml` **from inside the running VM** via a freshly minted bearer
- supervisor: `extend` visibly bumped the VM timeout 5→14 min; `release-completed` after settle; sandbox stopped
- all 5 stages completed in ~6.5 min with Kimi curate in-VM (OpenRouter was the only key present — billing path conclusive)
- after VM death: file route fell back to the store tarball; Download served the real crate tar.gz

Tests: 83 smither + 291 app + 53 account green; typecheck + lint clean.

## Deploy notes

Runner image: `vcr.vercel.com/aomi-labs/aomi-build/build-runner:live-1` (VCR, aomi-build project) — built from this branch @ `c0449506`, `AOMI_SDK_REF=b3c0c8b`. Env + cron wiring for the Vercel project is listed in `infra/build-runner/README.md` plus `CRON_SECRET` for `/api/bff/build/supervise`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)