### PR TITLE
feat(landing): /brand.md — live brand & positioning brief, linked from the llms.txt index

### DIFF
--- a/apps/landing/app/brand.md/route.ts
+++ b/apps/landing/app/brand.md/route.ts
@@ -1,0 +1,31 @@
+const BRIEF_URL = "https://scrum.aomi.dev/marketing/llms.txt?scope=public";
+
+// Served if the generated brief is unreachable — a crawler should always get
+// a 200 with real positioning, never a 5xx.
+const FALLBACK = `# aomi
+
+> Aomi Labs builds the native harness on blockchains.
+
+Aomi turns natural language into real on-chain execution against arbitrary protocols and smart contracts, on any chain, from any wallet. Non-custodial (keys never leave the user), type-checked at compile time, simulated before signing, with account abstraction built in. Also a cloud host for agentic applications — trading bots, prediction-market agents, DeFi assistants — plus a React widget, Telegram & Discord integrations, a Rust SDK, and installable agent skills (\`npx skills add aomi-labs/skills\`). x402 pricing and MPP settlement come out of the box.
+
+- Docs: https://aomi.dev/docs (machine index: https://aomi.dev/llms.txt)
+- Live product: https://chat.aomi.dev
+- Skills: https://github.com/aomi-labs/skills
+`;
+
+export async function GET() {
+  let body: string;
+  try {
+    const res = await fetch(BRIEF_URL, { next: { revalidate: 3600 } });
+    if (!res.ok) throw new Error(`upstream ${res.status}`);
+    body = await res.text();
+  } catch {
+    body = FALLBACK;
+  }
+  return new Response(body, {
+    headers: {
+      "content-type": "text/markdown; charset=utf-8",
+      "cache-control": "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
+    },
+  });
+}

--- a/apps/landing/content/agents/llms.txt
+++ b/apps/landing/content/agents/llms.txt
@@ -74,3 +74,7 @@ Background context for understanding how end-users actually reach Aomi.
 - Skills: https://github.com/aomi-labs/skills
 - Widget + landing: https://github.com/aomi-labs/aomi-widget
 - npm package: https://www.npmjs.com/package/@aomi-labs/client
+
+## Brand & positioning
+
+- [Brand & positioning brief](https://aomi.dev/brand.md): Who Aomi is, canonical positioning and messaging per audience, voice rules, and the design system (tokens, fonts, palette) — generated live from Aomi's canonical brand sources, always current.


### PR DESCRIPTION
## What

Adds `https://aomi.dev/brand.md` — aomi's public marketing/brand brief for AEO (answer-engine optimization), so agents crawling aomi get positioning + brand context alongside the API/docs index.

## Discovery: the existing /llms.txt index is preserved by design

While scoping this, we found `aomi.dev/llms.txt` already serves a deliberate, hand-curated agent index (`content/agents/llms.txt` — agents.md, faq.md, llms-full.txt, docs markdown mirrors). That is the spec-correct `llms.txt`: an index of links, not a content dump. It is intentionally untouched. The brand brief joins the surface as a **linked resource**: a new `## Brand & positioning` section at the end of the index points to `/brand.md`.

## How /brand.md works

- **Live proxy, no drift**: the route fetches `https://scrum.aomi.dev/marketing/llms.txt?scope=public`, which is *generated per-request* from canonical brand sources (MESSAGE.md, TONE.md, design tokens, docs terminology). Nothing is snapshotted into the repo, so the brief can never go stale.
- **Caching**: upstream fetch uses `next: { revalidate: 3600 }` (1h), and the response carries the same `cache-control` policy as the sibling `agents.md` / `faq.md` routes (`s-maxage=3600, stale-while-revalidate=86400`). Served as `text/markdown; charset=utf-8`, matching the siblings.
- **Fallback**: if the upstream fetch fails, the route returns a hardcoded minimal brief with **status 200** — a crawler never sees a 5xx.

## Verification

- Typecheck: the new route passes `tsc --noEmit` against the landing tsconfig (with Next types). Full monorepo build skipped — it's the heavy pnpm-workspace Vercel build; the change is a self-contained route handler with no imports.
- After deploy (preview URL works too):
  - `curl https://aomi.dev/brand.md` → the generated brief ("Aomi Labs builds the native harness on blockchains").
  - `curl https://aomi.dev/llms.txt` → unchanged index, now ending with the "Brand & positioning" section linking /brand.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)