### PR TITLE
Fix hosted app selection in the chat control bar

### DIFF
--- a/apps/shadcn-registry/src/components/control-bar/app-metadata.test.ts
+++ b/apps/shadcn-registry/src/components/control-bar/app-metadata.test.ts
@@ -3,7 +3,13 @@ import { getAppInfo, groupAppsByCategory } from "./app-metadata";
 
 describe("app-metadata", () => {
   it("handles non-string app ids without throwing", () => {
-    const apps = ["default", undefined, null, 123, "binance"] as unknown as string[];
+    const apps = [
+      "default",
+      undefined,
+      null,
+      123,
+      "binance",
+    ] as unknown as string[];
 
     expect(() => groupAppsByCategory(apps)).not.toThrow();
 
@@ -17,5 +23,17 @@ describe("app-metadata", () => {
     const info = getAppInfo("" as unknown as string);
     expect(info.displayName).toBe("Unknown App");
     expect(info.abbr).toBe("?");
+  });
+
+  it("preserves hosted application ids while grouping", () => {
+    const grouped = groupAppsByCategory([
+      { name: "somm-agent", applicationId: 1641 },
+    ]);
+
+    expect(grouped[0]?.apps[0]).toMatchObject({
+      id: "somm-agent",
+      displayName: "Somm Agent",
+      applicationId: 1641,
+    });
   });
 });

--- a/apps/shadcn-registry/src/components/control-bar/app-metadata.test.ts
+++ b/apps/shadcn-registry/src/components/control-bar/app-metadata.test.ts
@@ -27,13 +27,13 @@ describe("app-metadata", () => {
 
   it("preserves hosted application ids while grouping", () => {
     const grouped = groupAppsByCategory([
-      { name: "somm-agent", applicationId: 1641 },
+      { name: "somm-agent", applicationId: 2938032 },
     ]);
 
     expect(grouped[0]?.apps[0]).toMatchObject({
       id: "somm-agent",
       displayName: "Somm Agent",
-      applicationId: 1641,
+      applicationId: 2938032,
     });
   });
 });

--- a/apps/shadcn-registry/src/components/control-bar/app-metadata.test.ts
+++ b/apps/shadcn-registry/src/components/control-bar/app-metadata.test.ts
@@ -27,13 +27,13 @@ describe("app-metadata", () => {
 
   it("preserves hosted application ids while grouping", () => {
     const grouped = groupAppsByCategory([
-      { name: "somm-agent", applicationId: 2938032 },
+      { name: "partner-agent", applicationId: 42 },
     ]);
 
     expect(grouped[0]?.apps[0]).toMatchObject({
-      id: "somm-agent",
-      displayName: "Somm Agent",
-      applicationId: 2938032,
+      id: "partner-agent",
+      displayName: "Partner Agent",
+      applicationId: 42,
     });
   });
 });

--- a/apps/shadcn-registry/src/components/control-bar/app-metadata.ts
+++ b/apps/shadcn-registry/src/components/control-bar/app-metadata.ts
@@ -3,9 +3,13 @@
  * Maps raw backend app ids to display names, categories, and aliases.
  */
 
+import type { AomiAppDescriptor } from "@aomi-labs/client";
+
 export type AppInfo = {
   /** Raw app id sent to backend */
   id: string;
+  /** Backend application scope for hosted apps. */
+  applicationId?: AomiAppDescriptor["applicationId"];
   /** Human-readable display name */
   displayName: string;
   /** 1-2 letter abbreviation for avatar fallback */
@@ -241,14 +245,25 @@ export function getAppInfo(appId: string | null | undefined): AppInfo {
   };
 }
 
-export function groupAppsByCategory(apps: string[]): AppGroup[] {
+export function groupAppsByCategory(
+  apps: Array<string | AomiAppDescriptor>,
+): AppGroup[] {
   const grouped = new Map<string, AppInfo[]>();
 
   for (const app of apps) {
-    if (typeof app !== "string" || app.trim().length === 0) {
+    const name =
+      typeof app === "string"
+        ? app
+        : app && typeof app.name === "string"
+          ? app.name
+          : "";
+    if (name.trim().length === 0) {
       continue;
     }
-    const info = getAppInfo(app);
+    const info = {
+      ...getAppInfo(name),
+      applicationId: typeof app === "string" ? undefined : app.applicationId,
+    };
     const existing = grouped.get(info.category.id) ?? [];
     existing.push(info);
     grouped.set(info.category.id, existing);

--- a/apps/shadcn-registry/src/components/control-bar/app-select.test.tsx
+++ b/apps/shadcn-registry/src/components/control-bar/app-select.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ButtonHTMLAttributes, HTMLAttributes, ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const control = vi.hoisted(() => ({
+  state: {
+    authorizedApps: ["default", "somm-agent"],
+    appDescriptors: [
+      { name: "default" },
+      { name: "somm-agent", applicationId: 1641 },
+    ],
+  },
+  getAuthorizedApps: vi.fn(async () => ["default", "somm-agent"]),
+  getCurrentThreadApp: vi.fn(() => "default"),
+  getCurrentThreadApplicationId: vi.fn(() => null),
+  onAppSelect: vi.fn(),
+  isProcessing: false,
+}));
+
+vi.mock("@aomi-labs/react", () => ({
+  cn: (...classes: Array<string | false | null | undefined>) =>
+    classes.filter(Boolean).join(" "),
+  useControl: () => control,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    variant: _variant,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement> & { variant?: string }) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/ui/command", () => ({
+  Command: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CommandEmpty: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CommandGroup: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CommandInput: () => null,
+  CommandList: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CommandSeparator: () => null,
+  CommandItem: ({
+    children,
+    onSelect,
+    value: _value,
+    ...props
+  }: HTMLAttributes<HTMLButtonElement> & {
+    onSelect?: () => void;
+    value?: string;
+  }) => (
+    <button {...props} onClick={onSelect}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/icons", () => ({
+  AllAppsIcon: () => null,
+  getAppIcon: () => null,
+}));
+
+import { AppSelect } from "./app-select";
+
+describe("AppSelect", () => {
+  beforeEach(() => {
+    control.getAuthorizedApps.mockClear();
+    control.onAppSelect.mockClear();
+  });
+
+  it("passes a hosted app's application id to the controller", () => {
+    render(<AppSelect />);
+
+    fireEvent.click(screen.getByRole("button", { name: "S Somm Agent" }));
+
+    expect(control.onAppSelect).toHaveBeenCalledWith("somm-agent", {
+      applicationId: 1641,
+    });
+  });
+});

--- a/apps/shadcn-registry/src/components/control-bar/app-select.test.tsx
+++ b/apps/shadcn-registry/src/components/control-bar/app-select.test.tsx
@@ -4,13 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const control = vi.hoisted(() => ({
   state: {
-    authorizedApps: ["default", "somm-agent"],
+    authorizedApps: ["default", "partner-agent"],
     appDescriptors: [
       { name: "default" },
-      { name: "somm-agent", applicationId: 2938032 },
+      { name: "partner-agent", applicationId: 42 },
     ],
   },
-  getAuthorizedApps: vi.fn(async () => ["default", "somm-agent"]),
+  getAuthorizedApps: vi.fn(async () => ["default", "partner-agent"]),
   getCurrentThreadApp: vi.fn(() => "default"),
   getCurrentThreadApplicationId: vi.fn(() => null),
   onAppSelect: vi.fn(),
@@ -83,10 +83,10 @@ describe("AppSelect", () => {
   it("passes a hosted app's application id to the controller", () => {
     render(<AppSelect />);
 
-    fireEvent.click(screen.getByRole("button", { name: "S Somm Agent" }));
+    fireEvent.click(screen.getByRole("button", { name: "P Partner Agent" }));
 
-    expect(control.onAppSelect).toHaveBeenCalledWith("somm-agent", {
-      applicationId: 2938032,
+    expect(control.onAppSelect).toHaveBeenCalledWith("partner-agent", {
+      applicationId: 42,
     });
   });
 });

--- a/apps/shadcn-registry/src/components/control-bar/app-select.test.tsx
+++ b/apps/shadcn-registry/src/components/control-bar/app-select.test.tsx
@@ -7,7 +7,7 @@ const control = vi.hoisted(() => ({
     authorizedApps: ["default", "somm-agent"],
     appDescriptors: [
       { name: "default" },
-      { name: "somm-agent", applicationId: 1641 },
+      { name: "somm-agent", applicationId: 2938032 },
     ],
   },
   getAuthorizedApps: vi.fn(async () => ["default", "somm-agent"]),
@@ -86,7 +86,7 @@ describe("AppSelect", () => {
     fireEvent.click(screen.getByRole("button", { name: "S Somm Agent" }));
 
     expect(control.onAppSelect).toHaveBeenCalledWith("somm-agent", {
-      applicationId: 1641,
+      applicationId: 2938032,
     });
   });
 });

--- a/apps/shadcn-registry/src/components/control-bar/app-select.tsx
+++ b/apps/shadcn-registry/src/components/control-bar/app-select.tsx
@@ -37,6 +37,7 @@ export const AppSelect: FC<AppSelectProps> = ({
     state,
     getAuthorizedApps,
     getCurrentThreadApp,
+    getCurrentThreadApplicationId,
     onAppSelect,
     isProcessing,
   } = useControl();
@@ -46,13 +47,14 @@ export const AppSelect: FC<AppSelectProps> = ({
     void getAuthorizedApps();
   }, [getAuthorizedApps]);
 
-  const selectApp = (id: string) => {
+  const selectApp = (id: string, applicationId?: string | number | null) => {
     if (isProcessing) return;
-    onAppSelect(id);
+    onAppSelect(id, { applicationId });
     setOpen(false);
   };
 
   const selectedApp = getCurrentThreadApp();
+  const selectedApplicationId = getCurrentThreadApplicationId();
   const selectedInfo = getAppInfo(selectedApp);
   const SelectedAppIcon = getAppIcon(selectedApp);
 
@@ -60,7 +62,10 @@ export const AppSelect: FC<AppSelectProps> = ({
 
   // Separate "default" (All Apps) from the rest for pinned treatment
   const hasAllApps = apps.includes(ALL_APPS_ID);
-  const otherApps = apps.filter((a) => a !== ALL_APPS_ID);
+  const otherApps =
+    state.appDescriptors.length > 0
+      ? state.appDescriptors.filter((app) => app.name !== ALL_APPS_ID)
+      : apps.filter((app) => app !== ALL_APPS_ID);
   const groups = groupAppsByCategory(otherApps);
 
   if (apps.length === 0) {
@@ -159,12 +164,16 @@ export const AppSelect: FC<AppSelectProps> = ({
               >
                 {group.apps.map((app) => {
                   const AppIcon = getAppIcon(app.id);
+                  const selected =
+                    selectedApp === app.id &&
+                    String(selectedApplicationId ?? "") ===
+                      String(app.applicationId ?? "");
                   return (
                     <CommandItem
-                      key={app.id}
+                      key={`${app.id}:${app.applicationId ?? "unscoped"}`}
                       value={`${app.displayName} ${app.category.label} ${app.id}`}
                       disabled={isProcessing}
-                      onSelect={() => selectApp(app.id)}
+                      onSelect={() => selectApp(app.id, app.applicationId)}
                       className="flex items-center justify-between gap-2"
                     >
                       <div className="flex min-w-0 items-center gap-2">
@@ -172,15 +181,14 @@ export const AppSelect: FC<AppSelectProps> = ({
                           className={cn(
                             "flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[10px] font-medium",
                             "bg-muted text-muted-foreground",
-                            selectedApp === app.id &&
-                              "bg-primary/10 text-primary",
+                            selected && "bg-primary/10 text-primary",
                           )}
                         >
                           {AppIcon ? <AppIcon className="h-4 w-4" /> : app.abbr}
                         </span>
                         <span className="truncate">{app.displayName}</span>
                       </div>
-                      {selectedApp === app.id && (
+                      {selected && (
                         <CheckIcon className="text-primary h-4 w-4 shrink-0" />
                       )}
                     </CommandItem>


### PR DESCRIPTION
## What changed

- preserve hosted app descriptors, including `applicationId`, while grouping control-bar entries
- pass the selected hosted app's `applicationId` into `onAppSelect`
- compare both app name and application ID for selected styling and React keys
- add regression coverage using the production-shaped `somm-agent` descriptor

## Why

Production lists **Somm Agent**, but selecting it immediately falls back to **Basic Apps**. The controller intentionally rejects a scoped hosted app selected by bare name; the dropdown was discarding the descriptor's required `applicationId`.

## Impact

Hosted partner apps can remain selected and route the thread to the exact deployed application. Built-in unscoped apps keep their existing behavior.

## Validation

- Prettier check
- targeted ESLint
- TypeScript library type-check
- widget package build
- full widget test suite: 40 files, 279 tests passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787857845&installation_model_id=12362&pr_number=414&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F414&signature=270370791c5d139265d83d5c53412a4b31dde719617f9d4288a60867e9387d94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->