### PR TITLE
Make npm publishing idempotent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
     needs: build-and-lint
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    concurrency:
+      group: npm-publish-${{ github.ref }}
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -91,21 +94,21 @@ jobs:
         run: pnpm run build:deploy
 
       - name: Publish @aomi-labs/client
-        run: pnpm --filter @aomi-labs/client publish --access public --no-git-checks
+        run: node scripts/publish-package-if-needed.mjs packages/client
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @aomi-labs/deploy
-        run: pnpm --filter @aomi-labs/deploy publish --access public --no-git-checks
+        run: node scripts/publish-package-if-needed.mjs packages/deploy
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @aomi-labs/react
-        run: pnpm --filter @aomi-labs/react publish --access public --no-git-checks
+        run: node scripts/publish-package-if-needed.mjs packages/react
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @aomi-labs/widget-lib
-        run: pnpm --filter @aomi-labs/widget-lib publish --access public --no-git-checks
+        run: node scripts/publish-package-if-needed.mjs apps/shadcn-registry
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/GOAL.md
+++ b/GOAL.md
@@ -26,6 +26,11 @@ tables; fresh databases also finish replay with that drop.
 
 Progress:
 
+- 2026-07-24 idempotent npm publishing: changed the post-merge publish job to
+  skip exact package versions that are already live, publish only missing
+  versions, and fail closed on registry errors other than a definitive 404.
+  This makes reruns safe after partial publication or transient npm outages.
+
 - 2026-07-24 atomic account ownership: split provider sign-in from authenticated
   linking and preflight every verified provider, email, BetterAuth, EVM, and
   Solana signal under one transaction before creating or attaching canonical

