### PR TITLE
fix partner project usage routing

### DIFF
--- a/apps/build/src/app/(control-plane)/operate/observability/[application]/page.tsx
+++ b/apps/build/src/app/(control-plane)/operate/observability/[application]/page.tsx
@@ -3,7 +3,7 @@ import { AppDetailPage } from "@build/features/operate/app-detail-page";
 
 type PageProps = {
   params: Promise<{ application: string }>;
-  searchParams: Promise<{ project?: string }>;
+  searchParams: Promise<{ project?: string; platform?: string }>;
 };
 
 export default async function OperateObservabilityDetailPage({
@@ -22,5 +22,11 @@ export default async function OperateObservabilityDetailPage({
     notFound();
   }
 
-  return <AppDetailPage applicationId={applicationId} project={projectId} />;
+  return (
+    <AppDetailPage
+      applicationId={applicationId}
+      project={projectId}
+      platform={query.platform}
+    />
+  );
 }

--- a/apps/build/src/features/launch/components/deployments/project-page.tsx
+++ b/apps/build/src/features/launch/components/deployments/project-page.tsx
@@ -98,7 +98,11 @@ export function ProjectPage({
             // Details is merged into Home: status cards first, repo
             // metadata (the former Details tab) below.
             <>
-              <HomeTab detail={detail} tabHref={projectTabHref} />
+              <HomeTab
+                detail={detail}
+                tabHref={projectTabHref}
+                platform={platform}
+              />
               <SettingsTab detail={detail} />
             </>
           ) : active === "deployments" ? (

--- a/apps/build/src/features/launch/components/deployments/tabs/home-tab.test.tsx
+++ b/apps/build/src/features/launch/components/deployments/tabs/home-tab.test.tsx
@@ -133,4 +133,47 @@ describe("HomeTab", () => {
     ).toHaveAttribute("href", "/operate/usage?project=1#partner-payments");
     expect(await screen.findByText("No traffic yet")).toBeInTheDocument();
   });
+
+  it("keeps a partner project platform on usage and ledger reads", async () => {
+    (detail.source as { apps: unknown[] }).apps = [
+      {
+        name: "somm-agent",
+        pricing: {
+          config: {
+            resources: {
+              get_idle_assets: {
+                pricing: { flat: 100 },
+                beneficiary: "banana_evm",
+              },
+            },
+            beneficiaries: [],
+          },
+        },
+      },
+    ];
+
+    render(
+      <HomeTab
+        detail={detail}
+        platform="somm.finance"
+        tabHref={(tab) => `/projects/1?platform=somm.finance&tab=${tab}`}
+      />,
+    );
+
+    expect(await screen.findByText("No traffic yet")).toBeInTheDocument();
+    expect(operateFetch).toHaveBeenCalledWith("usage", {
+      sourceId: 1,
+      platform: "somm.finance",
+    });
+    expect(screen.getByRole("link", { name: /^open usage$/i })).toHaveAttribute(
+      "href",
+      "/operate/usage?project=1&platform=somm.finance",
+    );
+    expect(
+      screen.getByRole("link", { name: "View partner ledger" }),
+    ).toHaveAttribute(
+      "href",
+      "/operate/usage?project=1&platform=somm.finance#partner-payments",
+    );
+  });
 });

--- a/apps/build/src/features/launch/components/deployments/tabs/home-tab.tsx
+++ b/apps/build/src/features/launch/components/deployments/tabs/home-tab.tsx
@@ -159,14 +159,26 @@ function monetizationCard(source: NonNullable<Detail["source"]>) {
   };
 }
 
