### PR TITLE
Keep model catalog independent of account auth

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -24,6 +24,13 @@ tables; fresh databases also finish replay with that drop.
 
 Progress:
 
+- 2026-07-22 model catalog availability: traced the staging picker's permanent
+  `Loading...` state to Better Auth session-pool exhaustion on the otherwise
+  public `/api/thread/models` proxy route. Marked that catalog route as
+  bearer-independent so it bypasses account database resolution while still
+  stripping browser credentials, added proxy regression coverage, and
+  patch-bumped `@aomi-labs/account` to 0.1.6.
+
 - 2026-07-22 wallet account-access deduplication: hid the legacy `wallet`
   authentication identity from account management, matching the existing
   SIWE/SIWS proof-identity behavior while preserving the branded linked EVM or

--- a/apps/portal/src/app/api/[...slug]/route.ts
+++ b/apps/portal/src/app/api/[...slug]/route.ts
@@ -63,7 +63,7 @@ const ALLOWED_ROUTES: AllowedRoute[] = [
   {
     pattern: /^\/api\/thread\/models$/,
     methods: new Set(["GET"]),
-    auth: "optional",
+    auth: "none",
   },
   {
     pattern: /^\/api\/thread\/model$/,

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/account",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Server-only account graph: resolve-or-create the canonical user and mint AccountBearers. Node-only; never bundle into a browser.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/account/src/proxy.test.ts
+++ b/packages/account/src/proxy.test.ts
@@ -97,6 +97,43 @@ describe("createBackendProxy", () => {
     expect(headers.has("cookie")).toBe(false);
   });
 
+  it("does not resolve a session for bearer-independent public routes", async () => {
+    const fetchMock = vi.fn(async (_input: URL, _init?: RequestInit) =>
+      Response.json(["Gemini 3 Flash"]),
+    );
+    const resolveCanonicalUserId = vi.fn(async () => "user-123");
+    vi.stubGlobal("fetch", fetchMock);
+    const { GET } = createTestProxy({
+      allowedRoutes: [
+        {
+          pattern: /^\/api\/thread\/models$/,
+          methods: new Set(["GET"]),
+          auth: "none",
+        },
+      ],
+      resolveCanonicalUserId,
+    });
+
+    const response = await GET(
+      ...proxyRequest("/api/thread/models", {
+        headers: {
+          authorization: "Bearer user-supplied",
+          cookie: "better-auth.session_token=session",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(["Gemini 3 Flash"]);
+    expect(resolveCanonicalUserId).not.toHaveBeenCalled();
+    expect(mintMock).not.toHaveBeenCalled();
+    const init = fetchMock.mock.calls[0]?.[1];
+    if (!init) throw new Error("Expected upstream fetch init");
+    const headers = new Headers(init.headers);
+    expect(headers.has("authorization")).toBe(false);
+    expect(headers.has("cookie")).toBe(false);
+  });
+
   it("rejects protected routes instead of forwarding without Authorization", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);

--- a/packages/account/src/proxy.ts
+++ b/packages/account/src/proxy.ts
@@ -44,9 +44,10 @@ export type AllowedRoute = {
    * `required` (default) means the proxy must inject a trusted AccountBearer
    * before forwarding. `optional` is for explicitly public backend routes that
    * may be reached anonymously, while still receiving a bearer when a valid
-   * session is present.
+   * session is present. `none` is for bearer-independent public routes that
+   * must not touch the account database at all.
    */
-  auth?: "required" | "optional";
+  auth?: "required" | "optional" | "none";
 };
 
 export type ResolveCanonicalUserId = (
@@ -268,10 +269,10 @@ export function createBackendProxy(config: ProxyConfig) {
     }
 
     const headers = copyRequestHeaders(req);
-    const authState = await resolveProxyAuthState(
-      req,
-      config.resolveCanonicalUserId,
-    );
+    const authState =
+      allowedRoute.auth === "none"
+        ? ({ kind: "anonymous" } as const)
+        : await resolveProxyAuthState(req, config.resolveCanonicalUserId);
     const authResponse = applyProxyAuthState(allowedRoute, authState, headers);
     if (authResponse) return authResponse;
 


### PR DESCRIPTION
## What changed

- add an explicit bearer-independent proxy policy for public routes that must not touch the account database
- apply it to `GET /api/thread/models`
- keep stripping browser cookies and user-supplied authorization before forwarding
- patch-bump `@aomi-labs/account` to `0.1.6`

## Root cause

The model catalog is public, but the portal proxy resolved Better Auth for every request before forwarding it. When Supabase's 15 session-mode clients were exhausted, both catalog requests returned 500 and the picker remained on `Loading...` indefinitely.

## Impact

Model loading no longer depends on Better Auth or the account database. Protected and identity-sensitive routes keep their existing fail-closed behavior.

## Validation

- `pnpm exec vitest run packages/account/src/proxy.test.ts packages/account/test/pool.test.ts` (8 passed)
- `pnpm --filter @aomi-labs/account type-check`
- `pnpm --filter portal test`
- `pnpm --filter portal type-check`
- Vercel production build passed for deployment `dpl_A6eW5eWk5T3iGkW67LUreznZm6QP`
- canonical staging browser picker renders `Auto`
- catalog returns 24 models; 12 concurrent requests with an invalid session cookie all returned HTTP 200 while other auth-dependent routes reproduced pool exhaustion

## Known baseline

`pnpm --filter portal lint` remains red on six pre-existing `origin/main` violations outside this diff (legacy internal anchors and restricted account imports).