--- a/packages/client/test/publish-package-if-needed.test.mjs
+++ b/packages/client/test/publish-package-if-needed.test.mjs
@@ -1,0 +1,71 @@
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { publishPackageIfNeeded } from "../../../scripts/publish-package-if-needed.mjs";
+
+const packageDirectory = path.resolve("packages/client");
+
+describe("publishPackageIfNeeded", () => {
+  it("skips an exact version that is already published", async () => {
+    const publishImpl = vi.fn();
+
+    await expect(
+      publishPackageIfNeeded(packageDirectory, {
+        fetchImpl: vi.fn(async () => new Response(null, { status: 200 })),
+        publishImpl,
+      }),
+    ).resolves.toBe("skipped");
+
+    expect(publishImpl).not.toHaveBeenCalled();
+  });
+
+  it("publishes when the exact version is absent", async () => {
+    const publishImpl = vi.fn(async () => undefined);
+
+    await expect(
+      publishPackageIfNeeded(packageDirectory, {
+        fetchImpl: vi.fn(async () => new Response(null, { status: 404 })),
+        publishImpl,
+      }),
+    ).resolves.toBe("published");
+
+    expect(publishImpl).toHaveBeenCalledWith("@aomi-labs/client");
+  });
+
+  it("fails closed on registry errors instead of guessing that a version is missing", async () => {
+    const publishImpl = vi.fn();
+
+    await expect(
+      publishPackageIfNeeded(packageDirectory, {
+        fetchImpl: vi.fn(
+          async () =>
+            new Response("Service Unavailable", {
+              status: 503,
+            }),
+        ),
+        publishImpl,
+      }),
+    ).rejects.toThrow(
+      "Registry check for @aomi-labs/client@0.3.9 failed with HTTP 503",
+    );
+
+    expect(publishImpl).not.toHaveBeenCalled();
+  });
+
+  it("accepts a concurrent publish after its own publish attempt fails", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    await expect(
+      publishPackageIfNeeded(packageDirectory, {
+        fetchImpl,
+        publishImpl: vi.fn(async () => {
+          throw new Error("version already exists");
+        }),
+      }),
+    ).resolves.toBe("published");
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});

--- a/scripts/publish-package-if-needed.mjs
+++ b/scripts/publish-package-if-needed.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_REGISTRY_URL = "https://registry.npmjs.org";
+
+export async function publishPackageIfNeeded(
+  packageDirectory,
+  {
+    fetchImpl = globalThis.fetch,
+    publishImpl = publishWithPnpm,
+    registryUrl = process.env.NPM_CONFIG_REGISTRY ??
+      process.env.npm_config_registry ??
+      DEFAULT_REGISTRY_URL,
+  } = {},
+) {
+  const manifestPath = path.resolve(packageDirectory, "package.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  const packageSpec = `${manifest.name}@${manifest.version}`;
+  const versionUrl = [
+    registryUrl.replace(/\/+$/, ""),
+    encodeURIComponent(manifest.name).replace(/^%40/, "@"),
+    encodeURIComponent(manifest.version),
+  ].join("/");
+  const isPublished = () =>
+    checkPublishedVersion({ fetchImpl, packageSpec, versionUrl });
+
+  if (await isPublished()) {
+    console.log(`${packageSpec} is already published; skipping.`);
+    return "skipped";
+  }
+
+  console.log(`${packageSpec} is not published; publishing now.`);
+  try {
+    await publishImpl(manifest.name);
+  } catch (error) {
+    // A concurrent run may publish after our initial 404, or npm may accept a
+    // PUT but return a transient error. Treat the package's durable registry
+    // state as authoritative before failing the job.
+    if (await isPublished()) {
+      console.log(`${packageSpec} is now published; continuing.`);
+      return "published";
+    }
+    throw error;
+  }
+  return "published";
+}
+
+async function checkPublishedVersion({ fetchImpl, packageSpec, versionUrl }) {
+  let response;
+  try {
+    response = await fetchImpl(versionUrl, {
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (error) {
+    throw new Error(
+      `Could not check whether ${packageSpec} is published: ${error instanceof Error ? error.message : error}`,
+    );
+  }
+
+  if (response.ok) return true;
+  if (response.status === 404) return false;
+
+  const detail = (await response.text()).trim().slice(0, 500);
+  throw new Error(
+    `Registry check for ${packageSpec} failed with HTTP ${response.status}${detail ? `: ${detail}` : ""}`,
+  );
+}
+
+function publishWithPnpm(packageName) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      "pnpm",
+      [
+        "--filter",
+        packageName,
+        "publish",
+        "--access",
+        "public",
+        "--no-git-checks",
+      ],
+      { stdio: "inherit" },
+    );
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `pnpm publish for ${packageName} failed${signal ? ` with signal ${signal}` : ` with exit code ${code}`}`,
+        ),
+      );
+    });
+  });
+}
+
+async function main() {
+  const packageDirectory = process.argv[2];
+  if (!packageDirectory) {
+    throw new Error(
+      "Usage: node scripts/publish-package-if-needed.mjs <package-directory>",
+    );
+  }
+  await publishPackageIfNeeded(packageDirectory);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

- make the post-merge npm publisher skip exact versions already present in the registry
- publish only versions that receive a definitive 404 from npm
- fail closed on registry/network errors instead of treating them as missing packages
- serialize publish jobs and reconcile ambiguous/concurrent publish outcomes against npm's durable state

## Root cause

The post-merge run for PR #386 hit an npm 503 while publishing `@aomi-labs/client@0.3.9`. A blind job rerun was unsafe because client, deploy, and React versions were already published, while only `@aomi-labs/widget-lib@1.4.12` was missing.

## Verification

- 832 repository tests passed (28 skipped)
- root ESLint passed
- publisher unit tests cover existing, missing, 503, and concurrent/ambiguous publish cases
- live npm checks skip client `0.3.9`, deploy `0.2.2`, and React `0.5.4`, while detecting widget-lib `1.4.12` as missing without publishing it locally
- Prettier and `git diff --check` passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787483781&installation_model_id=12362&pr_number=387&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F387&signature=44b572bd77ccf95178747c76ca2ea0b319967c7e7b1c0f40cb9a5f14fdb2ff40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->