### PR TITLE
Fix project deployment history source

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -31,6 +31,11 @@ mistaken for another supported environment.
 
 Progress:
 
+- 2026-07-27 deployment-history correctness: the project History view now
+  loads the deployment-history API and merges it with the promotion log, so a
+  successfully deployed/live app remains visible even when its append-only
+  promotion records are empty. Promotions continue to use the activation log.
+
 - 2026-07-27 Shared chat welcome title: replaced the Portal and Landing
   one-off catchphrases with the shared “What should happen on-chain?” default
   and styled it with the same regular PT Serif display face used by Aomi Build

--- a/apps/build/src/features/launch/components/deployments/deployment-timeline.test.ts
+++ b/apps/build/src/features/launch/components/deployments/deployment-timeline.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildActivityList, buildDeploymentList, sortDeploymentsForTimeline } from "./deployment-timeline";
+import {
+  buildActivityList,
+  buildDeploymentList,
+  sortDeploymentsForTimeline,
+} from "./deployment-timeline";
 
 describe("buildDeploymentList", () => {
   it("returns [] for null", () => {
@@ -64,6 +68,38 @@ describe("buildDeploymentList", () => {
     ]);
 
     expect(rows[0].actor).toBe("bob");
+  });
+
+  it("shows deployed history even when no promotion record exists", () => {
+    const rows = buildDeploymentList({ "somm-agent": [] }, [
+      {
+        deploymentId: "dep_141779906_rd076a82c30_90642ef5ef1b",
+        state: "ready",
+        deployBranch: "ceciliaz030/somm-agent/141779906/90642ef5ef1b",
+        platformRepo: "aomi-labs/somm-finance-apps",
+        commitHash: "90642ef5ef1bad92f3690c8c005355172676d9ed",
+        ciStatus: "passed",
+        ciUrl: null,
+        releaseTags: ["apps-141779906-rd076a82c30-somm-agent-90642ef5ef1b"],
+        sdkVersion: "3.0.4",
+        createdAt: 1785132402,
+        apps: [
+          {
+            name: "somm-agent",
+            releaseTag: "apps-141779906-rd076a82c30-somm-agent-90642ef5ef1b",
+          },
+        ],
+      },
+    ]);
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        deploymentId: "dep_141779906_rd076a82c30_90642ef5ef1b",
+        commit: "90642ef5ef1b",
+        apps: ["somm-agent"],
+        sdkVersion: "3.0.4",
+      }),
+    ]);
   });
 
   it("sorts current first for the timeline view", () => {

--- a/apps/build/src/features/launch/components/deployments/deployment-timeline.ts
+++ b/apps/build/src/features/launch/components/deployments/deployment-timeline.ts
@@ -1,8 +1,9 @@
+import type { UserSourceLatestDeployment } from "@aomi-labs/deploy";
 import type { DeploymentRecord } from "@build/features/launch/contracts";
 
-/** One deployment as derived purely from the DB promotion records — no GitHub
- *  reads. `commit` is decoded from the deployment id
- *  (`dep_<install>_<repokey>_<shortcommit>`). */
+/** One deployment for the project timeline. `commit` is decoded from the
+ * deployment id (`dep_<install>_<repokey>_<shortcommit>`) when history does
+ * not carry the full commit hash. */
 export type TimelineDeployment = {
   deploymentId: string;
   commit: string | null;
@@ -25,19 +26,17 @@ export function commitFromDeploymentId(deploymentId: string): string | null {
 }
 
 /**
- * Merge per-app promotion records into a newest-first deployment list. A single
- * deploy can touch several apps (same `deploymentId`, one record per app), so
- * records are grouped by `deploymentId`. A deployment is "current" when any of
- * its apps' latest record is live; `createdAt`/`actor`/`sdkVersion` come from
- * the newest record in the group.
+ * Merge deployment history with per-app promotion records into a newest-first
+ * deployment list. History is the source of truth for what was deployed;
+ * promotion records enrich it with actor/current state and preserve legacy
+ * deployments that are only present in the activation log.
  */
 export function buildDeploymentList(
   recordsByApp: Record<string, DeploymentRecord[]> | null,
+  history: UserSourceLatestDeployment[] | null = null,
 ): TimelineDeployment[] {
-  if (!recordsByApp) return [];
-
   const byId = new Map<string, TimelineDeployment>();
-  for (const [app, rows] of Object.entries(recordsByApp)) {
+  for (const [app, rows] of Object.entries(recordsByApp ?? {})) {
     for (const row of rows) {
       const existing = byId.get(row.deploymentId);
       if (!existing) {
@@ -64,6 +63,34 @@ export function buildDeploymentList(
         existing.sdkVersion = row.sdkVersion;
       }
     }
+  }
+
+  for (const entry of history ?? []) {
+    if (!entry.deploymentId) continue;
+    const existing = byId.get(entry.deploymentId);
+    const apps = entry.apps.map((app) => app.name);
+    const releaseTags = [
+      ...entry.releaseTags,
+      ...entry.apps.flatMap((app) => (app.releaseTag ? [app.releaseTag] : [])),
+    ];
+    const sdkVersion =
+      entry.sdkVersion ??
+      entry.apps.find((app) => app.sdkVersion)?.sdkVersion ??
+      existing?.sdkVersion ??
+      null;
+    byId.set(entry.deploymentId, {
+      deploymentId: entry.deploymentId,
+      commit:
+        existing?.commit ?? commitFromDeploymentId(entry.deploymentId),
+      apps: [...new Set([...(existing?.apps ?? []), ...apps])],
+      releaseTags: [
+        ...new Set([...(existing?.releaseTags ?? []), ...releaseTags]),
+      ],
+      current: existing?.current ?? false,
+      actor: existing?.actor ?? null,
+      sdkVersion,
+      createdAt: entry.createdAt ?? existing?.createdAt ?? 0,
+    });
   }
 
   return [...byId.values()].sort((a, b) => b.createdAt - a.createdAt);

--- a/apps/build/src/features/launch/components/deployments/tabs/deployments-tab.test.tsx
+++ b/apps/build/src/features/launch/components/deployments/tabs/deployments-tab.test.tsx
@@ -7,7 +7,10 @@ import {
   within,
 } from "@testing-library/react";
 import { ToastProvider } from "@build/components/control-plane/toast";
+import type { useProjectDetail } from "@build/features/launch/hooks/use-project-detail";
 import { DeploymentsTab } from "./deployments-tab";
+
+type Detail = ReturnType<typeof useProjectDetail>;
 
 function renderTab(ui: React.ReactElement) {
   return render(<ToastProvider>{ui}</ToastProvider>);
@@ -32,6 +35,8 @@ function makeDetail(
     requiredSdk?: string;
     upgradeSdk?: ReturnType<typeof vi.fn>;
     checkSdkUpgradeStatus?: ReturnType<typeof vi.fn>;
+    history?: Detail["history"];
+    recordsByApp?: Detail["recordsByApp"];
   } = {},
 ) {
   const sdkVersion = overrides.sdkVersion ?? "3.0.1";
@@ -55,7 +60,7 @@ function makeDetail(
     loadRecords: vi.fn(),
     loadRequiredSecrets: vi.fn(),
     loadHistory: vi.fn(),
-    history: null,
+    history: overrides.history ?? null,
     historyError: null,
     refreshRequiredSecrets: vi.fn(async () => ({})),
     hasMissingSecrets: overrides.hasMissingSecrets ?? (() => false),
@@ -82,26 +87,28 @@ function makeDetail(
         },
       })),
     deployFlow: { phase: "idle" },
-    recordsByApp: {
-      "my-bot": [
-        {
-          deploymentId: "dep_1_ra_currentcmt",
-          releaseTag: "t-current",
-          actor: "alice",
-          createdAt: 200,
-          sdkVersion,
-          current: true,
-        },
-        {
-          deploymentId: "dep_1_ra_oldcommit1",
-          releaseTag: "t-old",
-          actor: "alice",
-          createdAt: 100,
-          sdkVersion,
-          current: false,
-        },
-      ],
-    },
+    recordsByApp:
+      overrides.recordsByApp ??
+      ({
+        "my-bot": [
+          {
+            deploymentId: "dep_1_ra_currentcmt",
+            releaseTag: "t-current",
+            actor: "alice",
+            createdAt: 200,
+            sdkVersion,
+            current: true,
+          },
+          {
+            deploymentId: "dep_1_ra_oldcommit1",
+            releaseTag: "t-old",
+            actor: "alice",
+            createdAt: 100,
+            sdkVersion,
+            current: false,
+          },
+        ],
+      } satisfies Detail["recordsByApp"]),
     promote,
     deactivate,
     reload: vi.fn(),
@@ -121,6 +128,7 @@ describe("DeploymentsTab", () => {
 
   it("renders deployments from the DB timeline, current first", async () => {
     renderTab(<DeploymentsTab detail={detail} />);
+    expect(detail.loadHistory).toHaveBeenCalled();
     expect(detail.loadRecords).toHaveBeenCalled();
     expect(
       await screen.findByText(/Live · my-bot · 2 deployments/i),
@@ -137,6 +145,37 @@ describe("DeploymentsTab", () => {
       "aria-selected",
       "false",
     );
+  });
+
+  it("renders history when the promotion log is empty", async () => {
+    const historyOnly = makeDetail({
+      recordsByApp: { "my-bot": [] },
+      history: [
+        {
+          deploymentId: "dep_1_ra_sommcommit",
+          state: "ready",
+          deployBranch: "alice/somm/1/sommcommit",
+          platformRepo: "aomi-labs/somm-finance-apps",
+          commitHash: "sommcommit00000000000000000000000000000",
+          ciStatus: "passed",
+          ciUrl: null,
+          releaseTags: ["t-current"],
+          sdkVersion: "3.0.4",
+          createdAt: 200,
+          apps: [{ name: "my-bot", releaseTag: "t-current" }],
+        },
+      ],
+    });
+
+    renderTab(<DeploymentsTab detail={historyOnly} />);
+
+    expect(
+      await screen.findByText(/Live · my-bot · 1 deployment in history/i),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("dep_1_ra_sommcommit").length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.queryByText(/No deployment history yet/i)).toBeNull();
   });
 
   it("renders promotion activity in the Promotions subtab", async () => {

--- a/apps/build/src/features/launch/components/deployments/tabs/deployments-tab.tsx
+++ b/apps/build/src/features/launch/components/deployments/tabs/deployments-tab.tsx
@@ -45,11 +45,13 @@ export function DeploymentsTab({
   const [view, setView] = useState<View>("deployments");
   const [expandedDetail, setExpandedDetail] = useState<string | null>(null);
   const [retryingSecrets, setRetryingSecrets] = useState(false);
+  const { loadHistory, loadRecords, loadRequiredSecrets } = detail;
 
   useEffect(() => {
-    detail.loadRecords();
-    detail.loadRequiredSecrets();
-  }, [detail]);
+    loadHistory();
+    loadRecords();
+    loadRequiredSecrets();
+  }, [loadHistory, loadRecords, loadRequiredSecrets]);
 
   const source = detail.source;
   const upgrade = useSdkUpgrade({
@@ -82,8 +84,8 @@ export function DeploymentsTab({
     [source],
   );
   const recordDeployments = useMemo(
-    () => buildDeploymentList(detail.recordsByApp),
-    [detail.recordsByApp],
+    () => buildDeploymentList(detail.recordsByApp, detail.history),
+    [detail.history, detail.recordsByApp],
   );
   const activity = useMemo(
     () => buildActivityList(detail.recordsByApp),


### PR DESCRIPTION
## Summary
- load the actual deployment-history feed when opening a project Deployments tab
- merge deployment history with promotion records so unlogged activations do not erase deployed releases
- keep the Promotions view backed by the append-only activation log
- cover the live Somm shape: deployment exists, promotion records empty

## Verification
- `pnpm --filter aomi-build exec vitest run src/features/launch/components/deployments/deployment-timeline.test.ts src/features/launch/components/deployments/tabs/deployments-tab.test.tsx` (24 passed)
- `pnpm exec vitest run apps/build/src` (331 passed after building `@aomi-labs/widget-lib`)
- `pnpm --filter aomi-build type-check`
- targeted ESLint
- authenticated Safari: history endpoint returned the Somm 3.0.4 deployment while records returned `[]`, reproducing the bug

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787772174&installation_model_id=12362&pr_number=408&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F408&signature=5ea6257f8de646f16a63f522fd81732f8041c53fc4deaa0b9cd64e021cdc9dc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->