### PR TITLE
Hide empty repository sources from Projects

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -31,6 +31,11 @@ mistaken for another supported environment.
 
 Progress:
 
+- 2026-07-27 Build project membership: the Projects index now treats GitHub
+  source records as internal import/ownership metadata and only surfaces
+  sources that contain at least one Aomi app, removing historical repositories
+  that were bound to a platform but never became Build projects.
+
 - 2026-07-27 deployment-history correctness: the project History view now
   loads the deployment-history API and merges it with the promotion log, so a
   successfully deployed/live app remains visible even when its append-only

--- a/apps/build/src/features/launch/hooks/use-projects.test.ts
+++ b/apps/build/src/features/launch/hooks/use-projects.test.ts
@@ -10,6 +10,13 @@ vi.mock("@build/features/launch/client", () => ({
         id: 1,
         installationId: 5,
         repositoryLink: "a/b",
+        apps: [{ name: "bot" }],
+        latestDeployment: null,
+      },
+      {
+        id: 2,
+        installationId: 5,
+        repositoryLink: "a/historical-repo",
         apps: [],
         latestDeployment: null,
       },
@@ -51,7 +58,7 @@ function wrapper() {
 describe("useProjects", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("loads sources off the shared session and never fetches history", async () => {
+  it("loads app projects off the shared session and omits empty sources", async () => {
     const { result } = renderHook(() => useProjects(), {
       wrapper: wrapper(),
     });
@@ -62,6 +69,7 @@ describe("useProjects", () => {
     expect(deploymentFeed).not.toHaveBeenCalled();
     if (result.current.state.status === "ready") {
       expect(result.current.state.sources).toHaveLength(1);
+      expect(result.current.state.sources[0]?.repositoryLink).toBe("a/b");
     }
   });
 });

--- a/apps/build/src/features/launch/hooks/use-projects.ts
+++ b/apps/build/src/features/launch/hooks/use-projects.ts
@@ -23,6 +23,10 @@ export type ProjectsState =
     }
   | { status: "error"; error: string };
 
+function hasApps(source: UserSource) {
+  return source.apps.length > 0;
+}
+
 export function useProjects() {
   // The GitHub session comes from the shell-level provider — reusing it here
   // avoids a second `/auth/github/status` round trip on every page mount.
@@ -63,7 +67,7 @@ export function useProjects() {
     const { loading: _loading, ...github } = account;
     return {
       status: "ready",
-      sources: projects.data?.sources ?? [],
+      sources: (projects.data?.sources ?? []).filter(hasApps),
       sdk: sdk.data ?? null,
       github,
     };


### PR DESCRIPTION
## Summary
- define a Build project as a GitHub source containing at least one Aomi app
- keep empty source records available to the CLI and ownership/preflight APIs while omitting them from project UI consumers
- cover real-app versus historical empty-source filtering

## Validation
- `pnpm --filter aomi-build exec vitest run src/features/launch/hooks/use-projects.test.ts`
- `pnpm --filter aomi-build exec vitest run src/features/launch/components/deployments/project-index.test.tsx src/app/(control-plane)/settings/settings-secrets-panel.test.tsx`
- `pnpm --filter aomi-build exec eslint src/features/launch/hooks/use-projects.ts src/features/launch/hooks/use-projects.test.ts`
- `pnpm --filter aomi-build exec tsc --noEmit`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787775972&installation_model_id=12362&pr_number=410&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F410&signature=c6fae715db66b93ae17e574b6c4828769e697ca05c60875fbaf2f635b7462f06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->