### PR TITLE
PR1: Render Build observability from live data

### DIFF
--- a/apps/build/src/features/operate/app-detail-page.test.tsx
+++ b/apps/build/src/features/operate/app-detail-page.test.tsx
@@ -60,6 +60,7 @@ const payload = {
     hourly: {
       chats: [0, 2, 3],
       toolCalls: [1, 4, 5],
+      p95LatencyMs: [800, 1_200, 950],
       transactions: [0, 1, 1],
     },
   },
@@ -112,7 +113,7 @@ describe("AppDetailPage", () => {
       await screen.findByRole("heading", { name: "goal-digger" }),
     ).toBeInTheDocument();
     expect(operateAppDetailFetch).toHaveBeenCalledWith(1586, 77);
-    expect(screen.getByText("Partial example data")).toBeInTheDocument();
+    expect(screen.queryByText("Partial example data")).not.toBeInTheDocument();
     expect(screen.getByText("Conversion funnel · 24h")).toBeInTheDocument();
     expect(screen.getByText(/20 calls · 1 error/)).toBeInTheDocument();
     // Live rows: rejected renders as a failed chip, ISO time as a short clock.

--- a/apps/build/src/features/operate/app-detail-page.tsx
+++ b/apps/build/src/features/operate/app-detail-page.tsx
@@ -82,7 +82,6 @@ export function AppDetailPage({
   return (
     <AppDetailView
       app={view.app}
-      exampleSections={view.exampleSections}
       onBack={() =>
         router.push(
           operateHref("/operate/observability", { project: projectValue }),

--- a/apps/build/src/features/operate/app-detail-view.tsx
+++ b/apps/build/src/features/operate/app-detail-view.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 // Per-app drill-down dashboard shared by the live product route and the fixture
-// design harness. The product adapter marks the few fields that still use a
-// fixture fallback while preserving live backend rows and aggregates.
+// design harness. Product data is rendered as received; empty series are an
+// honest no-data state rather than substituted example values.
 
 import { ArrowLeft, ExternalLink } from "lucide-react";
 import type { AppFixture, TxRecord } from "@build/features/operate/fixtures";
@@ -16,6 +16,16 @@ function BarChart({
   series: Array<{ values: number[]; className: string }>;
   height?: number;
 }) {
+  if (!series.some((item) => item.values.length)) {
+    return (
+      <div
+        className="text-dim flex items-center justify-center text-xs"
+        style={{ height }}
+      >
+        No data in this window.
+      </div>
+    );
+  }
   const max = Math.max(...series.flatMap((s) => s.values), 1);
   const n = Math.max(...series.map((s) => s.values.length), 1);
   const band = 100 / n;
@@ -55,6 +65,16 @@ function LineChart({
   values: number[];
   height?: number;
 }) {
+  if (!values.length) {
+    return (
+      <div
+        className="text-dim flex items-center justify-center text-xs"
+        style={{ height }}
+      >
+        No data in this window.
+      </div>
+    );
+  }
   const max = Math.max(...values, 1);
   const pts = values
     .map(
@@ -150,7 +170,6 @@ export function AppDetailView({
   app,
   displayName,
   example = false,
-  exampleSections = [],
   dashboardHref,
   onBack,
   onOpenTrace,
@@ -159,7 +178,6 @@ export function AppDetailView({
   app: AppFixture;
   displayName?: string;
   example?: boolean;
-  exampleSections?: string[];
   dashboardHref?: string | null;
   onBack: () => void;
   onOpenTrace: (tool: string) => void;
@@ -194,13 +212,6 @@ export function AppDetailView({
                   className="border-border bg-surface-subtle text-dim rounded-full border px-2 py-0.5 text-xs"
                 >
                   Example data
-                </span>
-              ) : exampleSections.length ? (
-                <span
-                  title={`Live backend data with fixture fallbacks for: ${exampleSections.join(", ")}.`}
-                  className="border-border bg-surface-subtle text-dim rounded-full border px-2 py-0.5 text-xs"
-                >
-                  Partial example data
                 </span>
               ) : null}
               <span className="flex items-center gap-1.5 text-xs">
@@ -254,7 +265,10 @@ export function AppDetailView({
         <div className="flex flex-wrap items-stretch gap-0">
           {detail.funnel.map((stage, i) => {
             const prev = i > 0 ? detail.funnel[i - 1].value : null;
-            const conv = prev ? Math.round((stage.value / prev) * 100) : null;
+            const conv =
+              prev && stage.value !== null
+                ? Math.round((stage.value / prev) * 100)
+                : null;
             return (
               <div key={stage.label} className="flex items-center">
                 {i > 0 ? (
@@ -264,7 +278,9 @@ export function AppDetailView({
                   </div>
                 ) : null}
                 <div className="border-border bg-surface-subtle min-w-28 rounded-md border px-4 py-3 text-center">
-                  <div className="text-2xl font-semibold">{stage.value}</div>
+                  <div className="text-2xl font-semibold">
+                    {stage.value ?? "—"}
+                  </div>
                   <div className="text-dim text-xs">{stage.label}</div>
                 </div>
               </div>
@@ -329,7 +345,12 @@ export function AppDetailView({
           <LineChart values={detail.p95Hourly} />
           <div className="text-dim mt-1 flex justify-between text-[10px]">
             <span>00:00</span>
-            <span>peak {Math.max(...detail.p95Hourly)} s</span>
+            <span>
+              peak{" "}
+              {detail.p95Hourly.length
+                ? `${Math.max(...detail.p95Hourly).toFixed(1)} s`
+                : "—"}
+            </span>
             <span>23:00</span>
           </div>
         </Panel>
@@ -348,10 +369,10 @@ export function AppDetailView({
             ]}
           />
           <div className="text-dim mt-1 flex justify-between text-[10px]">
-            <span>{detail.creditsDaily.days[0]}</span>
+            <span>{detail.creditsDaily.days[0] ?? "—"}</span>
             <span>
-              {detail.creditsDaily.days.at(-1)} ·{" "}
-              {detail.creditsDaily.values.at(-1)}
+              {detail.creditsDaily.days.at(-1) ?? "—"} ·{" "}
+              {detail.creditsDaily.values.at(-1) ?? "—"}
             </span>
           </div>
         </Panel>
@@ -379,24 +400,32 @@ export function AppDetailView({
               </tr>
             </thead>
             <tbody className="divide-border divide-y">
-              {detail.tools.map((row) => (
-                <tr
-                  key={row.tool}
-                  onClick={() => onOpenTrace(row.tool)}
-                  className="hover:bg-surface-subtle cursor-pointer"
-                >
-                  <td className="py-2 pr-3 font-mono text-xs">{row.tool}</td>
-                  <td className="py-2 pr-3">{row.calls ?? "—"}</td>
-                  <td className="py-2 pr-3">{row.errors ?? "—"}</td>
-                  <td
-                    className={`py-2 pr-3 font-medium ${row.bad ? "text-red-500" : ""}`}
+              {detail.tools.length ? (
+                detail.tools.map((row) => (
+                  <tr
+                    key={row.tool}
+                    onClick={() => onOpenTrace(row.tool)}
+                    className="hover:bg-surface-subtle cursor-pointer"
                   >
-                    {row.errorRate}
+                    <td className="py-2 pr-3 font-mono text-xs">{row.tool}</td>
+                    <td className="py-2 pr-3">{row.calls ?? "—"}</td>
+                    <td className="py-2 pr-3">{row.errors ?? "—"}</td>
+                    <td
+                      className={`py-2 pr-3 font-medium ${row.bad ? "text-red-500" : ""}`}
+                    >
+                      {row.errorRate}
+                    </td>
+                    <td className="py-2 pr-3">{row.p95}</td>
+                    <td className="text-dim py-2 text-xs">{row.last}</td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={6} className="text-dim py-6 text-center text-sm">
+                    No tool calls in this window.
                   </td>
-                  <td className="py-2 pr-3">{row.p95}</td>
-                  <td className="text-dim py-2 text-xs">{row.last}</td>
                 </tr>
-              ))}
+              )}
             </tbody>
           </table>
         </div>
@@ -477,24 +506,30 @@ export function AppDetailView({
           </Panel>
           <Panel title="Releases">
             <div className="space-y-2 text-sm">
-              {detail.releases.map((release) => (
-                <div
-                  key={release.tag}
-                  className="flex items-center justify-between gap-2"
-                >
-                  <span className="min-w-0 truncate font-mono text-xs">
-                    {release.tag}
-                  </span>
-                  <span className="text-dim text-xs">{release.when}</span>
-                  {release.current ? (
-                    <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-xs text-emerald-500">
-                      current
+              {detail.releases.length ? (
+                detail.releases.map((release) => (
+                  <div
+                    key={release.tag}
+                    className="flex items-center justify-between gap-2"
+                  >
+                    <span className="min-w-0 truncate font-mono text-xs">
+                      {release.tag}
                     </span>
-                  ) : (
-                    <span className="text-dim text-xs">{release.note}</span>
-                  )}
+                    <span className="text-dim text-xs">{release.when}</span>
+                    {release.current ? (
+                      <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-xs text-emerald-500">
+                        current
+                      </span>
+                    ) : (
+                      <span className="text-dim text-xs">{release.note}</span>
+                    )}
+                  </div>
+                ))
+              ) : (
+                <div className="text-dim py-2 text-center text-sm">
+                  No release history.
                 </div>
-              ))}
+              )}
             </div>
           </Panel>
         </div>

--- a/apps/build/src/features/operate/fixtures/types.ts
+++ b/apps/build/src/features/operate/fixtures/types.ts
@@ -98,9 +98,14 @@ export type AppCard = {
 };
 
 export type AppDetail = {
-  funnel: Array<{ label: string; value: number }>;
+  funnel: Array<{ label: string; value: number | null }>;
   funnelNote: string[];
-  kpis: Array<{ label: string; value: string; sub?: string; tone?: "bad" | "warn" }>;
+  kpis: Array<{
+    label: string;
+    value: string;
+    sub?: string;
+    tone?: "bad" | "warn";
+  }>;
   chatsHourly: number[];
   toolCallsHourly: number[];
   p95Hourly: number[];
@@ -109,7 +114,12 @@ export type AppDetail = {
   toolsSummary: string;
   fees24h: string;
   lifecycle: Array<[string, string]>;
-  releases: Array<{ tag: string; when: string; current: boolean; note: string }>;
+  releases: Array<{
+    tag: string;
+    when: string;
+    current: boolean;
+    note: string;
+  }>;
 };
 
 /** Mirrors the manager's statement wire (subjects, raw USD floats). */

--- a/apps/build/src/features/operate/live-app-detail.test.ts
+++ b/apps/build/src/features/operate/live-app-detail.test.ts
@@ -58,6 +58,7 @@ const livePayload = (): LiveAppDetailPayload => ({
     hourly: {
       chats: [0, 2, 3],
       toolCalls: [1, 4, 5],
+      p95LatencyMs: [800, 1_200, 950],
       transactions: [0, 1, 1],
     },
   },
@@ -178,13 +179,10 @@ describe("liveAppDetailView", () => {
         thread: "thread-real",
       }),
     ]);
-    expect(view.exampleSections).toEqual([
-      "Release history",
-      "P95 latency history",
-    ]);
+    expect(view.app.detail.p95Hourly).toEqual([0.8, 1.2, 0.95]);
   });
 
-  it("labels every fixture-backed section when the backend has no value", () => {
+  it("renders missing backend values as empty or unavailable, never fixtures", () => {
     const payload = livePayload();
     payload.detail.funnel.chats24h = null;
     payload.detail.activeUsers24h = null;
@@ -197,6 +195,7 @@ describe("liveAppDetailView", () => {
     payload.detail.hourly = {
       chats: null,
       toolCalls: null,
+      p95LatencyMs: null,
       transactions: null,
     };
     payload.health = null;
@@ -205,37 +204,23 @@ describe("liveAppDetailView", () => {
 
     const view = liveAppDetailView(payload);
 
-    expect(view.exampleSections).toEqual(
-      expect.arrayContaining([
-        "Conversion funnel",
-        "Chain families",
-        "Tool health",
-        "Release history",
-        "P95 latency history",
-        "Activity history",
-        "Credit history",
-        "User activity",
-        "Credit KPIs",
-        "Latency KPI",
-        "Inflight KPI",
-        "Error KPIs",
-      ]),
-    );
-    // Fallback KPI values must belong to their labels (fixture order differs
-    // from the live KPI order, so an index lookup would scramble them).
+    expect(view.app.detail.funnel[0]?.value).toBeNull();
+    expect(view.app.meta.families).toEqual([]);
+    expect(view.app.detail.tools).toEqual([]);
+    expect(view.app.detail.p95Hourly).toEqual([]);
     expect(
       Object.fromEntries(
         view.app.detail.kpis.map((kpi) => [kpi.label, kpi.value]),
       ),
     ).toMatchObject({
-      "Active users": "9",
-      Credits: "3.42",
+      "Active users": "—",
+      Credits: "—",
       "Credits / turn": "—",
-      "P95 latency": "8.4 s",
-      Inflight: "2",
-      "Chat errors": "2.5%",
-      "Tool errors": "12.0%",
-      "Tx failures": "8.3%",
+      "P95 latency": "—",
+      Inflight: "—",
+      "Chat errors": "—",
+      "Tool errors": "—",
+      "Tx failures": "—",
     });
     expect(view.app.transactions).toEqual([]);
     expect(view.app.logs).toEqual([]);

--- a/apps/build/src/features/operate/live-app-detail.ts
+++ b/apps/build/src/features/operate/live-app-detail.ts
@@ -5,14 +5,12 @@ import type {
   OperateTransaction,
   UserSourceLatestDeployment,
 } from "@aomi-labs/deploy";
-import {
-  FIXTURES,
-  appFixture,
-  type AppFixture,
-  type ChainFamily,
-  type LogRecord,
-  type TxRecord,
-} from "./fixtures";
+import type {
+  AppFixture,
+  ChainFamily,
+  LogRecord,
+  TxRecord,
+} from "./fixtures/types";
 import type { TxStatus } from "./fixtures/types";
 
 export type LiveAppDetailPayload = {
@@ -25,7 +23,6 @@ export type LiveAppDetailPayload = {
 
 export type LiveAppDetailView = {
   app: AppFixture;
-  exampleSections: string[];
 };
 
 const finite = (value: unknown): value is number =>
@@ -59,20 +56,6 @@ function txStatus(status: string): TxStatus {
     return "failed";
   return "created";
 }
-
-// The fixture KPI labels differ slightly from the live view's ("P95 turn"
-// vs "P95 latency"; the fixtures have no per-turn credits KPI at all), so a
-// fallback value must be looked up by its matching label — never by index —
-// or degraded cards render fixture values under the wrong labels.
-const FIXTURE_KPI_LABEL: Record<string, string> = {
-  "Active users": "Active users",
-  Credits: "Credits",
-  "P95 latency": "P95 turn",
-  Inflight: "Inflight",
-  "Chat errors": "Chat errors",
-  "Tool errors": "Tool errors",
-  "Tx failures": "Tx failures",
-};
 
 function transactionRow(tx: OperateTransaction, app: string): TxRecord {
   const family: ChainFamily =
@@ -178,28 +161,6 @@ export function liveAppDetailView(
   payload: LiveAppDetailPayload,
 ): LiveAppDetailView {
   const detail = payload.detail;
-  const fallback = appFixture(detail.app.name) ?? FIXTURES[0];
-  const example = new Set<string>();
-  const fallbackNumber = (
-    value: number | null,
-    replacement: number,
-    section: string,
-  ) => {
-    if (finite(value)) return value;
-    example.add(section);
-    return replacement;
-  };
-  const fallbackKpi = (label: string, value: string, section: string) => {
-    if (value !== "—") return value;
-    const fixtureLabel = FIXTURE_KPI_LABEL[label];
-    const fixtureValue = fixtureLabel
-      ? fallback.detail.kpis.find((kpi) => kpi.label === fixtureLabel)?.value
-      : undefined;
-    // No matching fixture KPI: an honest dash, not somebody else's number.
-    if (fixtureValue === undefined) return "—";
-    example.add(section);
-    return fixtureValue;
-  };
 
   const funnelValues = [
     detail.funnel.chats24h,
@@ -217,18 +178,13 @@ export function liveAppDetailView(
   ];
   const funnel = funnelLabels.map((label, index) => ({
     label,
-    value: fallbackNumber(
-      funnelValues[index] ?? null,
-      fallback.detail.funnel[index]?.value ?? 0,
-      "Conversion funnel",
-    ),
+    value: funnelValues[index] ?? null,
   }));
 
   const transactions = payload.transactions.map((tx) =>
     transactionRow(tx, detail.app.name),
   );
   const families = [...new Set(transactions.map((tx) => tx.family))];
-  if (!families.length) example.add("Chain families");
 
   const health = payload.health?.metrics;
   const activeUsers = numberLabel(detail.activeUsers24h);
@@ -251,33 +207,21 @@ export function liveAppDetailView(
       : "—",
     bad: finite(tool.errorRate) && tool.errorRate >= 0.1,
   }));
-  if (!realTools.length) example.add("Tool health");
-
   const realReleases = releases(payload);
-  if (!realReleases.length) example.add("Release history");
-
-  // The backend has no per-hour p95 series yet, so that chart is always
-  // fixture data (`p95Hourly: fallback...` below).
-  example.add("P95 latency history");
-  const chatsHourly = detail.hourly.chats ?? fallback.detail.chatsHourly;
-  const toolCallsHourly =
-    detail.hourly.toolCalls ?? fallback.detail.toolCallsHourly;
-  if (!detail.hourly.chats || !detail.hourly.toolCalls) {
-    example.add("Activity history");
-  }
+  const chatsHourly = detail.hourly.chats ?? [];
+  const toolCallsHourly = detail.hourly.toolCalls ?? [];
   const creditsDaily = detail.credits.creditsDaily.length
     ? {
         days: detail.credits.creditsDaily.map((row) => row.day),
         values: detail.credits.creditsDaily.map((row) => row.credits),
       }
-    : fallback.detail.creditsDaily;
-  if (!detail.credits.creditsDaily.length) example.add("Credit history");
+    : { days: [], values: [] };
 
   const app: AppFixture = {
     meta: {
       name: detail.app.name,
       applicationId: detail.app.applicationId,
-      families: families.length ? families : fallback.meta.families,
+      families,
       releaseTag: detail.app.releaseTag,
       sdkVersion: detail.app.sdkVersion,
       status:
@@ -286,7 +230,7 @@ export function liveAppDetailView(
         detail.app.status === "inactive"
           ? detail.app.status
           : "inactive",
-      repo: detail.source.repositoryLink ?? fallback.meta.repo,
+      repo: detail.source.repositoryLink ?? "—",
     },
     card: {
       requestsPerMinute: health?.requestsPerMinute ?? null,
@@ -313,48 +257,48 @@ export function liveAppDetailView(
       kpis: [
         {
           label: "Active users",
-          value: fallbackKpi("Active users", activeUsers, "User activity"),
+          value: activeUsers,
           sub: "24h",
         },
         {
           label: "Credits",
-          value: fallbackKpi("Credits", credits24h, "Credit KPIs"),
+          value: credits24h,
           sub: "24h",
         },
         {
           label: "Credits / turn",
-          value: fallbackKpi("Credits / turn", creditsPerTurn, "Credit KPIs"),
+          value: creditsPerTurn,
           sub: "24h",
         },
         {
           label: "P95 latency",
-          value: fallbackKpi("P95 latency", p95, "Latency KPI"),
+          value: p95,
         },
         {
           label: "Inflight",
-          value: fallbackKpi("Inflight", inflight, "Inflight KPI"),
+          value: inflight,
         },
         {
           label: "Chat errors",
-          value: fallbackKpi("Chat errors", chatErrors, "Error KPIs"),
+          value: chatErrors,
         },
         {
           label: "Tool errors",
-          value: fallbackKpi("Tool errors", toolErrors, "Error KPIs"),
+          value: toolErrors,
         },
         {
           label: "Tx failures",
-          value: fallbackKpi("Tx failures", txFailures, "Error KPIs"),
+          value: txFailures,
         },
       ],
       chatsHourly,
       toolCallsHourly,
-      p95Hourly: fallback.detail.p95Hourly,
+      p95Hourly: (detail.hourly.p95LatencyMs ?? []).map(
+        (value) => value / 1000,
+      ),
       creditsDaily,
-      tools: realTools.length ? realTools : fallback.detail.tools,
-      toolsSummary: realTools.length
-        ? toolsSummaryLabel(realTools)
-        : fallback.detail.toolsSummary,
+      tools: realTools,
+      toolsSummary: toolsSummaryLabel(realTools),
       fees24h: "receipt fees shown per transaction",
       lifecycle: [
         ["Cold start", durationLabel(detail.lifecycle.coldStartMs)],
@@ -362,12 +306,12 @@ export function liveAppDetailView(
         ["Loaded instances", numberLabel(detail.lifecycle.loads24h)],
         ["Evictions", numberLabel(detail.lifecycle.evictions24h)],
       ],
-      releases: realReleases.length ? realReleases : fallback.detail.releases,
+      releases: realReleases,
     },
     transactions,
     logs: payload.logs.map((row) => logRow(row, detail.app.name)),
-    statement: fallback.statement,
+    statement: { revenue: [], charges: [], entries: [] },
   };
 
-  return { app, exampleSections: [...example] };
+  return { app };
 }

--- a/apps/build/src/server/bff/operate/routes.test.ts
+++ b/apps/build/src/server/bff/operate/routes.test.ts
@@ -364,8 +364,8 @@ describe("operateUsageRoute statement fallback", () => {
   });
 });
 
-describe("operateObservabilityRoute trend fallback", () => {
-  it("grafts example 24h trends onto a live card; real metrics win", async () => {
+describe("operateObservabilityRoute live data", () => {
+  it("keeps a partial live card partial instead of grafting example trends", async () => {
     setSession({ githubUserId: "gh-1" });
     oneSource();
     client.getUserSourceObservability.mockResolvedValue({
@@ -384,7 +384,7 @@ describe("operateObservabilityRoute trend fallback", () => {
           active: true,
           loaded: true,
           status: "healthy",
-          // Live window metrics, but NO 24h trend fields.
+          // Live window metrics, but no 24h trend fields yet.
           metrics: {
             provider: "grafana_prometheus",
             windowSeconds: 900,
@@ -402,17 +402,17 @@ describe("operateObservabilityRoute trend fallback", () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body.example).toBe(true);
+    expect(body.example).toBeUndefined();
     const card = body.apps.find(
       (a: { application: string }) => a.application === "real-bot",
     );
     expect(card.metrics.errorRate).toBe(0.5); // real value preserved
     expect(card.metrics.p95LatencyMs).toBe(1234); // real value preserved
-    expect(card.metrics.chats24h).toBeGreaterThan(0); // example filled
-    expect(card.metrics.chatsHourly.length).toBe(24); // example filled
+    expect(card.metrics.chats24h).toBeUndefined();
+    expect(card.metrics.chatsHourly).toBeUndefined();
   });
 
-  it("serves full example cards when the account has no live apps", async () => {
+  it("returns an empty app list when the account has no live apps", async () => {
     setSession({ githubUserId: "gh-1" });
     oneSource();
     client.getUserSourceObservability.mockResolvedValue({
@@ -429,9 +429,9 @@ describe("operateObservabilityRoute trend fallback", () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body.example).toBe(true);
-    expect(body.apps.length).toBeGreaterThanOrEqual(3);
-    expect(body.monitoring.status).toBe("example");
+    expect(body.example).toBeUndefined();
+    expect(body.apps).toEqual([]);
+    expect(body.monitoring.status).toBe("unconfigured");
   });
 });
 

--- a/apps/build/src/server/bff/operate/routes.ts
+++ b/apps/build/src/server/bff/operate/routes.ts
@@ -15,9 +15,7 @@ import type {
 import { checkRateLimit, getClientIp } from "@build/lib/rate-limit";
 import {
   EXAMPLE_SOURCE,
-  exampleAppCards,
   exampleStatement,
-  withExampleTrends,
 } from "@build/features/operate/fixtures/wire";
 import { deploymentClient } from "@build/server/bff/backend";
 import { getGitHubSession } from "@build/server/cookies/github";
@@ -536,41 +534,26 @@ export async function operateObservabilityRoute(req: Request) {
           appSourceId: source.id,
         }),
     );
-    // Until the manager emits the 24h trend fields, fill them from the
-    // example fixtures: live cards keep every metric the backend reported
-    // (real values win per field), and an account with no apps at all gets
-    // the full example cards. Either fill flags the payload `example: true`.
-    const live = results.flatMap((result) =>
+    const apps = results.flatMap((result) =>
       result.apps.map((app) => ({
         ...app,
         source: result.source,
         platform: result.platform,
       })),
     );
-    const { apps, filled } = withExampleTrends(live);
-    const noLiveApps = apps.length === 0;
     return NextResponse.json({
       sources: results.map((result) => result.source),
       scope: "owned_applications",
-      example: filled || noLiveApps ? true : undefined,
-      monitoring: noLiveApps
-        ? {
-            provider: "grafana_prometheus",
-            status: "example",
-            windowSeconds: 900,
-          }
-        : {
-            provider: "grafana_prometheus",
-            status: results.some((result) => result.monitoring?.status === "ok")
-              ? results.some((result) => result.monitoring?.status !== "ok")
-                ? "partial"
-                : "ok"
-              : (results[0]?.monitoring?.status ?? "unconfigured"),
-            windowSeconds: results[0]?.monitoring?.windowSeconds ?? 0,
-          },
-      apps: noLiveApps
-        ? exampleAppCards(owned.sources[0] ?? EXAMPLE_SOURCE)
-        : apps,
+      monitoring: {
+        provider: "grafana_prometheus",
+        status: results.some((result) => result.monitoring?.status === "ok")
+          ? results.some((result) => result.monitoring?.status !== "ok")
+            ? "partial"
+            : "ok"
+          : (results[0]?.monitoring?.status ?? "unconfigured"),
+        windowSeconds: results[0]?.monitoring?.windowSeconds ?? 0,
+      },
+      apps,
       dashboardLinks: results.flatMap((result) => result.dashboardLinks),
       platformMetrics: results[0]?.platformMetrics ?? [],
     });

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/deploy",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "TypeScript toolkit for the Aomi platform deploy API: server client, drop-in BFF route factories, and a browser launch client. Root and ./bff entries are server-only.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/deploy/src/client.ts
+++ b/packages/deploy/src/client.ts
@@ -2183,6 +2183,7 @@ function camelOperateAppDetail(
     hourly: {
       chats: series(hourly.chats),
       toolCalls: series(hourly.tool_calls ?? hourly.toolCalls),
+      p95LatencyMs: series(hourly.p95_latency_ms ?? hourly.p95LatencyMs),
       transactions: series(hourly.transactions),
     },
   };

--- a/packages/deploy/src/types.ts
+++ b/packages/deploy/src/types.ts
@@ -876,8 +876,7 @@ export interface OperateAppMetrics {
   errorRate: number | null;
   p95LatencyMs: number | null;
   inflightRequests: number | null;
-  // 24h trend contract. Null until the manager emits grouped
-  // query_range reads; the card falls back to the live tiles.
+  /** 24h trend contract, oldest bucket first. */
   trendWindowSeconds: number | null;
   chats24h: number | null;
   toolCalls24h: number | null;
@@ -971,6 +970,8 @@ export interface OperateAppDetailResult {
   hourly: {
     chats: number[] | null;
     toolCalls: number[] | null;
+    /** Per-hour chat request P95, in milliseconds. */
+    p95LatencyMs: number[] | null;
     transactions: number[] | null;
   };
 }

--- a/packages/deploy/test/client.test.ts
+++ b/packages/deploy/test/client.test.ts
@@ -601,6 +601,7 @@ describe("DeploymentClient operate app detail", () => {
         hourly: {
           chats: [0, 2, 3],
           tool_calls: [1, 4, 5],
+          p95_latency_ms: [800, 1200, 950],
           transactions: [0, 1, 1],
         },
       }),
@@ -624,7 +625,11 @@ describe("DeploymentClient operate app detail", () => {
       activeUsers24h: 5,
       credits: { credits24h: 8.5, creditsPerTurn24h: 0.71 },
       lifecycle: { coldStartMs: 1250, loads24h: 2 },
-      hourly: { chats: [0, 2, 3], toolCalls: [1, 4, 5] },
+      hourly: {
+        chats: [0, 2, 3],
+        toolCalls: [1, 4, 5],
+        p95LatencyMs: [800, 1200, 950],
+      },
     });
     expect(result.tools[0]).toEqual({
       tool: "get_price",


### PR DESCRIPTION
## Summary

- Extend the deploy contract with hourly P95 latency.
- Remove observability fixture injection from the BFF and detail adapter.
- Render explicit empty states when live data is unavailable.
 
## Verification
- pnpm exec vitest run packages/deploy/test/client.test.ts\n- pnpm --filter aomi-build exec vitest run --config vitest.config.ts src/features/operate/live-app-detail.test.ts src/features/operate/app-detail-page.test.tsx src/server/bff/operate/routes.test.ts\n- pnpm --filter aomi-build type-check