### PR TITLE
Simplify Build deploy platform configuration

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -31,6 +31,11 @@ mistaken for another supported environment.
 
 Progress:
 
+- 2026-07-27 Build deploy-platform configuration: reduced the BFF deploy
+  admission allowlist to one server-only source, `APP_DEPLOY_PLATFORMS`, and
+  removed the singular and `NEXT_PUBLIC_*` compatibility paths so Vercel
+  configuration cannot silently diverge.
+
 - 2026-07-27 Para ACL mode recovery: confirmed the reported staging Para EVM
   row is user-controlled (`provider_managed = false`) and that the backend
   permits `client_auto` without a delegated grant. Removed the frontend's

--- a/apps/build/src/server/bff/launch/config.test.ts
+++ b/apps/build/src/server/bff/launch/config.test.ts
@@ -41,24 +41,14 @@ describe("launchConfig", () => {
     expect(config.catalogPlatforms).toEqual([]);
   });
 
-  it("falls back to public platform envs during deployment bootstrap", () => {
-    vi.stubEnv(
-      "NEXT_PUBLIC_APP_DEPLOY_PLATFORMS",
-      '["somm.finance", "community"]',
-    );
-
-    const config = launchConfig();
-    expect(config.platform).toBe("somm.finance");
-    expect(config.platforms).toEqual(["somm.finance", "community"]);
-    expect(config.catalogPlatforms).toEqual([]);
-  });
-
-  it("accepts a single platform env as a one-item platform list", () => {
+  it("ignores legacy singular and public platform env aliases", () => {
+    vi.stubEnv("APP_DEPLOY_PLATFORM", "partners");
+    vi.stubEnv("NEXT_PUBLIC_APP_DEPLOY_PLATFORMS", "partners");
     vi.stubEnv("NEXT_PUBLIC_APP_DEPLOY_PLATFORM", "somm.finance");
 
     const config = launchConfig();
-    expect(config.platform).toBe("somm.finance");
-    expect(config.platforms).toEqual(["somm.finance"]);
+    expect(config.platform).toBe("community");
+    expect(config.platforms).toEqual(["community"]);
     expect(config.catalogPlatforms).toEqual([]);
   });
 

--- a/apps/build/src/server/bff/launch/config.ts
+++ b/apps/build/src/server/bff/launch/config.ts
@@ -60,17 +60,8 @@ function envJsonOrCommaList(name: string): string[] {
 }
 
 function deployPlatforms(): string[] {
-  for (const name of [
-    "APP_DEPLOY_PLATFORMS",
-    "NEXT_PUBLIC_APP_DEPLOY_PLATFORMS",
-    "APP_DEPLOY_PLATFORM",
-    "NEXT_PUBLIC_APP_DEPLOY_PLATFORM",
-  ]) {
-    const platforms = envJsonOrCommaList(name);
-    if (platforms.length > 0) return platforms;
-  }
-
-  return [DEFAULT_DEPLOY_PLATFORM];
+  const platforms = envJsonOrCommaList("APP_DEPLOY_PLATFORMS");
+  return platforms.length > 0 ? platforms : [DEFAULT_DEPLOY_PLATFORM];
 }
 
 function catalogPlatforms(): string[] {


### PR DESCRIPTION
## What changed

- make `APP_DEPLOY_PLATFORMS` the only deploy-platform configuration read by the Build BFF
- remove the singular and `NEXT_PUBLIC_*` compatibility fallbacks
- add regression coverage proving legacy aliases no longer affect the admission allowlist
- record the configuration simplification in `GOAL.md`

## Why

The merged multi-platform BFF supported `somm.finance`, but staging still rejected it because four overlapping Vercel variables could drift. One server-only plural allowlist makes the deployed admission policy explicit and prevents UI/bootstrap aliases from silently overriding it.

## Environment reconciliation

The `aomi-build` Vercel project now has one canonical key per environment:

- Preview: `APP_DEPLOY_PLATFORMS=community,somm.finance`
- Production: `APP_DEPLOY_PLATFORMS=community`

The three legacy variables were removed from both Preview and Production.

## Validation

- `pnpm --filter aomi-build exec vitest run src/server/bff/launch/config.test.ts` (6 passed)
- `pnpm --filter aomi-build lint` (0 errors; 3 pre-existing warnings)
- `pnpm run typecheck:aomi-build`
- `pnpm run build:aomi-build`
- verified Vercel Preview and Production each expose only `APP_DEPLOY_PLATFORMS` for deploy-platform configuration

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787721873&installation_model_id=12362&pr_number=404&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F404&signature=50d2305dff731edc88f7d2c202132de3ae5d8927a4fcd882f2675c1ef0b7b400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->