### PR TITLE
Use transaction pooling for Portal auth

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -31,6 +31,12 @@ mistaken for another supported environment.
 
 Progress:
 
+- 2026-07-27 hosted account-pool hardening: traced recurring Settings auth
+  failures to aggregate Supabase session exhaustion across two backend and two
+  manager processes plus independently warm Vercel functions. Portal now
+  normalizes a Supabase session-pooler URL to transaction mode on Vercel while
+  retaining a one-client, short-idle local pool; paired backend deployment
+  work splits and verifies the fleet-wide session budget.
 - 2026-07-27 Build project membership: the Projects index now treats GitHub
   source records as internal import/ownership metadata and only surfaces
   sources that contain at least one Aomi app, removing historical repositories

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/account",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Server-only account graph: resolve-or-create the canonical user and mint AccountBearers. Node-only; never bundle into a browser.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/account/src/db/pool.ts
+++ b/packages/account/src/db/pool.ts
@@ -22,9 +22,37 @@ export type AccountPoolOptions = {
 };
 
 /**
+ * Supabase's port 5432 pooler is session mode: every warm Vercel function can
+ * consume one of its small fixed client allowance. Port 6543 is transaction
+ * mode and multiplexes those short serverless queries instead. Preserve all
+ * credentials and target identity while selecting the serverless-safe mode.
+ */
+export function resolveAccountConnectionString(
+  connectionString: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  if (!env.VERCEL) return connectionString;
+
+  let url: URL;
+  try {
+    url = new URL(connectionString);
+  } catch {
+    return connectionString;
+  }
+  if (
+    url.hostname.endsWith(".pooler.supabase.com") &&
+    (url.port === "" || url.port === "5432")
+  ) {
+    url.port = "6543";
+    return url.toString();
+  }
+  return connectionString;
+}
+
+/**
  * Vercel can keep a separate warm function instance for each API route. A
- * four-connection pool per instance quickly exhausts Supabase's session-mode
- * client cap, so serverless instances must keep a single, short-lived client.
+ * transaction pooler is still shared infrastructure, so each instance keeps a
+ * single, short-lived client instead of multiplying a larger local pool.
  */
 export function resolveAccountPoolOptions(
   env: NodeJS.ProcessEnv = process.env,
@@ -46,9 +74,8 @@ export function getPool(): Pool {
     );
   }
   cachedPool = new Pool({
-    connectionString,
-    // The portal is one of several DB clients; keep its footprint small so it
-    // never starves the backend on the shared Supabase pooler.
+    connectionString: resolveAccountConnectionString(connectionString),
+    application_name: "aomi-portal",
     ...resolveAccountPoolOptions(),
   });
   return cachedPool;

--- a/packages/account/test/pool.test.ts
+++ b/packages/account/test/pool.test.ts
@@ -1,5 +1,46 @@
 import { describe, expect, it } from "vitest";
-import { resolveAccountPoolOptions } from "../src/db/pool";
+import {
+  resolveAccountConnectionString,
+  resolveAccountPoolOptions,
+} from "../src/db/pool";
+
+describe("resolveAccountConnectionString", () => {
+  const sessionPooler =
+    "postgresql://postgres.project:secret@aws-0-us-east-1.pooler.supabase.com:5432/postgres";
+
+  it("uses Supabase transaction pooling for Vercel functions", () => {
+    const resolved = resolveAccountConnectionString(sessionPooler, {
+      VERCEL: "1",
+    });
+
+    expect(new URL(resolved).port).toBe("6543");
+    expect(new URL(resolved).username).toBe("postgres.project");
+  });
+
+  it("also normalizes an implicit session-pooler port", () => {
+    const resolved = resolveAccountConnectionString(
+      "postgresql://postgres.project:secret@aws-0-us-east-1.pooler.supabase.com/postgres",
+      { VERCEL: "1" },
+    );
+
+    expect(new URL(resolved).port).toBe("6543");
+  });
+
+  it("preserves local and persistent-runtime URLs", () => {
+    expect(resolveAccountConnectionString(sessionPooler, {})).toBe(
+      sessionPooler,
+    );
+  });
+
+  it("does not rewrite another Postgres provider", () => {
+    const connectionString =
+      "postgresql://user:secret@db.example.com:5432/aomi";
+
+    expect(
+      resolveAccountConnectionString(connectionString, { VERCEL: "1" }),
+    ).toBe(connectionString);
+  });
+});
 
 describe("resolveAccountPoolOptions", () => {
   it("uses one short-lived connection per Vercel function instance", () => {


### PR DESCRIPTION
## Summary
- normalize Supabase session-pooler URLs to transaction mode in Vercel functions
- keep each warm function at one short-idle client and tag connections as `aomi-portal`
- bump `@aomi-labs/account` to 0.1.9 and cover URL selection with focused tests

## Why
The Settings auth failures were `EMAXCONNSESSION`: independently warm Vercel routes were using Supabase session pooling, so a per-function max of one still did not bound aggregate connections.

## Verification
- `pnpm --filter @aomi-labs/account exec vitest run test/pool.test.ts` (6 passed)
- account and Portal typechecks
- Portal test suite (306 passed)
- Portal production build with mock-safe local auth env
- targeted ESLint and Prettier checks
- `pnpm --filter @aomi-labs/account pack` verified 0.1.9 tarball

The coordinated backend fleet-budget PR will be linked here once opened.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787800874&installation_model_id=12362&pr_number=412&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F412&signature=a1d4e8283d2e46df7f6d4c58fb054dbc2b753904fa66da075b8d622fe417fc3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->