### PR TITLE
Add branded CLI authorization completion page

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -31,6 +31,12 @@ mistaken for another supported environment.
 
 Progress:
 
+- 2026-07-27 Aomi Build CLI auth completion: replaced the localhost callback's
+  raw inline HTML with a redirect to a branded Build completion page based on
+  the existing Portal device-auth surface. The hosted page receives only a
+  coarse completion status; OAuth codes and state remain confined to the
+  loopback callback and CLI exchange.
+
 - 2026-07-27 Para ACL mode recovery: confirmed the reported staging Para EVM
   row is user-controlled (`provider_managed = false`) and that the backend
   permits `client_auto` without a delegated grant. Removed the frontend's

--- a/apps/build/src/app/cli/auth-complete/page.tsx
+++ b/apps/build/src/app/cli/auth-complete/page.tsx
@@ -1,0 +1,60 @@
+import { CheckCircle2, CircleAlert, Terminal } from "lucide-react";
+
+import { AomiLogo } from "@build/components/brand/aomi-logo";
+import { cn } from "@build/lib/utils";
+
+export const metadata = {
+  title: "CLI authorization · Aomi Build",
+};
+
+export default async function CliAuthCompletePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ status?: string | string[] }>;
+}) {
+  const failed = (await searchParams).status === "failed";
+  const Icon = failed ? CircleAlert : CheckCircle2;
+
+  return (
+    <main className="bg-background text-foreground relative flex min-h-screen items-center justify-center overflow-hidden p-6">
+      <div
+        aria-hidden="true"
+        className="bg-brand-dim pointer-events-none absolute -top-32 h-72 w-72 rounded-full blur-3xl"
+      />
+      <section className="border-border bg-card animate-fade-up relative w-full max-w-md overflow-hidden rounded-2xl border p-8 text-center shadow-lg">
+        <div className="flex justify-center">
+          <AomiLogo markClassName="h-7 w-7" />
+        </div>
+
+        <div
+          className={cn(
+            "mx-auto mt-8 flex size-14 items-center justify-center rounded-full",
+            failed
+              ? "bg-negative/10 text-negative"
+              : "bg-positive/10 text-positive",
+          )}
+        >
+          <Icon aria-hidden="true" className="size-7" />
+        </div>
+
+        <p className="text-subtle mt-5 text-xs font-medium uppercase tracking-[0.16em]">
+          Aomi Build CLI
+        </p>
+        <h1 className="mt-2 text-2xl font-semibold tracking-tight">
+          {failed ? "Authorization failed" : "Authorization received"}
+        </h1>
+        <p className="text-subtle mx-auto mt-3 max-w-sm text-sm leading-6">
+          {failed
+            ? "Return to your terminal for details, then try signing in again."
+            : "Aomi Build will finish signing you in and continue your deployment from the terminal."}
+        </p>
+
+        <div className="border-border bg-surface-2 mt-7 flex items-center justify-center gap-2 rounded-lg border px-4 py-3">
+          <Terminal aria-hidden="true" className="text-subtle size-4" />
+          <span className="text-sm font-medium">Return to your terminal</span>
+        </div>
+        <p className="text-dim mt-4 text-xs">This window is safe to close.</p>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

- add a branded Aomi Build completion page at `/cli/auth-complete`
- reuse the visual language of the existing Portal device-auth completion surface and the Build logo/tokens
- render explicit complete and failed states from a coarse `status` query value
- keep the page server-rendered with no client state, effects, casts, or OAuth data

## Why

The Builder CLI currently leaves users on raw inline localhost HTML after the browser callback. The paired SDK change redirects that callback to this hosted surface while keeping the OAuth code and state confined to localhost and the CLI exchange.

Paired SDK: https://github.com/aomi-labs/aomi-sdk/pull/93

## Validation

- `pnpm --filter aomi-build lint` (0 errors; 3 pre-existing warnings)
- `pnpm run typecheck:aomi-build`
- `pnpm --filter aomi-build test` (no frontend tests found)
- `pnpm run build:aomi-build`
- Playwright visual checks for desktop success and mobile failure states