+function operateUsageHref(
+  sourceId: number,
+  platform?: string,
+  anchor?: string,
+) {
+  const params = new URLSearchParams({ project: String(sourceId) });
+  if (platform) params.set("platform", platform);
+  return `/operate/usage?${params}${anchor ? `#${anchor}` : ""}`;
+}
+
 export function HomeTab({
   detail,
   tabHref,
+  platform,
 }: {
   detail: Detail;
   tabHref?: (
     tab: "home" | "deployments" | "providers" | "environment" | "chat",
   ) => string;
+  platform?: string;
 }) {
   const source = detail.source;
   const [usage, setUsage] = useState<UsagePeek | null>(null);
@@ -180,7 +192,7 @@ export function HomeTab({
     let alive = true;
     operateFetch<{
       daily?: Array<Record<string, unknown>>;
-    }>("usage", source.id)
+    }>("usage", { sourceId: source.id, platform })
       .then((payload) => {
         if (alive) setUsage(summarizeProjectUsage(payload));
       })
@@ -190,7 +202,7 @@ export function HomeTab({
     return () => {
       alive = false;
     };
-  }, [source]);
+  }, [platform, source]);
 
   const status = useMemo(
     () => (source ? projectDeploymentStatus(source) : null),
@@ -345,7 +357,7 @@ export function HomeTab({
               <UsageSpark spark={usage.spark} />
             ) : null
           }
-          actionHref={`/operate/usage?project=${source.id}`}
+          actionHref={operateUsageHref(source.id, platform)}
           actionLabel="Open Usage"
         />
         {monetization ? (
@@ -354,7 +366,11 @@ export function HomeTab({
             value={monetization.value}
             hint={monetization.hint}
             tone={monetization.tone}
-            actionHref={`/operate/usage?project=${source.id}#partner-payments`}
+            actionHref={operateUsageHref(
+              source.id,
+              platform,
+              "partner-payments",
+            )}
             actionLabel="View partner ledger"
           />
         ) : null}

--- a/apps/build/src/features/operate/app-detail-page.test.tsx
+++ b/apps/build/src/features/operate/app-detail-page.test.tsx
@@ -112,7 +112,7 @@ describe("AppDetailPage", () => {
     expect(
       await screen.findByRole("heading", { name: "goal-digger" }),
     ).toBeInTheDocument();
-    expect(operateAppDetailFetch).toHaveBeenCalledWith(1586, 77);
+    expect(operateAppDetailFetch).toHaveBeenCalledWith(1586, 77, undefined);
     expect(screen.queryByText("Partial example data")).not.toBeInTheDocument();
     expect(screen.getByText("Conversion funnel · 24h")).toBeInTheDocument();
     expect(screen.getByText(/20 calls · 1 error/)).toBeInTheDocument();
@@ -133,6 +133,32 @@ describe("AppDetailPage", () => {
     fireEvent.click(await screen.findByText("get_price"));
     expect(push).toHaveBeenCalledWith(
       "/operate/logs?app=goal-digger&tool=get_price&project=1494",
+    );
+  });
+
+  it("keeps a partner platform on detail reads and drill-down links", async () => {
+    render(
+      <AppDetailPage
+        applicationId={77}
+        project={1620}
+        platform="somm.finance"
+      />,
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "goal-digger" }),
+    ).toBeInTheDocument();
+    expect(operateAppDetailFetch).toHaveBeenCalledWith(
+      1620,
+      77,
+      "somm.finance",
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Back to observability" }),
+    );
+    expect(push).toHaveBeenCalledWith(
+      "/operate/observability?project=1620&platform=somm.finance",
     );
   });
 });

--- a/apps/build/src/features/operate/app-detail-page.tsx
+++ b/apps/build/src/features/operate/app-detail-page.tsx
@@ -23,9 +23,11 @@ function operateHref(
 export function AppDetailPage({
   applicationId,
   project,
+  platform,
 }: {
   applicationId: number;
   project: number;
+  platform?: string;
 }) {
   const router = useRouter();
   const [attempt, setAttempt] = useState(0);
@@ -36,7 +38,11 @@ export function AppDetailPage({
     let cancelled = false;
     setPayload(null);
     setError(null);
-    operateAppDetailFetch<LiveAppDetailPayload>(project, applicationId)
+    operateAppDetailFetch<LiveAppDetailPayload>(
+      project,
+      applicationId,
+      platform,
+    )
       .then((result) => {
         if (!cancelled) setPayload(result);
       })
@@ -50,7 +56,7 @@ export function AppDetailPage({
     return () => {
       cancelled = true;
     };
-  }, [applicationId, attempt, project]);
+  }, [applicationId, attempt, platform, project]);
 
   if (error) {
     return (
@@ -86,7 +92,10 @@ export function AppDetailPage({
       app={view.app}
       onBack={() =>
         router.push(
-          operateHref("/operate/observability", { project: projectValue }),
+          operateHref("/operate/observability", {
+            project: projectValue,
+            platform: platform ?? null,
+          }),
         )
       }
       onOpenTrace={(tool) =>
@@ -95,6 +104,7 @@ export function AppDetailPage({
             app: application,
             tool,
             project: projectValue,
+            platform: platform ?? null,
           }),
         )
       }
@@ -104,6 +114,7 @@ export function AppDetailPage({
             app: application,
             tx,
             project: projectValue,
+            platform: platform ?? null,
           }),
         )
       }

--- a/apps/build/src/features/operate/client.test.ts
+++ b/apps/build/src/features/operate/client.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { operateAppDetailFetch, operateFetch } from "./client";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(
+    new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("operate client platform scope", () => {
+  it("sends the project platform with usage reads", async () => {
+    await operateFetch("usage", {
+      sourceId: 1620,
+      platform: "somm.finance",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/bff/operate/usage?appSourceId=1620&platform=somm.finance",
+    );
+  });
+
+  it("sends the project platform with application detail reads", async () => {
+    await operateAppDetailFetch(1620, 2938032, "somm.finance");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/bff/operate/observability/detail?appSourceId=1620&applicationId=2938032&platform=somm.finance",
+    );
+  });
+});

--- a/apps/build/src/features/operate/client.ts
+++ b/apps/build/src/features/operate/client.ts
@@ -9,22 +9,34 @@ export type OperateKind =
   | "logs"
   | "observability";
 
+export type OperateFetchOptions = {
+  sourceId?: number | null;
+  cursor?: unknown;
+  limit?: number;
+  platform?: string | null;
+};
+
 export async function operateFetch<T>(
   kind: OperateKind,
-  sourceId?: number | null,
-  cursor?: unknown,
-  limit?: number,
+  options: OperateFetchOptions = {},
 ): Promise<T> {
   const path = API_PATHS.bff.operate[kind];
   const params = new URLSearchParams();
-  if (sourceId) params.set("appSourceId", String(sourceId));
-  if (cursor) {
+  if (options.sourceId) {
+    params.set("appSourceId", String(options.sourceId));
+  }
+  if (options.platform?.trim()) {
+    params.set("platform", options.platform.trim());
+  }
+  if (options.cursor) {
     params.set(
       "cursor",
-      typeof cursor === "string" ? cursor : JSON.stringify(cursor),
+      typeof options.cursor === "string"
+        ? options.cursor
+        : JSON.stringify(options.cursor),
     );
   }
-  if (limit) params.set("limit", String(limit));
+  if (options.limit) params.set("limit", String(options.limit));
   const res = await fetch(`${path}${params.size ? `?${params}` : ""}`);
   const json = (await res.json().catch(() => ({}))) as T & { error?: string };
   if (!res.ok) {
@@ -36,9 +48,14 @@ export async function operateFetch<T>(
 export async function operateAppDetailFetch<T>(
   appSourceId: number,
   applicationId: number,
+  platform?: string | null,
 ): Promise<T> {
   const res = await fetch(
-    API_PATHS.bff.operate.observabilityDetail(appSourceId, applicationId),
+    API_PATHS.bff.operate.observabilityDetail(
+      appSourceId,
+      applicationId,
+      platform,
+    ),
   );
   const json = (await res.json().catch(() => ({}))) as T & { error?: string };
   if (!res.ok) {

--- a/apps/build/src/features/operate/operate-view.test.tsx
+++ b/apps/build/src/features/operate/operate-view.test.tsx
@@ -635,7 +635,30 @@ describe("OperateView transactions", () => {
     render(<OperateView kind="usage" />);
 
     await waitFor(() => {
-      expect(operateFetch).toHaveBeenCalledWith("usage", 42);
+      expect(operateFetch).toHaveBeenCalledWith("usage", {
+        sourceId: 42,
+        platform: undefined,
+      });
+    });
+  });
+
+  it("keeps ?platform= on project-scoped operate reads", async () => {
+    searchParams.current = new URLSearchParams(
+      "project=1620&platform=somm.finance",
+    );
+    operateFetch.mockResolvedValue({
+      sources: [{ id: 1620, repositoryLink: "aomi/somm-agent", apps: [] }],
+      daily: [],
+      breakdown: [],
+    });
+
+    render(<OperateView kind="usage" />);
+
+    await waitFor(() => {
+      expect(operateFetch).toHaveBeenCalledWith("usage", {
+        sourceId: 1620,
+        platform: "somm.finance",
+      });
     });
   });
 });

--- a/apps/build/src/features/operate/operate-view.tsx
+++ b/apps/build/src/features/operate/operate-view.tsx
@@ -117,7 +117,10 @@ function EmptyState({
   );
 }
 
-function appDetailHref(app: Record<string, any>): string | null {
+function appDetailHref(
+  app: Record<string, any>,
+  platform?: string,
+): string | null {
   const applicationId = Number(app.applicationId);
   const sourceId = Number(app.source?.id);
   if (
@@ -128,7 +131,9 @@ function appDetailHref(app: Record<string, any>): string | null {
   ) {
     return null;
   }
-  return `/operate/observability/${applicationId}?project=${sourceId}`;
+  const params = new URLSearchParams({ project: String(sourceId) });
+  if (platform) params.set("platform", platform);
+  return `/operate/observability/${applicationId}?${params}`;
 }
 
 const STATUS_DOT: Record<string, string> = {
@@ -199,10 +204,12 @@ function Rows({
   kind,
   payload,
   view,
+  platform,
 }: {
   kind: ViewKind;
   payload: OperatePayload;
   view: ViewState;
+  platform?: string;
 }) {
   if (kind === "transactions") {
     const rows = payload.transactions ?? [];
@@ -383,7 +390,7 @@ function Rows({
               : null,
             bytesLabel(metrics.dylibBytes),
           ].filter(Boolean);
-          const detailHref = appDetailHref(app);
+          const detailHref = appDetailHref(app, platform);
           const card = (
             <>
               <div className="flex items-center justify-between gap-3">
@@ -543,8 +550,9 @@ function operateCacheKey(
   accountKey: string,
   kind: ViewKind,
   sourceId: number | null,
+  platform?: string,
 ): string {
-  return `${accountKey}:${kind}:${sourceId ?? "all"}`;
+  return `${accountKey}:${platform ?? "default"}:${kind}:${sourceId ?? "all"}`;
 }
 
 function projectIdFromSearch(raw: string | null): number | null {
@@ -557,6 +565,7 @@ export function OperateView({ kind }: { kind: ViewKind }) {
   const { account } = useGitHubSession();
   const searchParams = useSearchParams();
   const projectFromUrl = projectIdFromSearch(searchParams.get("project"));
+  const platformFromUrl = searchParams.get("platform") ?? undefined;
   const appFromUrl = searchParams.get("app");
   const toolFromUrl = searchParams.get("tool");
   const errorsFromUrl = searchParams.get("errors") === "1";
@@ -575,7 +584,7 @@ export function OperateView({ kind }: { kind: ViewKind }) {
   });
   const [logOpen, setLogOpen] = useState<string | null>(null);
   const initialCacheKey = accountCacheKey
-    ? operateCacheKey(accountCacheKey, kind, sourceId)
+    ? operateCacheKey(accountCacheKey, kind, sourceId, platformFromUrl)
     : null;
   const [payload, setPayload] = useState<OperatePayload | null>(
     () => (initialCacheKey ? operateCache.get(initialCacheKey) : null) ?? null,
@@ -626,7 +635,7 @@ export function OperateView({ kind }: { kind: ViewKind }) {
     }
     let alive = true;
     const key = accountCacheKey
-      ? operateCacheKey(accountCacheKey, kind, sourceId)
+      ? operateCacheKey(accountCacheKey, kind, sourceId, platformFromUrl)
       : null;
     const cached = key ? operateCache.get(key) : null;
     setError(null);
@@ -638,7 +647,10 @@ export function OperateView({ kind }: { kind: ViewKind }) {
       setPayload(null);
       setLoading(true);
     }
-    operateFetch<OperatePayload>(kind, sourceId)
+    operateFetch<OperatePayload>(kind, {
+      sourceId,
+      platform: platformFromUrl,
+    })
       .then((next) => {
         if (key) operateCache.set(key, next);
         if (alive) setPayload(next);
@@ -656,7 +668,14 @@ export function OperateView({ kind }: { kind: ViewKind }) {
     return () => {
       alive = false;
     };
-  }, [account.loading, account.signedIn, accountCacheKey, kind, sourceId]);
+  }, [
+    account.loading,
+    account.signedIn,
+    accountCacheKey,
+    kind,
+    platformFromUrl,
+    sourceId,
+  ]);
 
   if (account.loading) {
     return (
@@ -679,13 +698,13 @@ export function OperateView({ kind }: { kind: ViewKind }) {
     setLoadingMore(true);
     setError(null);
     try {
-      const next = await operateFetch<OperatePayload>(
-        kind,
+      const next = await operateFetch<OperatePayload>(kind, {
         sourceId,
-        nextCursor,
-      );
+        cursor: nextCursor,
+        platform: platformFromUrl,
+      });
       const key = accountCacheKey
-        ? operateCacheKey(accountCacheKey, kind, sourceId)
+        ? operateCacheKey(accountCacheKey, kind, sourceId, platformFromUrl)
         : null;
       setPayload((current) => {
         if (!current) {
@@ -779,7 +798,12 @@ export function OperateView({ kind }: { kind: ViewKind }) {
         </div>
       ) : payload ? (
         <>
-          <Rows kind={kind} payload={payload} view={view} />
+          <Rows
+            kind={kind}
+            payload={payload}
+            view={view}
+            platform={platformFromUrl}
+          />
           {nextCursor ? (
             <div className="flex justify-center">
               <button

--- a/apps/build/src/lib/api-paths.ts
+++ b/apps/build/src/lib/api-paths.ts
@@ -115,11 +115,16 @@ export const API_PATHS = {
       usage: `${BFF}/operate/usage`,
       logs: `${BFF}/operate/logs`,
       observability: `${BFF}/operate/observability`,
-      observabilityDetail: (appSourceId: number, applicationId: number) => {
+      observabilityDetail: (
+        appSourceId: number,
+        applicationId: number,
+        platform?: string | null,
+      ) => {
         const params = new URLSearchParams({
           appSourceId: String(appSourceId),
           applicationId: String(applicationId),
         });
+        if (platform?.trim()) params.set("platform", platform.trim());
         return `${BFF}/operate/observability/detail?${params}`;
       },
     },

--- a/apps/build/src/server/bff/operate/routes.test.ts
+++ b/apps/build/src/server/bff/operate/routes.test.ts
@@ -94,6 +94,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 describe("operateBotsRoute", () => {
@@ -271,8 +272,8 @@ describe("operateBotsDeleteRoute", () => {
   });
 });
 
-function usageReq() {
-  return new Request("http://localhost:3000/api/bff/operate/usage");
+function usageReq(qs = "") {
+  return new Request(`http://localhost:3000/api/bff/operate/usage${qs}`);
 }
 function observabilityReq() {
   return new Request("http://localhost:3000/api/bff/operate/observability");
@@ -363,6 +364,56 @@ function sharedSettlementPayments(applicationId: number | null = null) {
 }
 
 describe("operateUsageRoute statement fallback", () => {
+  it("uses an allowed partner platform for ownership and usage reads", async () => {
+    vi.stubEnv("APP_DEPLOY_PLATFORMS", "community,somm.finance");
+    setSession({ githubUserId: "gh-1" });
+    oneSource();
+    client.getUserSourceUsage.mockResolvedValue({
+      ...emptyUsage,
+      platform: "somm.finance",
+    });
+    client.getUserSourceStatement.mockRejectedValue(new Error("404"));
+
+    const res = await operateUsageRoute(
+      usageReq("?appSourceId=900&platform=somm.finance"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(client.listUserSources).toHaveBeenCalledWith({
+      githubUserId: "gh-1",
+      platform: "somm.finance",
+    });
+    expect(client.getUserSourceUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appSourceId: 900,
+        githubUserId: "gh-1",
+        platform: "somm.finance",
+      }),
+    );
+    expect(client.getUserSourceStatement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appSourceId: 900,
+        githubUserId: "gh-1",
+        platform: "somm.finance",
+      }),
+    );
+  });
+
+  it("rejects a platform outside the configured allowlist", async () => {
+    vi.stubEnv("APP_DEPLOY_PLATFORMS", "community,somm.finance");
+    setSession({ githubUserId: "gh-1" });
+
+    const res = await operateUsageRoute(
+      usageReq("?appSourceId=900&platform=attacker.example"),
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "missing or invalid `platform`",
+    });
+    expect(client.listUserSources).not.toHaveBeenCalled();
+  });
+
   it("serves the example statement (example: true) when the manager has none", async () => {
     setSession({ githubUserId: "gh-1" });
     oneSource();

--- a/apps/build/src/server/bff/operate/routes.ts
+++ b/apps/build/src/server/bff/operate/routes.ts
@@ -24,7 +24,10 @@ import {
 } from "@build/features/operate/format";
 import { deploymentClient } from "@build/server/bff/backend";
 import { authorize } from "@build/server/bff/auth";
-import { launchConfig } from "@build/server/bff/launch/config";
+import {
+  launchConfig,
+  resolveLaunchPlatform,
+} from "@build/server/bff/launch/config";
 import { launchErrorResponse } from "@build/server/bff/launch/errors";
 
 type DeploymentClientInstance = Awaited<ReturnType<typeof deploymentClient>>;
@@ -242,11 +245,23 @@ async function ownedSources(req: Request): Promise<
   const config = launchConfig();
   const client = await deploymentClient();
   const params = new URL(req.url).searchParams;
+  const platform = resolveLaunchPlatform(
+    params.get("platform") ?? undefined,
+    config,
+  );
+  if (!platform) {
+    return {
+      response: NextResponse.json(
+        { error: "missing or invalid `platform`" },
+        { status: 400 },
+      ),
+    };
+  }
   const requestedSourceId = Number(params.get("appSourceId"));
   const sources = await cachedUserSources(
     client,
     session.githubUserId,
-    config.platform,
+    platform,
   );
   if (params.has("appSourceId")) {
     if (!isValidAppSourceId(requestedSourceId)) {
@@ -270,14 +285,14 @@ async function ownedSources(req: Request): Promise<
     }
     return {
       githubUserId: session.githubUserId,
-      platform: config.platform,
+      platform,
       sources: [source],
       client,
     };
   }
   return {
     githubUserId: session.githubUserId,
-    platform: config.platform,
+    platform,
     sources,
     client,
   };


### PR DESCRIPTION
## What changed

- preserve the selected partner `platform` from the project page through Home usage and monetization links
- propagate the platform through Operate list, pagination, app-detail, cache keys, and back/drill-down links
- make the Build BFF validate the requested platform against the configured allowlist before resolving owned sources
- add regression coverage for source 1620 on `somm.finance` and for rejecting an unconfigured platform

## Why

Partner project pages were rendered with `platform=somm.finance`, but their usage/observability requests silently fell back to Build's default platform. That made the Usage card unavailable and would send the merged Monetization card to the wrong ledger scope once pricing metadata was present.

## Impact

`/projects/1620?platform=somm.finance` now keeps the partner scope throughout the project-to-Operate flow. Default-platform behavior remains unchanged.

## Validation

- 59 Build test files / 348 tests passed
- `pnpm --filter aomi-build type-check`
- `pnpm --filter aomi-build build` (74 static pages)
- targeted ESLint passed
- Prettier check passed
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787886398&installation_model_id=12362&pr_number=418&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F418&signature=88e4b89111db8b91652bf43a44e0ee48f0a8a231dfe64c96e2cd267993595094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->