### PR TITLE
Polish Portal account auth failures

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -26,6 +26,15 @@ tables; fresh databases also finish replay with that drop.
 
 Progress:
 
+- 2026-07-26 staging Portal account-auth recovery: traced the Settings
+  `widget_auth_failed` response to Vercel Preview using the production Supabase
+  session pool, where parallel BetterAuth/account functions exhausted the
+  15-client cap. Restored global Preview to the canonical staging branch using
+  its transaction-pool URL, rebuilt merged `main`, and confirmed concurrent
+  session/account probes with no 5xx or pool-exhaustion logs. Settings now
+  translates widget-auth and unknown structured transport failures into calm,
+  actionable copy instead of rendering raw JSON.
+
 - 2026-07-24 idempotent npm publishing: changed the post-merge publish job to
   skip exact package versions that are already live, publish only missing
   versions, and fail closed on registry errors other than a definitive 404.

--- a/apps/portal/src/features/account/account-api.ts
+++ b/apps/portal/src/features/account/account-api.ts
@@ -238,7 +238,15 @@ export function explainAccountError(cause: unknown): string {
       return "Unsupported signing mode.";
     case "internal":
       return "The server hit an error. Try again shortly.";
+    case "widget_auth_failed":
+      return "Couldn’t authenticate your account. Sign in again and retry.";
     default:
+      // Transport failures commonly arrive as structured JSON. Never render
+      // an unknown server payload verbatim in Settings; it is implementation
+      // detail, not an actionable message for the account holder.
+      if (code !== raw) {
+        return "Couldn’t load your account. Try again shortly.";
+      }
       return raw || "Something went wrong.";
   }
 }

--- a/apps/portal/src/features/usage/usage-settings.test.tsx
+++ b/apps/portal/src/features/usage/usage-settings.test.tsx
@@ -140,4 +140,31 @@ describe("usage settings wiring", () => {
       calls.filter((path) => path === "/api/account/statement"),
     ).toHaveLength(1);
   });
+
+  it("turns widget auth failures into an actionable message", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = new URL(input.toString(), "https://portal.test");
+        if (url.pathname === "/api/account/statement") {
+          return Response.json(
+            { error: "widget_auth_failed" },
+            { status: 401 },
+          );
+        }
+        return new Response("unexpected", { status: 500 });
+      }),
+    );
+
+    await act(async () => {
+      render(<UsageSettings />);
+    });
+
+    expect(
+      await screen.findByText(
+        "Couldn’t authenticate your account. Sign in again and retry.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText(/widget_auth_failed/)).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- render an actionable Settings message for widget authentication failures
- prevent unknown structured transport errors from appearing as raw JSON
- document the staging recovery and add a Usage regression

## Live recovery
- restored Vercel Preview `DATABASE_URL` to canonical staging `cmwkmjpfbffmdiluvgtu` via transaction pooling
- rebuilt merged main and verified `chat-staging.aomi.dev` aliases the new Ready deployment
- 8 concurrent session probes returned 200; 16 anonymous account probes returned expected 401; no pool-exhaustion or 5xx logs

## Checks
- `pnpm --filter portal test -- src/features/usage/usage-settings.test.tsx` (303 passed)
- `pnpm exec eslint apps/portal/src/features/account/account-api.ts apps/portal/src/features/usage/usage-settings.test.tsx`
- `pnpm --filter portal type-check`

The existing unstaged proxy-route change in the worktree is intentionally excluded.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787707326&installation_model_id=12362&pr_number=398&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F398&signature=5b29da2bcf65a4474672cb5d04c743ef2da1fc9c9800584a59115a328b181d8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->