### PR TITLE
List projects across deploy platforms

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -31,6 +31,11 @@ mistaken for another supported environment.
 
 Progress:
 
+- 2026-07-27 cross-platform project discovery: the Projects index now uses the
+  backend's platform-agnostic, GitHub-user-scoped source list instead of
+  silently defaulting to `community`, and project links preserve each source's
+  bound platform for detail reads.
+
 - 2026-07-27 deployment-history correctness: the project History view now
   loads the deployment-history API and merges it with the promotion log, so a
   successfully deployed/live app remains visible even when its append-only

--- a/apps/build/src/features/launch/components/deployments/project-index.test.tsx
+++ b/apps/build/src/features/launch/components/deployments/project-index.test.tsx
@@ -10,6 +10,7 @@ vi.mock("@build/features/launch/hooks/use-projects", () => ({
           id: 3,
           installationId: 1,
           repositoryLink: "alice/bot",
+          boundPlatformName: "somm.finance",
           apps: [],
           latestDeployment: null,
         },
@@ -31,9 +32,10 @@ describe("ProjectIndex", () => {
   it("lists projects with links", async () => {
     render(<ProjectIndex />);
     await waitFor(() =>
-      expect(
-        screen.getByRole("link", { name: /alice\/bot/ }),
-      ).toHaveAttribute("href", "/projects/3"),
+      expect(screen.getByRole("link", { name: /alice\/bot/ })).toHaveAttribute(
+        "href",
+        "/projects/3?platform=somm.finance",
+      ),
     );
   });
 });

--- a/apps/build/src/features/launch/components/deployments/project-index.tsx
+++ b/apps/build/src/features/launch/components/deployments/project-index.tsx
@@ -83,7 +83,6 @@ export function ProjectIndex() {
                 key={source.id}
                 source={source}
                 requiredSdk={requiredSdk}
-                href={`/projects/${source.id}`}
               />
             ))}
         </div>

--- a/apps/build/src/features/launch/components/deployments/project-row.test.tsx
+++ b/apps/build/src/features/launch/components/deployments/project-row.test.tsx
@@ -81,6 +81,7 @@ describe("ProjectRow", () => {
           id: 42,
           installationId: 1,
           repositoryLink: "alice/bot",
+          boundPlatformName: "somm.finance",
           sdkVersion: "3.0.2",
           apps: [
             {
@@ -99,7 +100,7 @@ describe("ProjectRow", () => {
     expect(screen.getByText("Outdated")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Upgrade" })).toHaveAttribute(
       "href",
-      "/projects/42?tab=deployments",
+      "/projects/42?platform=somm.finance&tab=deployments",
     );
   });
 });

--- a/apps/build/src/features/launch/components/deployments/project-row.tsx
+++ b/apps/build/src/features/launch/components/deployments/project-row.tsx
@@ -22,7 +22,15 @@ export function ProjectRow({
         ? source.apps[0]?.name
         : `${source.apps.length} apps`;
   const stamped = sourceSdkVersion(source);
-  const projectHref = href ?? `/projects/${source.id}`;
+  const boundPlatform = source.boundPlatformName?.trim();
+  const projectHref =
+    href ??
+    `/projects/${source.id}${
+      boundPlatform ? `?platform=${encodeURIComponent(boundPlatform)}` : ""
+    }`;
+  const deploymentsHref = `${projectHref}${
+    projectHref.includes("?") ? "&" : "?"
+  }tab=deployments`;
   const outdated = sdkCompatibility(stamped, requiredSdk) === "outdated";
   return (
     <div className="border-border hover:bg-accent-hover flex items-center gap-3 border-b px-4 py-3 last:border-b-0">
@@ -49,7 +57,7 @@ export function ProjectRow({
         <SdkBadge stamped={stamped} required={requiredSdk} />
         {outdated && (
           <Link
-            href={`${projectHref}?tab=deployments`}
+            href={deploymentsHref}
             className="border-warning/40 bg-warning/10 text-warning hover:bg-warning/15 inline-flex h-7 items-center justify-center rounded-md border px-2.5 text-xs font-medium"
           >
             Upgrade

--- a/apps/build/src/server/bff/launch/routes.ts
+++ b/apps/build/src/server/bff/launch/routes.ts
@@ -1174,8 +1174,9 @@ export async function redeployLaunchRoute(req: Request) {
 }
 
 // GET /api/bff/launch/sources — the signed-in user's source repos + their apps,
-// merged across installations. Scoped to the github_user_id in the session
-// cookie; a client can never request someone else's sources.
+// merged across installations and platforms unless `platform` is explicit.
+// Scoped to the github_user_id in the session cookie; a client can never
+// request someone else's sources.
 export async function userSourcesRoute(req: Request) {
   const auth = await authorize(req);
   if ("response" in auth) return auth.response;
@@ -1183,12 +1184,18 @@ export async function userSourcesRoute(req: Request) {
 
   try {
     const config = launchConfig();
-    const platform = requestedPlatformFromUrl(req, config);
-    if (!platform) return invalidPlatformResponse();
+    const requestedPlatform = new URL(req.url).searchParams.get("platform");
+    const platform =
+      requestedPlatform === null
+        ? undefined
+        : resolveLaunchPlatform(requestedPlatform, config);
+    if (requestedPlatform !== null && !platform) {
+      return invalidPlatformResponse();
+    }
     const client = await deploymentClient();
     const sources = await client.listUserSources({
       githubUserId: session.githubUserId,
-      platform,
+      platform: platform ?? undefined,
     });
     return NextResponse.json({ sources, githubLogin: session.githubLogin });
   } catch (err) {

--- a/apps/build/src/server/bff/launch/user-sources.test.ts
+++ b/apps/build/src/server/bff/launch/user-sources.test.ts
@@ -79,8 +79,9 @@ describe("userSourcesRoute", () => {
     // The backend call is scoped to the session's github_user_id.
     const [url] = fetchMock.mock.calls[0];
     expect(String(url)).toContain(
-      "/api/integrations/github-app/user/sources?github_user_id=42&platform=community",
+      "/api/integrations/github-app/user/sources?github_user_id=42",
     );
+    expect(String(url)).not.toContain("&platform=");
   });
 
   it("looks up sources on an explicitly configured partner platform", async () => {


### PR DESCRIPTION
## Summary
- use the backend platform-agnostic source list for the unfiltered Projects index
- retain explicit platform scoping for partner-specific reads
- preserve each source bound platform in project and upgrade links
- cover the unscoped BFF request and platform-aware links

## Verification
- `pnpm --filter aomi-build exec vitest run src/server/bff/launch/user-sources.test.ts src/features/launch/components/deployments/project-index.test.tsx src/features/launch/components/deployments/project-row.test.tsx` (8 passed)
- `pnpm --filter aomi-build type-check`
- targeted ESLint
- authenticated Safari proved source 1620 is absent from the default-scoped response and present under `somm.finance`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787775547&installation_model_id=12362&pr_number=409&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F409&signature=36639e5d1ab2fcdea839e3fe618d96e10b8f85ebdd6899ee0471c8c615bc99fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->