### PR TITLE
Document canonical Supabase targets

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -24,6 +24,11 @@ databases. Local schema convergence applies the backend's forward drop instead
 of recreating the retired `bff_cli_device_sessions` / `bff_cli_sessions`
 tables; fresh databases also finish replay with that drop.
 
+2026-07-26 follow-up: the hosted topology is explicitly limited to staging
+`cmwkmjpfbffmdiluvgtu` and production `akejwtxsjvbexutsfhkn`; the public
+architecture guide now names both refs so a legacy third target cannot be
+mistaken for another supported environment.
+
 Progress:
 
 - 2026-07-24 idempotent npm publishing: changed the post-merge publish job to

--- a/apps/landing/content/guides/reference/architecture.mdx
+++ b/apps/landing/content/guides/reference/architecture.mdx
@@ -333,26 +333,26 @@ flowchart TB
 
 ## External Integrations
 
-| Service          | Crate      | Purpose                |
-| ---------------- | ---------- | ---------------------- |
-| Anthropic Claude | aomi-chat  | LLM inference          |
-| Etherscan        | aomi-tools | Contract data          |
-| Brave Search     | aomi-tools | Web search             |
-| BAML Server      | aomi-baml  | Structured AI outputs  |
-| Alchemy/Infura   | aomi-tools | RPC endpoints          |
+| Service          | Crate      | Purpose               |
+| ---------------- | ---------- | --------------------- |
+| Anthropic Claude | aomi-chat  | LLM inference         |
+| Etherscan        | aomi-tools | Contract data         |
+| Brave Search     | aomi-tools | Web search            |
+| BAML Server      | aomi-baml  | Structured AI outputs |
+| Alchemy/Infura   | aomi-tools | RPC endpoints         |
 
 ## Configuration
 
 ### Environment Variables
 
-| Variable               | Required | Purpose                      |
-| ---------------------- | -------- | ---------------------------- |
-| `ANTHROPIC_API_KEY`    | Yes      | Claude API access            |
-| `DATABASE_URL`         | Yes      | Backend Postgres connection; staging and production use separate Supabase project URLs |
-| `BRAVE_SEARCH_API_KEY` | No       | Web search                   |
-| `ETHERSCAN_API_KEY`    | No       | Contract data                |
-| `ALCHEMY_API_KEY`      | No       | RPC endpoints                |
-| `BAML_SERVER_URL`      | No       | Structured AI                |
+| Variable               | Required | Purpose                                                                                                                               |
+| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `ANTHROPIC_API_KEY`    | Yes      | Claude API access                                                                                                                     |
+| `DATABASE_URL`         | Yes      | Backend Postgres connection; only staging `cmwkmjpfbffmdiluvgtu` and production `akejwtxsjvbexutsfhkn` are valid hosted Supabase refs |
+| `BRAVE_SEARCH_API_KEY` | No       | Web search                                                                                                                            |
+| `ETHERSCAN_API_KEY`    | No       | Contract data                                                                                                                         |
+| `ALCHEMY_API_KEY`      | No       | RPC endpoints                                                                                                                         |
+| `BAML_SERVER_URL`      | No       | Structured AI                                                                                                                         |
 
 ### Network Configuration
 

--- a/packages/client/test/client.unit.test.ts
+++ b/packages/client/test/client.unit.test.ts
@@ -11,8 +11,13 @@ describe("AomiClient route manifest", () => {
         `${endpoint.method} ${endpoint.path} [${endpoint.auth.join(", ")}]`,
     );
 
-    expect(routeKeys).toHaveLength(109);
+    expect(routeKeys).toHaveLength(112);
     expect(new Set(routeKeys).size).toBe(routeKeys.length);
+    expect(routeKeys).toContain("GET /api/account/statement [account]");
+    expect(routeKeys).toContain(
+      "POST /api/account/providers/:provider/agent-wallet [account]",
+    );
+    expect(routeKeys).toContain("PUT /api/account/apps [account]");
     expect(routeKeys).toContain("POST /api/exec/run [account, thread]");
     expect(routeKeys).toContain(
       "POST /api/threads/:thread_id/archive [account, thread]",

--- a/packages/client/test/fixtures/backend-openapi.json
+++ b/packages/client/test/fixtures/backend-openapi.json
@@ -448,6 +448,38 @@
         "x-aomi-auth": [
           "account"
         ]
+      },
+      "put": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "accountBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "account"
+        ]
+      }
+    },
+    "/api/account/statement": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "accountBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/usage": {
@@ -519,6 +551,23 @@
       }
     },
     "/api/account/authorization/commit": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "accountBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "account"
+        ]
+      }
+    },
+    "/api/account/providers/{provider}/agent-wallet": {
       "post": {
         "responses": {
           "200": {

--- a/packages/client/test/generated/backend-routes.ts
+++ b/packages/client/test/generated/backend-routes.ts
@@ -105,6 +105,11 @@ export const AOMI_BACKEND_ENDPOINTS = [
   },
   {
     method: "GET",
+    path: "/api/account/statement",
+    auth: ["account"],
+  },
+  {
+    method: "GET",
     path: "/api/account/usage",
     auth: ["account"],
   },
@@ -380,6 +385,11 @@ export const AOMI_BACKEND_ENDPOINTS = [
   },
   {
     method: "POST",
+    path: "/api/account/providers/:provider/agent-wallet",
+    auth: ["account"],
+  },
+  {
+    method: "POST",
     path: "/api/admin/apps/:app/reload",
     auth: ["admin"],
   },
@@ -537,6 +547,11 @@ export const AOMI_BACKEND_ENDPOINTS = [
     method: "POST",
     path: "/api/threads/:thread_id/unarchive",
     auth: ["account","thread"],
+  },
+  {
+    method: "PUT",
+    path: "/api/account/apps",
+    auth: ["account"],
   },
   {
     method: "PUT",


### PR DESCRIPTION
## What changed

- name the exact staging and production Supabase refs in the public architecture guide
- record the two-target topology in the repository goal so future work does not treat a legacy ref as another supported environment

## Why

The hosted stack has exactly two database targets: staging `cmwkmjpfbffmdiluvgtu` and production `akejwtxsjvbexutsfhkn`. The frontend documentation previously said only that the databases were separate, which left room for a stale third ref to look legitimate.

## Coordinated backend change

- aomi-labs/product-mono#883 adds the machine-readable contract and deploy guard
- keep that backend PR draft until the staging `DATABASE_URL` is corrected

## Validation

- rebased onto current `main`
- Prettier check passed for the architecture guide
- `git diff --check` passed

No publishable package files changed, so no npm version bump is required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787705909&installation_model_id=12362&pr_number=396&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F396&signature=7c0af0b2b220230d702aff62655ba3aabafed735c246c954ed98136e5492b8cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->