### PR TITLE
Show backend system notices in chat

### DIFF
--- a/packages/react/src/runtime/__tests__/utils.test.ts
+++ b/packages/react/src/runtime/__tests__/utils.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { toInboundMessage } from "../utils";
+
+describe("toInboundMessage", () => {
+  it("renders backend credit errors as an actionable assistant notice", () => {
+    const message = toInboundMessage({
+      sender: "system",
+      content:
+        "Completion credit budget is exhausted. Please add credits and try again.",
+      tool_result: null,
+      timestamp: "2026-07-25T23:26:40Z",
+      is_streaming: false,
+    });
+
+    expect(message).toMatchObject({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Completion credit budget is exhausted. Please add credits and try again.",
+        },
+      ],
+      metadata: {
+        custom: {
+          aomiNoticeKind: "payment_required",
+          aomiNoticeTitle: "Credits needed",
+        },
+      },
+    });
+  });
+
+  it("keeps non-credit system messages visible as notices", () => {
+    const message = toInboundMessage({
+      sender: "system",
+      content: "The requested operation could not be completed.",
+      tool_result: null,
+      timestamp: "2026-07-25T23:26:40Z",
+      is_streaming: false,
+    });
+
+    expect(message).toMatchObject({
+      role: "assistant",
+      metadata: {
+        custom: {
+          aomiNoticeKind: "system_notice",
+          aomiNoticeTitle: "System notice",
+        },
+      },
+    });
+  });
+});

--- a/packages/react/src/runtime/utils.ts
+++ b/packages/react/src/runtime/utils.ts
@@ -48,8 +48,6 @@ type MessageContentPart =
     : never;
 
 export function toInboundMessage(msg: AomiMessage): ThreadMessageLike | null {
-  if (msg.sender === "system") return null;
-
   const content: MessageContentPart[] = [];
   const role: ThreadMessageLike["role"] =
     msg.sender === "user" ? "user" : "assistant";
@@ -83,9 +81,25 @@ export function toInboundMessage(msg: AomiMessage): ThreadMessageLike | null {
     role,
     content: content as ThreadMessageLike["content"],
     ...(msg.timestamp && { createdAt: new Date(msg.timestamp) }),
+    ...(msg.sender === "system" && {
+      metadata: {
+        custom: {
+          aomiNoticeKind: isCreditNotice(msg.content)
+            ? "payment_required"
+            : "system_notice",
+          aomiNoticeTitle: isCreditNotice(msg.content)
+            ? "Credits needed"
+            : "System notice",
+        },
+      },
+    }),
   } satisfies ThreadMessageLike;
 
   return threadMessage;
+}
+
+function isCreditNotice(content: string | undefined): boolean {
+  return /\b(?:credit|quota|payment)\b/i.test(content ?? "");
 }
 
 function parseToolResult(


### PR DESCRIPTION
## What changed

- render backend system messages as assistant notices instead of dropping them
- classify credit, quota, and payment messages as the existing actionable credit notice
- keep other system messages visible as generic system notices

## Why

When the backend returned a credit-exhaustion message, the frontend filtered it out and made the chat appear frozen.

## Validation

- ESLint
- React/client library build including declarations
- full Vitest suite: 834 passed, 28 skipped
- focused notice-mapping regression tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787616837&installation_model_id=12362&pr_number=393&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F393&signature=f9f3090d30c7bdc7fbc11fce160e28e5dd5a2dbb0f8e04bff8919467ce31213b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->