### PR TITLE
Run the Privy delegation ceremony on the wallet kit's Privy instance

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -31,6 +31,18 @@ mistaken for another supported environment.
 
 Progress:
 
+- 2026-07-29 Privy delegation BFF: moved the Portal begin call out of Better
+  Auth's `/api/auth/*` catch-all into an authenticated
+  `/api/delegation/privy/begin` proxy. The route forwards the thread header
+  and a server-minted AccountBearer to the Rust `/api/auth/privy/begin`
+  contract; begin and callback proxy coverage now run under the root Vitest
+  configuration. The standalone authorization page now reuses Portal's root
+  PrivyProvider instead of mounting a second wallet kit, avoiding the SDK's
+  duplicate-provider and server-side IndexedDB failures. New delegation now
+  remains in the Settings surface: it invokes Privy's native login modal,
+  adds Aomi's signer, posts the verified callback, and refreshes the ACL
+  without navigating away.
+
 - 2026-07-27 hosted account-pool hardening: traced recurring Settings auth
   failures to aggregate Supabase session exhaustion across two backend and two
   manager processes plus independently warm Vercel functions. Portal now

--- a/apps/portal/next.config.ts
+++ b/apps/portal/next.config.ts
@@ -24,6 +24,8 @@ const widgetTurbopackAliases = {
   "@/lib": "../../apps/shadcn-registry/src/lib",
   "@aomi-labs/widget-lib/providers/para":
     "../../apps/shadcn-registry/src/lib/wallet-kit/providers/para/index.ts",
+  "@aomi-labs/widget-lib/providers/privy":
+    "../../apps/shadcn-registry/src/lib/wallet-kit/providers/privy/index.ts",
   "@aomi-labs/widget-lib": "../../apps/shadcn-registry/src/index.ts",
 } as const;
 
@@ -36,6 +38,10 @@ const widgetWebpackAliases = {
   "@aomi-labs/widget-lib/providers/para": path.join(
     widgetSrc,
     "lib/wallet-kit/providers/para/index.ts",
+  ),
+  "@aomi-labs/widget-lib/providers/privy": path.join(
+    widgetSrc,
+    "lib/wallet-kit/providers/privy/index.ts",
   ),
   "@aomi-labs/widget-lib": path.join(widgetSrc, "index.ts"),
 } as const;

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -27,7 +27,6 @@
     "@getpara/evm-wallet-connectors": "^2.24.0",
     "@getpara/react-core": "^2.24.0",
     "@getpara/react-sdk": "^2.24.0",
-    "@privy-io/react-auth": "^3.27.1",
     "@solana/web3.js": "^1.98.4",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/apps/portal/src/app/api/delegation/privy/begin/route.test.ts
+++ b/apps/portal/src/app/api/delegation/privy/begin/route.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const canonicalUserId = vi.hoisted(() => vi.fn());
+
+vi.mock("@portal/server/canonical-session", () => ({
+  resolveCanonicalUserId: canonicalUserId,
+}));
+
+vi.mock("@aomi-labs/account/bearer", () => ({
+  mintAccountBearer: vi.fn(async () => ({
+    bearer: "test-account-bearer",
+    expiresAt: 0,
+  })),
+}));
+
+import { POST } from "./route";
+
+describe("Privy delegation begin BFF", () => {
+  afterEach(() => {
+    canonicalUserId.mockReset();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("forwards the begin request through the authenticated backend proxy", async () => {
+    canonicalUserId.mockResolvedValue("user-123");
+    vi.stubEnv("AOMI_PROXY_BACKEND_URL", "https://api.test.aomi.dev");
+    const fetchMock = vi.fn(async () =>
+      Response.json({ auth_url: "https://portal.test/auth/privy?state=abc" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(
+      new NextRequest("https://portal.test/api/delegation/privy/begin", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-thread-id": "thread-123",
+        },
+        body: JSON.stringify({ wallet_family: "evm" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      auth_url: "https://portal.test/auth/privy?state=abc",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL("/api/auth/privy/begin", "https://api.test.aomi.dev/"),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ wallet_family: "evm" }),
+      }),
+    );
+    const headers = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+    expect(headers.get("authorization")).toBe("Bearer test-account-bearer");
+    expect(headers.get("x-thread-id")).toBe("thread-123");
+  });
+
+  it("requires a Portal session before forwarding", async () => {
+    canonicalUserId.mockResolvedValue(null);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(
+      new NextRequest("https://portal.test/api/delegation/privy/begin", {
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: "Authentication required",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/portal/src/app/api/delegation/privy/begin/route.ts
+++ b/apps/portal/src/app/api/delegation/privy/begin/route.ts
@@ -1,0 +1,32 @@
+import { createBackendProxy, type AllowedRoute } from "@aomi-labs/account";
+import { resolveCanonicalUserId } from "@portal/server/canonical-session";
+import { widgetPreflight, widgetRoute } from "@portal/lib/widget-auth/response";
+import type { NextRequest } from "next/server";
+
+// Keep Privy delegation outside `/api/auth/*`: Better Auth owns that namespace
+// through its catch-all route. The Rust endpoint remains the provider-facing
+// contract; this BFF route supplies its trusted AccountBearer and thread header.
+const ROUTES: AllowedRoute[] = [
+  {
+    pattern: /^\/api\/auth\/privy\/begin$/,
+    methods: new Set(["POST"]),
+  },
+];
+
+const proxy = createBackendProxy({
+  allowedRoutes: ROUTES,
+  resolveCanonicalUserId,
+});
+
+export const POST = widgetRoute(
+  (request: NextRequest) =>
+    proxy.POST(request, {
+      params: Promise.resolve({ slug: ["auth", "privy", "begin"] }),
+    }),
+  "Privy delegation begin",
+);
+
+export const OPTIONS = widgetPreflight(["POST", "OPTIONS"]);
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";

--- a/apps/portal/src/app/api/delegation/privy/callback/route.test.ts
+++ b/apps/portal/src/app/api/delegation/privy/callback/route.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./route";
+
+const CALLBACK = {
+  state: "signed-state",
+  access_token: "privy-access-token",
+  user_id: "did:privy:alice",
+  wallets: [
+    {
+      id: "wallet-1",
+      address: "0x1234567890abcdef1234567890ABCDEF12345678",
+      chain_type: "ethereum",
+    },
+  ],
+};
+
+describe("Privy delegation callback proxy", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("forwards a well-formed callback to the configured backend", async () => {
+    vi.stubEnv("AOMI_PROXY_BACKEND_URL", "https://api.test.aomi.dev");
+    const fetchMock = vi.fn(async () => new Response("done", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(
+      new Request("https://portal.test/api/delegation/privy/callback", {
+        method: "POST",
+        body: JSON.stringify(CALLBACK),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ status: "connected" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL("/api/auth/privy/callback", "https://api.test.aomi.dev/"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("rejects malformed browser input without contacting the backend", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(
+      new Request("https://portal.test/api/delegation/privy/callback", {
+        method: "POST",
+        body: JSON.stringify({ state: "missing-token" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not expose an upstream callback body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("secret upstream error", { status: 403 })),
+    );
+
+    const response = await POST(
+      new Request("https://portal.test/api/delegation/privy/callback", {
+        method: "POST",
+        body: JSON.stringify(CALLBACK),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "privy_delegation_rejected",
+    });
+  });
+});

--- a/apps/portal/src/app/api/delegation/privy/callback/route.ts
+++ b/apps/portal/src/app/api/delegation/privy/callback/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type PrivyCallback = {
+  state?: unknown;
+  access_token?: unknown;
+  user_id?: unknown;
+  wallets?: unknown;
+};
+
+function backendBaseUrl(): string {
+  const configured =
+    process.env.AOMI_PROXY_BACKEND_URL ??
+    process.env.BACKEND_URL ??
+    process.env.NEXT_PUBLIC_BACKEND_URL;
+  if (configured) {
+    try {
+      return new URL(configured).toString();
+    } catch {
+      // Browser calls may use `/`; a server-side callback needs an origin.
+    }
+  }
+  if (process.env.VERCEL_ENV === "production") return "https://api.aomi.dev";
+  if (process.env.VERCEL_ENV === "preview") {
+    return "https://api-staging.aomi.dev";
+  }
+  return "http://127.0.0.1:8080";
+}
+
+function isCallback(value: PrivyCallback | null): value is Required<PrivyCallback> {
+  return Boolean(
+    value &&
+      typeof value.state === "string" &&
+      typeof value.access_token === "string" &&
+      typeof value.user_id === "string" &&
+      Array.isArray(value.wallets),
+  );
+}
+
+// The signed `state` binds this public backend callback to the thread which
+// initiated it. This route keeps the Privy access token off cross-origin
+// browser traffic; it does not mint a Portal account session.
+export async function POST(req: Request) {
+  const body = (await req.json().catch(() => null)) as PrivyCallback | null;
+  if (!isCallback(body)) {
+    return NextResponse.json({ error: "invalid_privy_callback" }, { status: 400 });
+  }
+
+  try {
+    const upstream = await fetch(
+      new URL("/api/auth/privy/callback", backendBaseUrl()),
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        cache: "no-store",
+      },
+    );
+    if (!upstream.ok) {
+      console.warn("Privy delegation callback rejected", {
+        status: upstream.status,
+      });
+      return NextResponse.json(
+        { error: "privy_delegation_rejected" },
+        { status: upstream.status },
+      );
+    }
+    return NextResponse.json({ status: "connected" });
+  } catch (error) {
+    console.error("Privy delegation callback upstream failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { error: "privy_delegation_unavailable" },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/portal/src/app/auth/privy/page.tsx
+++ b/apps/portal/src/app/auth/privy/page.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from "react";
+import { PrivyDelegationClient } from "./privy-delegation-client";
+import { PrivyDelegationShell } from "./privy-delegation-shell";
+
+export const dynamic = "force-dynamic";
+
+export default function PrivyDelegationPage() {
+  return (
+    <Suspense fallback={<PrivyDelegationShell status="Loading Privy..." />}>
+      <PrivyDelegationClient />
+    </Suspense>
+  );
+}

--- a/apps/portal/src/app/auth/privy/privy-delegation-client.tsx
+++ b/apps/portal/src/app/auth/privy/privy-delegation-client.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { CheckCircle2, Loader2 } from "lucide-react";
+import { usePrivyDelegation } from "@aomi-labs/widget-lib";
+import { useSearchParams } from "next/navigation";
+import { PrivyDelegationShell } from "./privy-delegation-shell";
+
+export function PrivyDelegationClient() {
+  const params = useSearchParams();
+  const request = useMemo(
+    () => ({
+      appId: params.get("app_id")?.trim() ?? "",
+      signerId: params.get("signer_id")?.trim() ?? "",
+      state: params.get("state")?.trim() ?? "",
+    }),
+    [params],
+  );
+
+  if (!request.appId || !request.signerId || !request.state) {
+    return <PrivyDelegationShell status="Invalid Privy delegation request." />;
+  }
+
+  // The root Portal layout already owns the sole PrivyProvider. Mounting a
+  // second wallet kit here makes the Privy SDK initialize IndexedDB twice and
+  // causes its contexts to update each other while React is rendering.
+  return <PrivyDelegationPanel request={request} />;
+}
+
+function PrivyDelegationPanel({
+  request,
+}: {
+  request: { appId: string; signerId: string; state: string };
+}) {
+  // The ceremony itself lives in the wallet kit, beside the PrivyProvider whose
+  // context it reads. Driving it from here rather than re-implementing it keeps
+  // this page on the same Privy install as the rest of Portal.
+  const { start } = usePrivyDelegation();
+  const [status, setStatus] = useState("Sign in with Privy to authorize Aomi.");
+  const [pending, setPending] = useState(false);
+  const [complete, setComplete] = useState(false);
+
+  const connect = useCallback(async () => {
+    setPending(true);
+    setStatus("Opening Privy...");
+    try {
+      await start({ state: request.state, signerId: request.signerId });
+      setComplete(true);
+      setStatus("Delegation connected. You can return to Aomi.");
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : "Delegation failed.");
+    } finally {
+      setPending(false);
+    }
+  }, [request.signerId, request.state, start]);
+
+  return (
+    <PrivyDelegationShell status={status}>
+      <div className="mt-6">
+        <button
+          className="bg-foreground text-background flex h-11 w-full items-center justify-center gap-2 rounded-md px-4 text-sm font-medium disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={pending || complete}
+          onClick={() => void connect()}
+          type="button"
+        >
+          {complete ? (
+            <CheckCircle2 className="h-4 w-4" />
+          ) : pending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : null}
+          {complete ? "Delegation connected" : "Continue with Privy"}
+        </button>
+      </div>
+    </PrivyDelegationShell>
+  );
+}

--- a/apps/portal/src/app/auth/privy/privy-delegation-shell.tsx
+++ b/apps/portal/src/app/auth/privy/privy-delegation-shell.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+
+export function PrivyDelegationShell({
+  children,
+  status,
+}: {
+  children?: ReactNode;
+  status: string;
+}) {
+  return (
+    <main className="bg-background text-foreground flex min-h-screen items-center justify-center p-6">
+      <section className="w-full max-w-sm">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Connect your Privy wallet
+        </h1>
+        <p className="text-muted-foreground mt-3 text-sm">{status}</p>
+        {children}
+      </section>
+    </main>
+  );
+}

--- a/apps/portal/src/components/providers/aomi-session-bridge.tsx
+++ b/apps/portal/src/components/providers/aomi-session-bridge.tsx
@@ -20,11 +20,13 @@ export type AomiSessionStatus =
 
 export function useAomiSession(): {
   status: AomiSessionStatus;
+  error?: string;
   retry: () => void;
 } {
   const adapter = useAomiAuthAdapter();
   const adapterStatus = adapter.identity.status;
   const accountStatus = adapter.accountStatus;
+  const accountError = adapter.accountError;
   const accountUserId = adapter.accountUser?.id;
   const [probeStatus, setProbeStatus] =
     useState<AomiSessionStatus>("establishing");
@@ -51,6 +53,10 @@ export function useAomiSession(): {
   }, [adapterSettling]);
 
   useEffect(() => {
+    if (adapterStatus === "connected" && accountStatus === "ready" && accountError) {
+      setProbeStatus("error");
+      return;
+    }
     if (adapterSettling && !adapterWaitExpired) {
       setProbeStatus("establishing");
       return;
@@ -120,6 +126,7 @@ export function useAomiSession(): {
     adapterSettling,
     adapterStatus,
     accountStatus,
+    accountError,
     accountUserId,
     adapterWaitExpired,
     probeAttempt,
@@ -127,10 +134,12 @@ export function useAomiSession(): {
 
   const retry = useCallback(() => {
     setProbeAttempt((attempt) => attempt + 1);
+    adapter.retryAccount?.();
     void adapter.connect?.();
   }, [adapter]);
   return {
     status: probeStatus,
+    error: accountError,
     retry,
   };
 }

--- a/apps/portal/src/components/providers/wallet-providers.tsx
+++ b/apps/portal/src/components/providers/wallet-providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import "@aomi-labs/widget-lib/providers/para";
+import "@aomi-labs/widget-lib/providers/privy";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import {
   mainnet,
@@ -24,10 +25,15 @@ import {
   E2EWalletProvider,
   type E2EWalletSeedClient,
 } from "@portal/components/providers/e2e-wallet-provider";
+// Must come from the wallet kit, not a Portal-local copy: the ceremony reads
+// the Privy context that `AomiWalletKitProvider` mounts, and Portal resolves a
+// different `@privy-io/react-auth` install than the kit does.
+import { PrivyDelegationProvider } from "@aomi-labs/widget-lib/providers/privy";
 
 const paraApiKey = process.env.NEXT_PUBLIC_PARA_API_KEY?.trim() ?? "";
 const paraEnvironment =
   process.env.NEXT_PUBLIC_PARA_ENVIRONMENT === "PROD" ? "PROD" : "BETA";
+const privyAppId = process.env.NEXT_PUBLIC_PRIVY_APP_ID?.trim() ?? "";
 
 const walletConnectProjectId =
   process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID?.trim() ||
@@ -124,8 +130,14 @@ export function WalletProviders({ children, e2eWallet }: Props) {
     typeof window !== "undefined" && walletConnectProjectId
       ? (["metamask", "rabby", "coinbase", "walletconnect"] as const)
       : (["metamask", "rabby", "coinbase"] as const);
-  const auth =
-    paraApiKey.length > 0
+  // Privy is the primary embedded-wallet provider when configured. Its
+  // browser SDK attaches Aomi's quorum signer during delegation setup.
+  const auth = privyAppId
+    ? ({
+        provider: "privy",
+        methods: ["email", "google"],
+      } as const)
+    : paraApiKey.length > 0
       ? ({
           provider: "para",
           methods: ["email", "google"],
@@ -157,6 +169,12 @@ export function WalletProviders({ children, e2eWallet }: Props) {
               environment: paraEnvironment,
             }
           : false,
+        privy: privyAppId
+          ? {
+              appId: privyAppId,
+              appName: "Aomi Labs",
+            }
+          : false,
       }}
       wallets={{
         evm: {
@@ -171,7 +189,11 @@ export function WalletProviders({ children, e2eWallet }: Props) {
         },
       }}
     >
-      {children}
+      {privyAppId ? (
+        <PrivyDelegationProvider>{children}</PrivyDelegationProvider>
+      ) : (
+        children
+      )}
     </AomiWalletKitProvider>
   );
 }

--- a/apps/portal/src/components/settings/settings-modal.tsx
+++ b/apps/portal/src/components/settings/settings-modal.tsx
@@ -26,11 +26,13 @@ const NAV: {
 function GateNotice({
   status,
   walletConnected,
+  error,
   onRetry,
   onConnect,
 }: {
   status: Exclude<AomiSessionStatus, "ready">;
   walletConnected?: boolean;
+  error?: string;
   onRetry: () => void;
   onConnect?: () => void;
 }) {
@@ -81,7 +83,7 @@ function GateNotice({
       {status === "error" && (
         <>
           <span className="text-aomi-muted text-[13px]">
-            Couldn’t connect your account. Please try again.
+            {error ?? "Couldn’t connect your account. Please try again."}
           </span>
           <button
             type="button"
@@ -104,7 +106,7 @@ function GateNotice({
  */
 export function SettingsModal({ onClose }: { onClose: () => void }) {
   const [tab, setTab] = useState<SettingsTab>("general");
-  const { status, retry } = useAomiSession();
+  const { status, error: sessionError, retry } = useAomiSession();
   const adapter = useAomiAuthAdapter();
 
   const renderContent = () => {
@@ -117,6 +119,7 @@ export function SettingsModal({ onClose }: { onClose: () => void }) {
         <GateNotice
           status={status}
           walletConnected={adapter.identity.isConnected}
+          error={sessionError}
           onRetry={retry}
           onConnect={
             adapter.openAccountUI
@@ -143,7 +146,7 @@ export function SettingsModal({ onClose }: { onClose: () => void }) {
     switch (tab) {
       case "general":
         return status === "error" ? (
-          <GateNotice status={status} onRetry={retry} />
+          <GateNotice status={status} error={sessionError} onRetry={retry} />
         ) : (
           <div className="px-[22px] py-5">
             <GeneralSettings onManageAccount={() => setTab("account")} />

--- a/apps/portal/src/features/account/account-acl.test.tsx
+++ b/apps/portal/src/features/account/account-acl.test.tsx
@@ -340,4 +340,28 @@ describe("account ACL wiring", () => {
       expect(paths(calls)).toContain("/api/account/providers/privy/grant"),
     );
   });
+
+  // A revoked grant stays in the list as history, so gating the connect CTA on
+  // "no rows" stranded the account: a dead row, no Revoke button (it only
+  // renders while active), and no way to grant again.
+  it("offers a reconnect when every grant is revoked", async () => {
+    installFetchRecorder({
+      "/api/account/grants": () =>
+        Response.json({
+          grants: [
+            { ...GRANTS.grants[0], status: "revoked", revoked_at: 1_760_000_000 },
+          ],
+        }),
+    });
+
+    await renderAcl();
+
+    expect(await screen.findByText(/No active delegation/)).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Reconnect Privy delegation/ }),
+    ).toBeTruthy();
+    // The historical row is still listed, and offers no revoke of its own.
+    expect(screen.getByText("revoked")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Revoke" })).toBeNull();
+  });
 });

--- a/apps/portal/src/features/account/account-acl.test.tsx
+++ b/apps/portal/src/features/account/account-acl.test.tsx
@@ -16,6 +16,8 @@ const walletKit = vi.hoisted(() => ({
   identity: { address: "", svmAddress: undefined as string | undefined },
   // Defaults to the identity; a test sets it to pin the divergent case.
   evmSigningAddress: undefined as string | undefined,
+  // Whether the active EVM connection has a wagmi connector behind it.
+  evmCanSign: true,
 }));
 
 vi.mock("@aomi-labs/widget-lib", () => ({
@@ -150,6 +152,7 @@ describe("account ACL wiring", () => {
   beforeEach(() => {
     walletKit.identity = { address: CONNECTED_EVM, svmAddress: undefined };
     walletKit.evmSigningAddress = undefined;
+    walletKit.evmCanSign = true;
     walletKit.signTypedData.mockClear();
     // The overview store is module-level; seed it so the tab doesn't also
     // depend on /api/account here.
@@ -261,6 +264,29 @@ describe("account ACL wiring", () => {
       screen.getByRole("button", { name: /Sign to authorize/ }),
     ).toHaveProperty("disabled", true);
     expect(paths(calls)).not.toContain("/api/account/authorization/challenge");
+  });
+
+  // What actually happened: Privy's embedded wallet registers as a session with
+  // the synthetic uid `privy-smart-session`, so it IS the active EVM connection
+  // (its address matches the row) but no wagmi connector backs it. wagmi read
+  // `connector: undefined` as "use the current connection" and popped MetaMask
+  // to sign a permit for the Privy wallet.
+  it("blocks a permit when the active connection has no signer behind it", async () => {
+    walletKit.identity = { address: CONNECTED_EVM, svmAddress: undefined };
+    walletKit.evmSigningAddress = CONNECTED_EVM;
+    walletKit.evmCanSign = false;
+    const { calls } = installFetchRecorder();
+
+    await renderAcl();
+    await click(await screen.findByText("0x71C7…976F"));
+    await click(await screen.findByText("Accept transactions"));
+
+    expect(screen.getByText(/no signer wired into this app/)).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Sign to authorize/ }),
+    ).toHaveProperty("disabled", true);
+    expect(paths(calls)).not.toContain("/api/account/authorization/challenge");
+    expect(walletKit.signTypedData).not.toHaveBeenCalled();
   });
 
   // The real failure: Privy reports the embedded wallet as the identity while

--- a/apps/portal/src/features/account/account-acl.test.tsx
+++ b/apps/portal/src/features/account/account-acl.test.tsx
@@ -14,6 +14,8 @@ const walletKit = vi.hoisted(() => ({
   signSolanaMessage: vi.fn(async () => ({ signature: "c2ln" })),
   openAccountUI: vi.fn(async () => undefined),
   identity: { address: "", svmAddress: undefined as string | undefined },
+  // Defaults to the identity; a test sets it to pin the divergent case.
+  evmSigningAddress: undefined as string | undefined,
 }));
 
 vi.mock("@aomi-labs/widget-lib", () => ({
@@ -147,6 +149,7 @@ const bodyOf = (calls: FetchCall[], path: string) => {
 describe("account ACL wiring", () => {
   beforeEach(() => {
     walletKit.identity = { address: CONNECTED_EVM, svmAddress: undefined };
+    walletKit.evmSigningAddress = undefined;
     walletKit.signTypedData.mockClear();
     // The overview store is module-level; seed it so the tab doesn't also
     // depend on /api/account here.
@@ -253,13 +256,32 @@ describe("account ACL wiring", () => {
     await click(row);
     await click(await screen.findByText("Accept transactions"));
 
-    expect(
-      screen.getByText("Connect this wallet itself to widen what it may sign."),
-    ).toBeTruthy();
+    expect(screen.getByText(/Only 0x71C7…976F can widen/)).toBeTruthy();
     expect(
       screen.getByRole("button", { name: /Sign to authorize/ }),
     ).toHaveProperty("disabled", true);
     expect(paths(calls)).not.toContain("/api/account/authorization/challenge");
+  });
+
+  // The real failure: Privy reports the embedded wallet as the identity while
+  // MetaMask is the active connector, so the guard passed, MetaMask signed, and
+  // the backend rejected the permit as `wrong_signer` after the user had
+  // already approved it. Gate on the key that actually signs.
+  it("blocks a loosening permit when the signing key differs from the identity", async () => {
+    walletKit.identity = { address: CONNECTED_EVM, svmAddress: undefined };
+    walletKit.evmSigningAddress = "0xMetaMaskWalletAddress00000000000000000000";
+    const { calls } = installFetchRecorder();
+
+    await renderAcl();
+    await click(await screen.findByText("0x71C7…976F"));
+    await click(await screen.findByText("Accept transactions"));
+
+    expect(screen.getByText(/Only 0x71C7…976F can widen/)).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Sign to authorize/ }),
+    ).toHaveProperty("disabled", true);
+    expect(paths(calls)).not.toContain("/api/account/authorization/challenge");
+    expect(walletKit.signTypedData).not.toHaveBeenCalled();
   });
 
   it("restates a lost version CAS in words instead of raw JSON", async () => {

--- a/apps/portal/src/features/account/account-acl.test.tsx
+++ b/apps/portal/src/features/account/account-acl.test.tsx
@@ -18,6 +18,13 @@ const walletKit = vi.hoisted(() => ({
 
 vi.mock("@aomi-labs/widget-lib", () => ({
   useAomiWalletKit: () => walletKit,
+  // These tests never mount a PrivyProvider, so stand in for the delegation
+  // handle with the same "not configured" behaviour its default context has.
+  usePrivyDelegation: () => ({
+    start: async () => {
+      throw new Error("Privy is not configured for this app.");
+    },
+  }),
 }));
 
 /** Backend `AccountWalletView` rows — the exact wire shape of /api/account/wallets. */

--- a/apps/portal/src/features/account/account-settings.tsx
+++ b/apps/portal/src/features/account/account-settings.tsx
@@ -47,6 +47,7 @@ export function AccountSettings() {
       onCommit={acl.commitMode}
       onRevokeGrant={acl.revokeGrant}
       onStopAllAuto={acl.stopAllAuto}
+      onConnectPrivy={acl.connectPrivy}
       onRegrant={acl.regrant}
       blockedReason={acl.blockedReason}
     />

--- a/apps/portal/src/features/account/account-signing.tsx
+++ b/apps/portal/src/features/account/account-signing.tsx
@@ -37,6 +37,7 @@ interface AccountSigningViewProps {
   onCommit: (wallet: WalletPolicy, mode: SignerMode) => Promise<void>;
   onRevokeGrant: (grant: DelegationGrant) => Promise<void>;
   onStopAllAuto: () => Promise<void>;
+  onConnectPrivy: () => Promise<void>;
   onRegrant: (wallet: WalletPolicy) => Promise<void>;
   /** Why a target mode can't be signed right now, or null when it can. */
   blockedReason?: (wallet: WalletPolicy, mode: SignerMode) => string | null;
@@ -95,6 +96,7 @@ const EMBEDDED_PROVIDERS: Partial<Record<LinkedVia, ProviderIdentity>> = {
 
 /** Busy/error key for the account-wide "stop all auto-signing" action. */
 const STOP_ALL_KEY = "__stop_all__";
+const CONNECT_PRIVY_KEY = "__connect_privy__";
 
 const CUSTODY_GROUPS: { key: Custody; label: string }[] = [
   { key: "self", label: "Self-custody wallets" },
@@ -177,6 +179,7 @@ export function AccountSigningView({
   onCommit,
   onRevokeGrant,
   onStopAllAuto,
+  onConnectPrivy,
   onRegrant,
   blockedReason,
 }: AccountSigningViewProps) {
@@ -309,6 +312,10 @@ export function AccountSigningView({
       return next;
     });
 
+  const connectPrivy = () => {
+    void run(CONNECT_PRIVY_KEY, onConnectPrivy);
+  };
+
   const walletById = (id: string) => wallets.find((w) => w.id === id);
 
   /**
@@ -436,8 +443,23 @@ export function AccountSigningView({
           desc="These grants are what let an “Aomi auto” policy actually reconcile. Revoke to force those wallets back to manual."
         >
           {grants.length === 0 && (
-            <p className="rounded-xl border border-dashed border-aomi-border px-4 py-3 text-[13px] text-aomi-muted">
-              No delegated grants — nothing can sign on your behalf right now.
+            <div className="rounded-xl border border-dashed border-aomi-border px-4 py-3 text-[13px] text-aomi-muted">
+              <p>No delegated grants — nothing can sign on your behalf right now.</p>
+              <button
+                className="mt-3 rounded-lg bg-aomi-accent px-3 py-2 text-xs font-medium text-white disabled:opacity-60"
+                disabled={Boolean(busy[CONNECT_PRIVY_KEY])}
+                onClick={connectPrivy}
+                type="button"
+              >
+                {busy[CONNECT_PRIVY_KEY]
+                  ? "Opening Privy…"
+                  : "Connect Privy delegation"}
+              </button>
+            </div>
+          )}
+          {errors[CONNECT_PRIVY_KEY] && (
+            <p className="text-[13px] text-aomi-danger">
+              {errors[CONNECT_PRIVY_KEY]}
             </p>
           )}
           {grants.map((grant) => (

--- a/apps/portal/src/features/account/account-signing.tsx
+++ b/apps/portal/src/features/account/account-signing.tsx
@@ -347,6 +347,9 @@ export function AccountSigningView({
     void run(STOP_ALL_KEY, onStopAllAuto);
   };
 
+  /** Whether anything can currently sign — revoked and expired rows cannot. */
+  const hasActiveGrant = grants.some((grant) => grant.status === "active");
+
   return (
     <div className="flex-1 overflow-y-auto px-[22px] py-5">
       <div className="flex flex-col gap-6">
@@ -442,9 +445,17 @@ export function AccountSigningView({
           title="Delegated signing grants"
           desc="These grants are what let an “Aomi auto” policy actually reconcile. Revoke to force those wallets back to manual."
         >
-          {grants.length === 0 && (
+          {/* Keyed on "nothing can sign", not "no rows": revoked and expired
+              grants stay in the list as history, and gating on `length === 0`
+              stranded the account after a revoke — a dead row and no way to
+              grant again. */}
+          {!hasActiveGrant && (
             <div className="rounded-xl border border-dashed border-aomi-border px-4 py-3 text-[13px] text-aomi-muted">
-              <p>No delegated grants — nothing can sign on your behalf right now.</p>
+              <p>
+                {grants.length === 0
+                  ? "No delegated grants — nothing can sign on your behalf right now."
+                  : "No active delegation — nothing can sign on your behalf right now."}
+              </p>
               <button
                 className="mt-3 rounded-lg bg-aomi-accent px-3 py-2 text-xs font-medium text-white disabled:opacity-60"
                 disabled={Boolean(busy[CONNECT_PRIVY_KEY])}
@@ -453,7 +464,9 @@ export function AccountSigningView({
               >
                 {busy[CONNECT_PRIVY_KEY]
                   ? "Opening Privy…"
-                  : "Connect Privy delegation"}
+                  : grants.length === 0
+                    ? "Connect Privy delegation"
+                    : "Reconnect Privy delegation"}
               </button>
             </div>
           )}
@@ -471,7 +484,7 @@ export function AccountSigningView({
               onRevoke={() => revokeGrant(grant.id)}
             />
           ))}
-          {grants.some((grant) => grant.status === "active") && (
+          {hasActiveGrant && (
             <button
               onClick={stopAllAuto}
               disabled={Boolean(busy[STOP_ALL_KEY])}

--- a/apps/portal/src/features/account/use-account-acl.ts
+++ b/apps/portal/src/features/account/use-account-acl.ts
@@ -15,6 +15,7 @@ import {
   fetchGrants,
   fetchWalletPolicies,
   revokeProviderGrant,
+  shortenAddress,
 } from "./account-api";
 import type { DelegationGrant, SignerMode, WalletPolicy } from "./types";
 
@@ -85,7 +86,12 @@ export function useAccountAcl(): AccountAcl {
     };
   }, []);
 
-  const evmAddress = adapter.identity.address;
+  // The key that will actually produce the signature, not the displayed
+  // identity. `identity.address` survives a disconnect on a grace window and
+  // can name a different wallet than the connector `signTypedData` uses; a
+  // permit checked against the former and signed by the latter is rejected by
+  // the backend as `wrong_signer` only after the user has already approved it.
+  const evmAddress = adapter.evmSigningAddress ?? adapter.identity.address;
   const svmAddress = adapter.identity.svmAddress;
   const svmCluster =
     adapter.identity.svmCluster ?? adapter.identity.solanaCluster;
@@ -152,7 +158,11 @@ export function useAccountAcl(): AccountAcl {
         needsSelf &&
         signer.address?.toLowerCase() !== wallet.address.toLowerCase()
       ) {
-        return "Connect this wallet itself to widen what it may sign.";
+        // Name both sides: with several wallets connected, "connect this wallet"
+        // gave no clue which one was about to be asked for the signature.
+        return `Only ${shortenAddress(wallet.address)} can widen what it may sign, but ${shortenAddress(
+          signer.address ?? "",
+        )} is the active wallet. Switch to it and try again.`;
       }
       return null;
     },

--- a/apps/portal/src/features/account/use-account-acl.ts
+++ b/apps/portal/src/features/account/use-account-acl.ts
@@ -7,7 +7,8 @@ import {
   type AuthorizationPoster,
   type WalletEip712Payload,
 } from "@aomi-labs/client";
-import { useAomiWalletKit } from "@aomi-labs/widget-lib";
+import { useOptionalAomiRuntime } from "@aomi-labs/react";
+import { useAomiWalletKit, usePrivyDelegation } from "@aomi-labs/widget-lib";
 import { accountScopedFetch } from "@portal/lib/settings-api";
 import {
   explainAccountError,
@@ -59,6 +60,8 @@ export type AccountAcl = {
   commitMode: (wallet: WalletPolicy, mode: SignerMode) => Promise<void>;
   revokeGrant: (grant: DelegationGrant) => Promise<void>;
   stopAllAuto: () => Promise<void>;
+  /** Start a fresh Privy embedded-wallet delegation for the current thread. */
+  connectPrivy: () => Promise<void>;
   /** Re-open the provider so a fresh grant can be minted, then reload. */
   regrant: (wallet: WalletPolicy) => Promise<void>;
   /** Why this wallet can't sign the given change right now, or null if it can. */
@@ -67,6 +70,8 @@ export type AccountAcl = {
 
 export function useAccountAcl(): AccountAcl {
   const adapter = useAomiWalletKit();
+  const runtime = useOptionalAomiRuntime();
+  const privyDelegation = usePrivyDelegation();
   const [wallets, setWallets] = useState<WalletPolicy[]>([]);
   const [grants, setGrants] = useState<DelegationGrant[]>([]);
   const [status, setStatus] = useState<AclStatus>("loading");
@@ -82,10 +87,12 @@ export function useAccountAcl(): AccountAcl {
 
   const evmAddress = adapter.identity.address;
   const svmAddress = adapter.identity.svmAddress;
-  const svmCluster = adapter.identity.svmCluster ?? adapter.identity.solanaCluster;
+  const svmCluster =
+    adapter.identity.svmCluster ?? adapter.identity.solanaCluster;
   const signTypedData = adapter.signTypedData;
   const signSolanaMessage = adapter.signSolanaMessage;
   const openAccountUI = adapter.openAccountUI;
+  const currentThreadId = runtime?.currentThreadId;
 
   const refresh = useCallback(async () => {
     try {
@@ -139,7 +146,8 @@ export function useAccountAcl(): AccountAcl {
       // Loosening authority must be signed by the wallet whose authority grows
       // — except for provider-managed keys, where the user holds no key
       // material and the backend accepts any linked sibling key instead.
-      const needsSelf = isLoosening(wallet.desiredMode, mode) && !wallet.providerManaged;
+      const needsSelf =
+        isLoosening(wallet.desiredMode, mode) && !wallet.providerManaged;
       if (
         needsSelf &&
         signer.address?.toLowerCase() !== wallet.address.toLowerCase()
@@ -172,7 +180,8 @@ export function useAccountAcl(): AccountAcl {
           signTypedData({
             // The backend assembles wagmi-ready EIP-712; the wire type is
             // `unknown` because only the wallet interprets it.
-            typed_data: challenge.typed_data as WalletEip712Payload["typed_data"],
+            typed_data:
+              challenge.typed_data as WalletEip712Payload["typed_data"],
             description: permitDescription(wallet, mode),
           }),
         );
@@ -202,7 +211,14 @@ export function useAccountAcl(): AccountAcl {
 
       await refresh();
     },
-    [blockedReason, refresh, signSolanaMessage, signTypedData, svmAddress, svmCluster],
+    [
+      blockedReason,
+      refresh,
+      signSolanaMessage,
+      signTypedData,
+      svmAddress,
+      svmCluster,
+    ],
   );
 
   const revokeGrant = useCallback(
@@ -228,8 +244,54 @@ export function useAccountAcl(): AccountAcl {
     await refresh();
   }, [grants, refresh]);
 
+  const beginPrivyDelegation = useCallback(
+    async (family: "evm" | "svm") => {
+      if (!currentThreadId) {
+        throw new Error(
+          "Open a chat thread before connecting Privy delegated signing.",
+        );
+      }
+      const response = await fetch("/api/delegation/privy/begin", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Thread-Id": currentThreadId,
+        },
+        body: JSON.stringify({ wallet_family: family }),
+        credentials: "include",
+        cache: "no-store",
+      });
+      const payload = (await response.json().catch(() => null)) as {
+        auth_url?: unknown;
+        state_token?: unknown;
+      } | null;
+      if (
+        !response.ok ||
+        typeof payload?.auth_url !== "string" ||
+        typeof payload.state_token !== "string"
+      ) {
+        throw new Error("Could not start Privy delegated signing.");
+      }
+      const signerId = new URL(payload.auth_url).searchParams
+        .get("signer_id")
+        ?.trim();
+      if (!signerId) {
+        throw new Error(
+          "Privy delegation is missing its signer configuration.",
+        );
+      }
+      await privyDelegation.start({ state: payload.state_token, signerId });
+      await refresh();
+    },
+    [currentThreadId, privyDelegation, refresh],
+  );
+
   const regrant = useCallback(
     async (wallet: WalletPolicy) => {
+      if (wallet.provider?.toLowerCase() === "privy") {
+        await beginPrivyDelegation(wallet.chain);
+        return;
+      }
       if (!openAccountUI) {
         throw new Error(
           "Reconnect this provider from the wallet menu to mint a new grant.",
@@ -241,7 +303,7 @@ export function useAccountAcl(): AccountAcl {
       await openAccountUI({ family: wallet.chain });
       await refresh();
     },
-    [openAccountUI, refresh],
+    [beginPrivyDelegation, openAccountUI, refresh],
   );
 
   return useMemo(
@@ -254,8 +316,10 @@ export function useAccountAcl(): AccountAcl {
       commitMode,
       revokeGrant,
       stopAllAuto,
+      connectPrivy: () => beginPrivyDelegation("evm"),
       regrant,
       blockedReason,
+      beginPrivyDelegation,
     }),
     [
       blockedReason,

--- a/apps/portal/src/features/account/use-account-acl.ts
+++ b/apps/portal/src/features/account/use-account-acl.ts
@@ -92,6 +92,7 @@ export function useAccountAcl(): AccountAcl {
   // permit checked against the former and signed by the latter is rejected by
   // the backend as `wrong_signer` only after the user has already approved it.
   const evmAddress = adapter.evmSigningAddress ?? adapter.identity.address;
+  const evmCanSign = adapter.evmCanSign ?? true;
   const svmAddress = adapter.identity.svmAddress;
   const svmCluster =
     adapter.identity.svmCluster ?? adapter.identity.solanaCluster;
@@ -131,12 +132,18 @@ export function useAccountAcl(): AccountAcl {
   const signerFor = useCallback(
     (wallet: WalletPolicy) =>
       wallet.chain === "evm"
-        ? { address: evmAddress, canSign: Boolean(signTypedData && evmAddress) }
+        ? {
+            address: evmAddress,
+            // `evmCanSign` is false for a provider session with no wagmi
+            // connector: the address is real but nothing can sign for it, and
+            // wagmi would otherwise fall through to another connected wallet.
+            canSign: Boolean(signTypedData && evmAddress && evmCanSign),
+          }
         : {
             address: svmAddress,
             canSign: Boolean(signSolanaMessage && svmAddress),
           },
-    [evmAddress, svmAddress, signSolanaMessage, signTypedData],
+    [evmAddress, evmCanSign, svmAddress, signSolanaMessage, signTypedData],
   );
 
   const blockedReason = useCallback(
@@ -147,6 +154,10 @@ export function useAccountAcl(): AccountAcl {
       const signer = signerFor(wallet);
       const chainLabel = wallet.chain === "evm" ? "Ethereum" : "Solana";
       if (!signer.canSign) {
+        // "Connect a wallet" reads as nonsense when one plainly is connected.
+        if (wallet.chain === "evm" && evmAddress && !evmCanSign) {
+          return `${shortenAddress(evmAddress)} is connected through its provider, which has no signer wired into this app yet, so it can't sign this authorization.`;
+        }
         return `Connect a ${chainLabel} wallet to sign this authorization.`;
       }
       // Loosening authority must be signed by the wallet whose authority grows
@@ -166,7 +177,7 @@ export function useAccountAcl(): AccountAcl {
       }
       return null;
     },
-    [signerFor],
+    [evmAddress, evmCanSign, signerFor],
   );
 
   const commitMode = useCallback(

--- a/apps/portal/vitest.config.ts
+++ b/apps/portal/vitest.config.ts
@@ -16,6 +16,16 @@ export default defineConfig({
       "@/components": resolve(registryDir, "components"),
       "@/hooks": resolve(registryDir, "hooks"),
       "@/lib": resolve(registryDir, "lib"),
+      // Subpath entries must precede the bare package alias — prefix matching
+      // is order-sensitive. Keep in sync with the alias maps in next.config.ts.
+      "@aomi-labs/widget-lib/providers/para": resolve(
+        registryDir,
+        "lib/wallet-kit/providers/para/index.ts",
+      ),
+      "@aomi-labs/widget-lib/providers/privy": resolve(
+        registryDir,
+        "lib/wallet-kit/providers/privy/index.ts",
+      ),
       "@aomi-labs/widget-lib": registryDir,
       "@aomi-labs/account": resolve(currentDir, "../../packages/account/src"),
       "@aomi-labs/client": resolve(currentDir, "../../packages/client/src"),

--- a/apps/shadcn-registry/src/index.ts
+++ b/apps/shadcn-registry/src/index.ts
@@ -67,6 +67,13 @@ export {
   useAomiWalletKit,
 } from "./lib/wallet-kit";
 export { AomiWalletProvider } from "./lib/wallet-kit/providers";
+// The hook only, never `PrivyDelegationProvider` — that one pulls in
+// `@privy-io/react-auth` and stays behind the `providers/privy` subpath so apps
+// that do not use Privy never pay for the SDK.
+export {
+  usePrivyDelegation,
+  type PrivyDelegationContextValue,
+} from "./lib/wallet-kit/providers/privy/privy-delegation-context";
 export {
   AomiBaseAccountProvider,
   type AomiBaseAccountProviderProps,

--- a/apps/shadcn-registry/src/lib/wallet-kit/account/aomi-backend-runtime.test.ts
+++ b/apps/shadcn-registry/src/lib/wallet-kit/account/aomi-backend-runtime.test.ts
@@ -325,6 +325,13 @@ describe("useAomiBackendAccountRuntime", () => {
       ),
     );
     expect(result.current.user).toBeUndefined();
+
+    act(() => result.current.retryProviderCredential?.());
+    await waitFor(() =>
+      expect(
+        mockState.accountClient?.exchangeProviderCredential,
+      ).toHaveBeenCalledTimes(2),
+    );
   });
 
   it("creates a Solana-only account through BetterAuth SIWS", async () => {

--- a/apps/shadcn-registry/src/lib/wallet-kit/account/aomi-backend-runtime.ts
+++ b/apps/shadcn-registry/src/lib/wallet-kit/account/aomi-backend-runtime.ts
@@ -8,7 +8,6 @@ import { brandDisplayName } from "../runtime/evm/brands";
 import type { AccountRuntime, AccountWallet } from "./types";
 import type { AomiAccount, SvmCluster, WalletFamily } from "../types";
 import {
-  AomiAccountRequestError,
   createAomiBackendAccountClient,
   type AomiBackendAccountResponse,
   type AomiBackendNonceResponse,
@@ -86,6 +85,8 @@ export function useAomiBackendAccountRuntime(input: {
     input.enabled ? (widgetSignedOut ? "ready" : "loading") : "disabled",
   );
   const [errorVersion, setErrorVersion] = useState(0);
+  const [providerCredentialRetryVersion, setProviderCredentialRetryVersion] =
+    useState(0);
   const [accountError, setAccountError] = useState<string | undefined>();
   const refreshContextKey = JSON.stringify([
     input.enabled,
@@ -462,13 +463,11 @@ export function useAomiBackendAccountRuntime(input: {
         await refresh();
       } catch (error) {
         credentialFailed.current = { attemptKey, failedAt: Date.now() };
-        if (
-          error instanceof AomiAccountRequestError &&
-          error.status === 409 &&
-          error.code === "already_linked_to_another_account"
-        ) {
-          setAccountError(error.message);
-        }
+        setAccountError(
+          error instanceof Error
+            ? error.message
+            : "Could not establish your account session.",
+        );
         setStatus("ready");
         setErrorVersion((version) => version + 1);
       } finally {
@@ -490,9 +489,18 @@ export function useAomiBackendAccountRuntime(input: {
     accountClient,
     input.auth,
     input.enabled,
+    providerCredentialRetryVersion,
     refresh,
     status,
   ]);
+
+  const retryProviderCredential = useCallback(() => {
+    credentialFailed.current = null;
+    credentialExchanged.current = null;
+    providerSessionAttempted.current = null;
+    setAccountError(undefined);
+    setProviderCredentialRetryVersion((version) => version + 1);
+  }, []);
 
   const liveAccounts = useMemo(
     () => [
@@ -532,6 +540,7 @@ export function useAomiBackendAccountRuntime(input: {
     linkedAccounts: account?.linkedAccounts ?? [],
     wallets,
     getAccountBearer: widgetSessionProvider,
+    retryProviderCredential,
     refresh,
     signOut: async () => {
       if (activeEvmAddress && activeEvmChainId) {

--- a/apps/shadcn-registry/src/lib/wallet-kit/account/types.ts
+++ b/apps/shadcn-registry/src/lib/wallet-kit/account/types.ts
@@ -75,6 +75,8 @@ export type AccountRuntime = {
   linkedAccounts: LinkedAuthAccount[];
   wallets: AccountWallet[];
   refresh: () => Promise<void>;
+  /** Retry a failed provider credential → Better Auth session exchange. */
+  retryProviderCredential?: () => void;
   signOut?: () => Promise<void>;
   deleteAccount?: () => Promise<void>;
   updateAccount?: (input: UpdateAccountInput) => Promise<void>;

--- a/apps/shadcn-registry/src/lib/wallet-kit/composer/AomiWalletKitComposer.tsx
+++ b/apps/shadcn-registry/src/lib/wallet-kit/composer/AomiWalletKitComposer.tsx
@@ -178,6 +178,9 @@ export function AomiWalletKitComposer({
       // Same source the execution runtime resolves `activeConnector` from, so
       // this is the key that will sign — not the grace-window identity above.
       evmSigningAddress: registryState.activeByFamily.evm?.address,
+      // A provider session (Privy's embedded wallet) is a real connection with
+      // no wagmi connector, so it cannot answer a signing request at all.
+      evmCanSign: Boolean(execution.evm.activeConnector),
       walletModalRows,
       accountStatus: account.status,
       accountError: account.error,

--- a/apps/shadcn-registry/src/lib/wallet-kit/composer/AomiWalletKitComposer.tsx
+++ b/apps/shadcn-registry/src/lib/wallet-kit/composer/AomiWalletKitComposer.tsx
@@ -175,6 +175,9 @@ export function AomiWalletKitComposer({
         identity.isConnected,
       canDisconnect: hasAnyDisconnectablePath,
       accounts,
+      // Same source the execution runtime resolves `activeConnector` from, so
+      // this is the key that will sign — not the grace-window identity above.
+      evmSigningAddress: registryState.activeByFamily.evm?.address,
       walletModalRows,
       accountStatus: account.status,
       accountError: account.error,
@@ -244,6 +247,7 @@ export function AomiWalletKitComposer({
     gracefulEvmIdentity.identity.address,
     gracefulEvmIdentity.identity.chainId,
     gracefulEvmIdentity.identity.walletName,
+    registryState.activeByFamily.evm,
     registryStore,
     svm,
     supportedChains,

--- a/apps/shadcn-registry/src/lib/wallet-kit/composer/AomiWalletKitComposer.tsx
+++ b/apps/shadcn-registry/src/lib/wallet-kit/composer/AomiWalletKitComposer.tsx
@@ -181,6 +181,7 @@ export function AomiWalletKitComposer({
       accountUser: account.user,
       accountLinkedAccounts: account.linkedAccounts,
       accountWallets: account.wallets,
+      retryAccount: account.retryProviderCredential,
       signOutAccount: account.signOut,
       deleteAccount: account.deleteAccount,
       updateAccount: account.updateAccount,

--- a/apps/shadcn-registry/src/lib/wallet-kit/composer/types.ts
+++ b/apps/shadcn-registry/src/lib/wallet-kit/composer/types.ts
@@ -84,6 +84,13 @@ export type EvmExecutionRuntime = {
   signTypedData?: (p: WalletEip712Payload) => Promise<{ signature: string }>;
   signMessage?: (p: WalletEip712Payload) => Promise<{ signature: string }>;
   activeConnector?: Connector;
+  /**
+   * Address of the active EVM connection. Present even when `activeConnector`
+   * is not: a provider session is a real connection with no wagmi connector
+   * behind it — Privy's embedded wallet registers under the synthetic uid
+   * `privy-smart-session`, which no wagmi connector will ever match.
+   */
+  activeAddress?: string;
   capabilities?: WalletExecutionKitState["capabilities"];
   chainsById: Record<number, Chain>;
   currentChainId?: number;

--- a/apps/shadcn-registry/src/lib/wallet-kit/execution/execution-runtime.ts
+++ b/apps/shadcn-registry/src/lib/wallet-kit/execution/execution-runtime.ts
@@ -24,6 +24,7 @@ export function buildEvmExecutionRuntime(
 ): EvmExecutionRuntime {
   const runtime: EvmExecutionRuntime = {
     activeConnector: evm.activeConnector,
+    activeAddress: evm.activeEvmConnection?.address,
     capabilities: evm.capabilities,
     chainsById: evm.chainsById,
     currentChainId: evm.activeEvmConnection?.chainId,
@@ -86,8 +87,23 @@ export function buildEvmExecutionRuntime(
             if (!signArgs) {
               throw new Error("Missing typed_data payload");
             }
+            // wagmi reads `connector: undefined` as "use the current
+            // connection". For a provider session that has no wagmi connector,
+            // that silently hands the request to whichever external wallet
+            // happens to be connected — the user is asked to sign as one wallet
+            // on behalf of another, and only the server catches it. Refuse.
+            if (runtime.activeAddress && !runtime.activeConnector) {
+              throw new Error(
+                "This wallet has no signer wired into the app, so it cannot sign here.",
+              );
+            }
             const signature = await signTypedDataAsync({
               ...(signArgs as Record<string, unknown>),
+              // Bind the request to the intended key so a connector holding
+              // several accounts cannot answer with the wrong one.
+              ...(runtime.activeAddress
+                ? { account: runtime.activeAddress }
+                : {}),
               connector: runtime.activeConnector,
             } as never);
             return { signature };

--- a/apps/shadcn-registry/src/lib/wallet-kit/providers/privy/PrivyPluginProvider.tsx
+++ b/apps/shadcn-registry/src/lib/wallet-kit/providers/privy/PrivyPluginProvider.tsx
@@ -165,20 +165,24 @@ export function AomiPrivyPluginProvider({
       getCredential:
         (privy.getIdentityToken ?? privy.getAccessToken)
           ? async (): Promise<AomiAccountCredential | null> => {
-              const identityToken = (await privy.getIdentityToken?.())?.trim();
-              if (identityToken) {
+              // Aomi's delegated-signing callback already verifies Privy's
+              // access token with PRIVY_JWT_VERIFICATION_KEY. Prefer that
+              // same token here so a normal portal sign-in does not silently
+              // depend on a distinct identity-token verification key.
+              const accessToken = (await privy.getAccessToken?.())?.trim();
+              if (accessToken) {
                 return {
                   provider: "privy",
-                  tokenKind: "identity_token",
-                  providerToken: identityToken,
+                  tokenKind: "access_token",
+                  providerToken: accessToken,
                 };
               }
-              const accessToken = (await privy.getAccessToken?.())?.trim();
-              return accessToken
+              const identityToken = (await privy.getIdentityToken?.())?.trim();
+              return identityToken
                 ? {
                     provider: "privy",
-                    tokenKind: "access_token",
-                    providerToken: accessToken,
+                    tokenKind: "identity_token",
+                    providerToken: identityToken,
                   }
                 : null;
             }

--- a/apps/shadcn-registry/src/lib/wallet-kit/providers/privy/index.ts
+++ b/apps/shadcn-registry/src/lib/wallet-kit/providers/privy/index.ts
@@ -1,5 +1,10 @@
 "use client";
 
 export { AomiPrivyProvider, type AomiPrivyProviderProps } from "./privy";
+export { PrivyDelegationProvider } from "./privy-delegation";
+export {
+  usePrivyDelegation,
+  type PrivyDelegationContextValue,
+} from "./privy-delegation-context";
 export { privyPlugin, registerAomiPrivyWalletProvider } from "./privy-plugin";
 export { privyAuth, type PrivyAuthOptions } from "./widget-auth";

--- a/apps/shadcn-registry/src/lib/wallet-kit/providers/privy/privy-delegation-context.ts
+++ b/apps/shadcn-registry/src/lib/wallet-kit/providers/privy/privy-delegation-context.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+/**
+ * The delegation handle, split out from `privy-delegation.tsx` so that consumers
+ * which only *drive* the ceremony can import the hook without pulling in
+ * `@privy-io/react-auth`. Only the provider component needs the SDK; a settings
+ * screen calling `start()` does not, and dragging the SDK into its module graph
+ * costs bundle size in apps and peer dependencies in tests.
+ */
+export type PrivyDelegationContextValue = {
+  start: (input: { state: string; signerId: string }) => Promise<void>;
+};
+
+export const PrivyDelegationContext =
+  createContext<PrivyDelegationContextValue>({
+    start: async () => {
+      throw new Error("Privy is not configured for this app.");
+    },
+  });
+
+export function usePrivyDelegation(): PrivyDelegationContextValue {
+  return useContext(PrivyDelegationContext);
+}

--- a/apps/shadcn-registry/src/lib/wallet-kit/providers/privy/privy-delegation.tsx
+++ b/apps/shadcn-registry/src/lib/wallet-kit/providers/privy/privy-delegation.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  useModalStatus,
+  usePrivy,
+  useSessionSigners,
+} from "@privy-io/react-auth";
+import { PrivyDelegationContext } from "./privy-delegation-context";
+
+/**
+ * The Privy delegation ceremony.
+ *
+ * This lives in the wallet kit rather than in a consuming app because it must
+ * observe the SAME Privy context as {@link PrivyAuthLayer}'s `PrivyProvider`.
+ * React context identity is per module instance, so a copy of this component
+ * that resolved a different `@privy-io/react-auth` install would silently read
+ * the SDK's *default* context — `ready: false`, `authenticated: false`, and a
+ * no-op `login` — and the ceremony would stall with no modal and no error.
+ * Keeping it beside the provider makes that impossible.
+ */
+
+type EmbeddedEvmWallet = {
+  address: string;
+  id: string;
+  chainType?: string;
+  imported?: boolean;
+  walletClientType?: string;
+};
+
+type PendingDelegation = {
+  id: number;
+  state: string;
+  signerId: string;
+  resolve: () => void;
+  reject: (error: Error) => void;
+};
+
+function embeddedEvmWallet(user: unknown): EmbeddedEvmWallet | null {
+  if (!user || typeof user !== "object") return null;
+  const record = user as { wallet?: unknown; linkedAccounts?: unknown[] };
+  const candidates = [record.wallet, ...(record.linkedAccounts ?? [])];
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== "object") continue;
+    const wallet = candidate as Partial<EmbeddedEvmWallet>;
+    if (
+      typeof wallet.id === "string" &&
+      typeof wallet.address === "string" &&
+      /^0x[0-9a-fA-F]{40}$/.test(wallet.address) &&
+      wallet.imported !== true &&
+      (wallet.chainType === undefined ||
+        wallet.chainType === "ethereum" ||
+        wallet.chainType === "evm") &&
+      (wallet.walletClientType === undefined ||
+        wallet.walletClientType === "privy" ||
+        wallet.walletClientType === "privy-v2")
+    ) {
+      return wallet as EmbeddedEvmWallet;
+    }
+  }
+  return null;
+}
+
+/**
+ * Runs the Privy delegation ceremony within the app's one root PrivyProvider.
+ * `login()` opens Privy's native modal; no popup window or second provider is
+ * needed. The signed state remains in memory until the callback succeeds.
+ *
+ * An already-authenticated user with an already-delegated wallet sees no modal
+ * at all — Privy has nothing left to ask — and the ceremony completes straight
+ * through to the callback. That is success, not a stall.
+ */
+export function PrivyDelegationProvider({
+  callbackPath = "/api/delegation/privy/callback",
+  children,
+}: {
+  /** BFF route that verifies the state token and persists the grant. */
+  callbackPath?: string;
+  children: ReactNode;
+}) {
+  const { authenticated, getAccessToken, login, ready, user } = usePrivy();
+  const { addSessionSigners } = useSessionSigners();
+  const { isOpen: modalOpen } = useModalStatus();
+  const [pending, setPending] = useState<PendingDelegation | null>(null);
+  const pendingRef = useRef<PendingDelegation | null>(null);
+  const sequence = useRef(0);
+  const loginStarted = useRef<number | null>(null);
+  const signerStarted = useRef<number | null>(null);
+  const modalWasOpen = useRef(false);
+
+  const settle = useCallback((id: number, error?: Error) => {
+    const operation = pendingRef.current;
+    if (!operation || operation.id !== id) return;
+    pendingRef.current = null;
+    setPending(null);
+    if (error) operation.reject(error);
+    else operation.resolve();
+  }, []);
+
+  const openLogin = useCallback(
+    (operation: PendingDelegation) => {
+      if (loginStarted.current === operation.id) return;
+      loginStarted.current = operation.id;
+      try {
+        // `login` synchronously opens Privy's native modal. Invoke it from the
+        // initiating interaction whenever the SDK is ready rather than waiting
+        // for a later render effect (which can lose the browser interaction).
+        login();
+      } catch (error) {
+        settle(
+          operation.id,
+          error instanceof Error
+            ? error
+            : new Error("Privy login could not be opened."),
+        );
+      }
+    },
+    [login, settle],
+  );
+
+  const start = useCallback(
+    ({ signerId, state }: { state: string; signerId: string }) =>
+      new Promise<void>((resolve, reject) => {
+        if (pendingRef.current) {
+          reject(new Error("A Privy delegation is already in progress."));
+          return;
+        }
+        const operation: PendingDelegation = {
+          id: ++sequence.current,
+          state,
+          signerId,
+          resolve,
+          reject,
+        };
+        pendingRef.current = operation;
+        setPending(operation);
+        if (ready && !authenticated) openLogin(operation);
+      }),
+    [authenticated, openLogin, ready],
+  );
+
+  // There is no `usePrivy().error` to observe here, so a sign-in the user backs
+  // out of would leave the ceremony pending forever. Watch the modal instead:
+  // once it has opened for this operation and closed again with no session, the
+  // user dismissed it.
+  useEffect(() => {
+    if (!pending) {
+      modalWasOpen.current = false;
+      return;
+    }
+    if (modalOpen) {
+      modalWasOpen.current = true;
+      return;
+    }
+    if (modalWasOpen.current && !authenticated) {
+      modalWasOpen.current = false;
+      settle(pending.id, new Error("Privy sign-in was dismissed."));
+    }
+  }, [authenticated, modalOpen, pending, settle]);
+
+  useEffect(() => {
+    if (!pending) return;
+    if (!ready) return;
+    if (!authenticated) {
+      openLogin(pending);
+      return;
+    }
+    if (signerStarted.current === pending.id) return;
+    const wallet = embeddedEvmWallet(user);
+    if (!wallet) {
+      settle(
+        pending.id,
+        new Error("Privy did not create an embedded Ethereum wallet."),
+      );
+      return;
+    }
+    signerStarted.current = pending.id;
+    void (async () => {
+      // Kept so a failed callback can explain itself: re-granting an
+      // already-authorized wallet throws here in the normal case, so this is
+      // only worth reporting once the authoritative step has also failed.
+      let addSignersError: unknown;
+      try {
+        try {
+          await addSessionSigners({
+            address: wallet.address,
+            signers: [{ signerId: pending.signerId, policyIds: [] }],
+          });
+        } catch (error) {
+          // Re-granting an already-authorized wallet is expected. The backend
+          // callback verifies the signer before persisting anything, so keep
+          // that authoritative check rather than treating this as a failure.
+          addSignersError = error;
+        }
+        const accessToken = await getAccessToken();
+        if (!accessToken || !user?.id) {
+          throw new Error("Privy did not provide an access token.");
+        }
+        const response = await fetch(callbackPath, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({
+            state: pending.state,
+            access_token: accessToken,
+            user_id: user.id,
+            wallets: [
+              {
+                id: wallet.id,
+                address: wallet.address,
+                chain_type: "ethereum",
+              },
+            ],
+          }),
+        });
+        if (!response.ok) {
+          const because =
+            addSignersError instanceof Error
+              ? ` Privy also rejected the signer: ${addSignersError.message}`
+              : "";
+          throw new Error(
+            `Aomi could not save the delegation (HTTP ${response.status}).${because}`,
+          );
+        }
+        settle(pending.id);
+      } catch (error) {
+        settle(
+          pending.id,
+          error instanceof Error
+            ? error
+            : new Error("Privy delegation failed."),
+        );
+      }
+    })();
+  }, [
+    addSessionSigners,
+    authenticated,
+    callbackPath,
+    getAccessToken,
+    openLogin,
+    pending,
+    ready,
+    settle,
+    user,
+  ]);
+
+  useEffect(() => {
+    if (!pending || ready) return;
+    const timer = globalThis.setTimeout(
+      () =>
+        settle(
+          pending.id,
+          new Error(
+            "Privy is still loading. Disable privacy/ad-blocking extensions and try again.",
+          ),
+        ),
+      12_000,
+    );
+    return () => globalThis.clearTimeout(timer);
+  }, [pending, ready, settle]);
+
+  return (
+    <PrivyDelegationContext.Provider value={{ start }}>
+      {children}
+    </PrivyDelegationContext.Provider>
+  );
+}

--- a/apps/shadcn-registry/src/lib/wallet-kit/types.ts
+++ b/apps/shadcn-registry/src/lib/wallet-kit/types.ts
@@ -305,6 +305,7 @@ export type AomiWalletKit = {
   accountUser?: AomiUserRef;
   accountLinkedAccounts?: readonly LinkedAuthAccount[];
   accountWallets?: readonly AccountWallet[];
+  retryAccount?: () => void;
   signOutAccount?: () => Promise<void>;
   deleteAccount?: () => Promise<void>;
   updateAccount?: (input: UpdateAccountInput) => Promise<void>;

--- a/apps/shadcn-registry/src/lib/wallet-kit/types.ts
+++ b/apps/shadcn-registry/src/lib/wallet-kit/types.ts
@@ -296,6 +296,19 @@ export type AomiWalletKit = {
   selectedSolanaNetwork?: SvmNetworkOption;
   solanaNetworkSwitchRequiresReconnect?: boolean;
 
+  /**
+   * The EVM address that `signTypedData`/`signMessage` will actually sign with:
+   * the registry's active connection, which is the connector the execution
+   * runtime hands to wagmi.
+   *
+   * Deliberately separate from `identity.address`. That one is the *displayed*
+   * identity and keeps reporting a cached value through a disconnect grace
+   * window, so the two legitimately diverge — the composer logs
+   * `registry:shadow-diff` when they do. Anything that must hold for the key
+   * that actually produces a signature, such as a permit only the wallet itself
+   * may sign, has to check this one.
+   */
+  evmSigningAddress?: string;
   /** All wallet accounts known to the adapter, tagged by family. */
   accounts: readonly AomiAccount[];
   /** Unified picker rows: live accounts, stored account-runtime rows, and options. */

--- a/apps/shadcn-registry/src/lib/wallet-kit/types.ts
+++ b/apps/shadcn-registry/src/lib/wallet-kit/types.ts
@@ -309,6 +309,12 @@ export type AomiWalletKit = {
    * may sign, has to check this one.
    */
   evmSigningAddress?: string;
+  /**
+   * Whether the active EVM connection can actually answer a signing request.
+   * False for a provider session with no wagmi connector behind it, where the
+   * address is real but nothing is wired up to sign for it.
+   */
+  evmCanSign?: boolean;
   /** All wallet accounts known to the adapter, tagged by family. */
   accounts: readonly AomiAccount[];
   /** Unified picker rows: live accounts, stored account-runtime rows, and options. */

--- a/apps/shadcn-registry/src/test/mocks/privy-react-auth.tsx
+++ b/apps/shadcn-registry/src/test/mocks/privy-react-auth.tsx
@@ -33,3 +33,18 @@ export function usePrivy() {
 export function useWallets() {
   return { wallets: [] as ConnectedWallet[], ready: false };
 }
+
+/** Used by the delegation ceremony in `providers/privy/privy-delegation.tsx`.
+ *  Inert here: `usePrivy().ready` is false in this mock, so the ceremony never
+ *  reaches the signer step. */
+export function useSessionSigners() {
+  return {
+    addSessionSigners: async () => undefined,
+    removeSessionSigners: async () => undefined,
+  };
+}
+
+/** Also read by the delegation ceremony, to notice a dismissed sign-in. */
+export function useModalStatus() {
+  return { isOpen: false };
+}

--- a/packages/account/src/better-auth/env.ts
+++ b/packages/account/src/better-auth/env.ts
@@ -127,13 +127,37 @@ function collectTrustedOrigins(
   env: AccountAuthEnvInput,
   betterAuthUrl: string,
 ): string[] {
+  const localOrigins = isAccountAuthLocalRuntime(env)
+    ? localLoopbackOrigins(betterAuthUrl)
+    : [];
   return uniqueOrigins([
     ...parseCsv(env.AOMI_TRUSTED_ORIGINS),
     betterAuthUrl,
+    ...localOrigins,
     firstUrl(env.VERCEL_BRANCH_URL),
     firstUrl(env.VERCEL_URL),
     firstUrl(env.VERCEL_PROJECT_PRODUCTION_URL),
   ]);
+}
+
+/** Browsers treat localhost and 127.0.0.1 as distinct origins. The local dev
+ * launcher binds the latter, while users commonly open the former. Trust both
+ * loopback spellings only in development so provider-session exchange works
+ * whichever URL was typed into the browser. */
+function localLoopbackOrigins(betterAuthUrl: string): string[] {
+  const url = new URL(betterAuthUrl);
+  // Account's historical package fallback is :3001, while Portal's local dev
+  // server defaults to :3000. Include both in dev so a manual `pnpm dev`
+  // startup cannot reject the browser's normal Portal origin.
+  const ports = new Set([url.port, "3000"]);
+  return [...ports].flatMap((port) => {
+    const suffix = port ? `:${port}` : "";
+    return [
+      `http://localhost${suffix}`,
+      `http://127.0.0.1${suffix}`,
+      `http://[::1]${suffix}`,
+    ];
+  });
 }
 
 function resolveSiweDomain(

--- a/packages/account/src/better-auth/provider-plugin.ts
+++ b/packages/account/src/better-auth/provider-plugin.ts
@@ -59,59 +59,81 @@ export function aomiProviderAuthPlugin(): BetterAuthPlugin {
                 error instanceof Error
                   ? error.message
                   : "provider_exchange_failed",
-            });
+              });
           }
-          const seed = providerSessionUserSeed(verified);
-          const existing = seed.email
-            ? await ctx.context.internalAdapter.findUserByEmail(seed.email, {
-                includeAccounts: false,
-              })
-            : null;
-          const betterAuthUser =
-            existing?.user ??
-            (await ctx.context.internalAdapter.createUser({
-              email: seed.email,
-              emailVerified: seed.emailVerified,
-              name: seed.name,
-            }));
-          const resolution = await signInWithVerifiedProviderCredential({
-            betterAuthUserId: betterAuthUser.id,
-            verified,
-            email: seed.email,
-            name: seed.name,
-          });
-          if (resolution.status === "conflict") {
-            console.error("provider credential link conflict", {
-              provider: verified.provider,
-              subject: verified.token.subject,
-              betterAuthUserId: betterAuthUser.id,
-              signalType: resolution.signalType,
-            });
-            throw new APIError("CONFLICT", {
-              message: "already_linked_to_another_account",
-            });
-          }
-          const aomiUser = resolution.user;
-          if (!aomiUser) throw new Error("resolved_account_not_found");
+          let stage = "provision_better_auth_user";
+          try {
+            const seed = providerSessionUserSeed(verified);
+            const existing = seed.email
+              ? await ctx.context.internalAdapter.findUserByEmail(seed.email, {
+                  includeAccounts: false,
+                })
+              : null;
+            const betterAuthUser =
+              existing?.user ??
+              (await ctx.context.internalAdapter.createUser({
+                email: seed.email,
+                emailVerified: seed.emailVerified,
+                name: seed.name,
+              }));
 
-          const session = await ctx.context.internalAdapter.createSession(
-            betterAuthUser.id,
-          );
-          await setSessionCookie(ctx, {
-            session,
-            user: betterAuthUser,
-          });
-          return ctx.json({
-            status: "linked",
-            account: await buildAccountResponse({
-              user: aomiUser,
-              session: {
-                carrier: "better_auth",
+            stage = "link_account";
+            const resolution = await signInWithVerifiedProviderCredential({
+              betterAuthUserId: betterAuthUser.id,
+              verified,
+              email: seed.email,
+              name: seed.name,
+            });
+            if (resolution.status === "conflict") {
+              console.error("provider credential link conflict", {
+                provider: verified.provider,
+                subject: verified.token.subject,
                 betterAuthUserId: betterAuthUser.id,
-                expiresAt: session.expiresAt,
-              },
-            }),
-          });
+                signalType: resolution.signalType,
+              });
+              throw new APIError("CONFLICT", {
+                message: "already_linked_to_another_account",
+              });
+            }
+            const aomiUser = resolution.user;
+            if (!aomiUser) throw new Error("resolved_account_not_found");
+
+            stage = "create_session";
+            const session = await ctx.context.internalAdapter.createSession(
+              betterAuthUser.id,
+            );
+            if (!session) {
+              throw new Error("better_auth_session_not_created");
+            }
+            await setSessionCookie(ctx, {
+              session,
+              user: betterAuthUser,
+            });
+
+            stage = "build_account_response";
+            return ctx.json({
+              status: "linked",
+              account: await buildAccountResponse({
+                user: aomiUser,
+                session: {
+                  carrier: "better_auth",
+                  betterAuthUserId: betterAuthUser.id,
+                  expiresAt: session.expiresAt,
+                },
+              }),
+            });
+          } catch (error) {
+            if (error instanceof APIError) throw error;
+            console.error("provider exchange failed", {
+              provider: verified.provider,
+              stage,
+              error: error instanceof Error ? error.message : String(error),
+              claims: decodeClaimsForLog(credential.providerToken),
+            });
+            throw new APIError("INTERNAL_SERVER_ERROR", {
+              message: `provider_exchange_${stage}_failed`,
+            });
+          }
         },
       ),
     },

--- a/packages/account/src/providers/privy.ts
+++ b/packages/account/src/providers/privy.ts
@@ -54,7 +54,10 @@ export type VerifyPrivyAccessToken = (
 export function createPrivyAccessTokenVerifier(
   config: PrivyAccessTokenVerifierConfig,
 ): VerifyPrivyAccessToken {
-  const verificationKey = importSPKI(config.jwtVerificationKey, "ES256");
+  const verificationKey = importSPKI(
+    normalizePem(config.jwtVerificationKey),
+    "ES256",
+  );
 
   return async (accessToken: string): Promise<VerifiedPrivyAccessToken> => {
     const { payload } = await jwtVerify(accessToken, await verificationKey, {
@@ -101,7 +104,7 @@ export async function verifyPrivyToken(input: {
   if (!key) {
     throw new Error("Privy identity-token verification key is not configured");
   }
-  const cryptoKey = await importSPKI(key, "ES256");
+  const cryptoKey = await importSPKI(normalizePem(key), "ES256");
   const { payload } = await jwtVerify<PrivyClaims>(input.token, cryptoKey, {
     issuer: "privy.io",
     audience: input.appId,
@@ -126,6 +129,13 @@ export async function verifyPrivyToken(input: {
     linkedAccounts,
     rawClaims: { ...payload },
   };
+}
+
+// `.env` files commonly encode PEM newlines as the two literal characters
+// `\\n`. `jose` treats that backslash as part of the base64 body and rejects
+// the key, so accept either representation at this trust boundary.
+function normalizePem(value: string): string {
+  return value.replaceAll("\\r\\n", "\n").replaceAll("\\n", "\n");
 }
 
 /** Fetch every wallet Privy attests is owned by `userId` (a verified

--- a/packages/account/test/env.test.ts
+++ b/packages/account/test/env.test.ts
@@ -19,6 +19,30 @@ describe("readAccountAuthEnv", () => {
     expect(env.databaseUrl).toBe(TEST_DATABASE_URL);
   });
 
+  it("trusts localhost and loopback aliases during local development", () => {
+    const env = readAccountAuthEnv({
+      BETTER_AUTH_URL: "http://127.0.0.1:3000",
+      DATABASE_URL: TEST_DATABASE_URL,
+      NODE_ENV: "development",
+    });
+
+    expect(env.trustedOrigins).toEqual([
+      "http://127.0.0.1:3000",
+      "http://localhost:3000",
+      "http://[::1]:3000",
+    ]);
+  });
+
+  it("trusts Portal's default :3000 origin with the legacy auth URL fallback", () => {
+    const env = readAccountAuthEnv({
+      DATABASE_URL: TEST_DATABASE_URL,
+      NODE_ENV: "development",
+    });
+
+    expect(env.betterAuthUrl).toBe("http://localhost:3001");
+    expect(env.trustedOrigins).toContain("http://localhost:3000");
+  });
+
   it("requires BetterAuth secret outside development and test", () => {
     expect(() =>
       readAccountAuthEnv({

--- a/packages/account/test/privy.test.ts
+++ b/packages/account/test/privy.test.ts
@@ -28,6 +28,30 @@ describe("createPrivyAccessTokenVerifier", () => {
       sessionId: "session-id",
     });
   });
+
+  it("accepts a PEM loaded from an env file with escaped newlines", async () => {
+    const { privateKey, publicKey } = await generateKeyPair("ES256");
+    const jwtVerificationKey = (await exportSPKI(publicKey)).replaceAll(
+      "\n",
+      "\\n",
+    );
+    const verify = createPrivyAccessTokenVerifier({
+      appId: "privy-app",
+      jwtVerificationKey,
+    });
+    const accessToken = await new SignJWT({ sid: "session-id" })
+      .setProtectedHeader({ alg: "ES256" })
+      .setSubject("did:privy:alice")
+      .setIssuer("privy.io")
+      .setAudience("privy-app")
+      .setExpirationTime("1h")
+      .sign(privateKey);
+
+    await expect(verify(accessToken)).resolves.toMatchObject({
+      userId: "did:privy:alice",
+      sessionId: "session-id",
+    });
+  });
 });
 
 describe("verifyPrivyToken", () => {

--- a/packages/account/test/provider-plugin.test.ts
+++ b/packages/account/test/provider-plugin.test.ts
@@ -78,4 +78,40 @@ describe("provider auth plugin", () => {
     });
     expect(createSession).not.toHaveBeenCalled();
   });
+
+  it("returns a safe stage code when account linking fails unexpectedly", async () => {
+    exchangeMocks.signInWithVerifiedProviderCredential.mockRejectedValueOnce(
+      new Error("database unavailable"),
+    );
+    const endpoint = aomiProviderAuthPlugin().endpoints
+      ?.exchangeProviderToken as unknown as (ctx: unknown) => Promise<unknown>;
+
+    await expect(
+      endpoint({
+        request: new Request(
+          "https://chat.aomi.dev/api/auth/aomi/provider/exchange",
+        ),
+        body: { provider: "privy", providerToken: "token" },
+        context: {
+          internalAdapter: {
+            findUserByEmail: vi.fn(async () => ({
+              user: {
+                id: "ba-user-1",
+                email: "alice@example.com",
+                emailVerified: true,
+                name: "Alice",
+              },
+            })),
+            createUser: vi.fn(),
+            createSession: vi.fn(),
+          },
+        },
+        json: vi.fn(),
+      }),
+    ).rejects.toMatchObject({
+      body: expect.objectContaining({
+        message: "provider_exchange_link_account_failed",
+      }),
+    });
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -579,9 +579,6 @@ importers:
       '@getpara/react-sdk':
         specifier: ^2.24.0
         version: 2.24.0(5fa8ac97d642b29558a9f2b73ec7e673)
-      '@privy-io/react-auth':
-        specifier: ^3.27.1
-        version: 3.27.1(d04cc54dbaf9119316f1ab3048b026e0)
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
       "apps/build/src/**/*.{test,spec}.{ts,tsx}",
       "apps/portal/src/{app,server}/mcp/**/*.{test,spec}.{ts,tsx}",
       "apps/portal/src/lib/widget-auth/**/*.{test,spec}.{ts,tsx}",
-      "apps/portal/src/app/api/*/route.{test,spec}.{ts,tsx}",
+      "apps/portal/src/app/api/**/route.{test,spec}.{ts,tsx}",
     ],
     exclude: [".claude/**", "**/.claude/**", "**/node_modules/**", "dist/**"],
     restoreMocks: true,


### PR DESCRIPTION
## The bug

Clicking **"Connect Privy delegation"** never opened the Privy modal.

The server half was fine — `/api/delegation/privy/begin` returns 200 with a valid `signer_id`. The break was **two copies of the SDK**.

Portal declared `@privy-io/react-auth@^3.27.1`; the wallet kit (`apps/shadcn-registry`) declares `^2.0.0`. Incompatible ranges, so pnpm kept both. `AomiWalletKitProvider` mounts the **v2** `PrivyProvider`, but Portal's `PrivyDelegationProvider` called **v3**'s `usePrivy()`. React context identity is per module instance, so it silently read v3's *default* context:

```
ready: false, authenticated: false, user: null, login: /* no-op */
```

With `ready` permanently false, `start()` skipped `if (ready && !authenticated) openLogin(...)`, the effect bailed at `if (!ready) return`, and twelve seconds later the user got a misleading *"disable privacy/ad-blocking extensions"*. Even with `ready` true, `login` was a stub.

Confirmed on the live page: exactly one Privy iframe, the v2 one.

## The fix

Move the ceremony into the wallet kit, beside the provider whose context it reads, ported to v2's `useSessionSigners().addSessionSigners` — identical argument shape to v3's `addSigners`. Portal drops its own `@privy-io/react-auth` dependency, leaving one install.

The SDK-free context and hook live in `privy-delegation-context.ts`, exported from the kit's main entry, so a screen that only *drives* the ceremony doesn't pull the Privy SDK into its module graph. `PrivyDelegationProvider` stays behind the `providers/privy` subpath, so apps that don't use Privy keep paying nothing for it.

Two things the port had to handle:

- v2 has no `usePrivy().error`, so a dismissed sign-in would leave the ceremony pending forever. `useModalStatus()` covers it — a modal that opened and closed again with no session means the user backed out.
- `/auth/privy` re-implemented the same ceremony against the same dead context, leaving its button permanently disabled by `!privy.ready`. It now drives the shared one.

This is the same failure mode `next.config.ts` already guards against by pinning `viem`, `wagmi`, `zustand`, and `@tanstack/react-query` to Portal's copy — `@privy-io/react-auth` was simply not on that list. Portal's Vitest config gains the `@aomi-labs/widget-lib/providers/*` subpath aliases next.config already had, ordered before the bare package alias.

## Reviewing locally

Turbopack caches these `externalDir` registry modules aggressively and will keep reporting errors that quote **deleted** source until you clear the cache:

```bash
rm -rf apps/portal/.next
```

## Verification

`tsc --noEmit` clean, eslint clean, **277** wallet-kit + **311** Portal tests passing. The lockfile change is deliberately three lines — a full re-resolve churns unrelated majors (zod 3→4, `@solana/kit` 3→2), which does not belong in this PR. `pnpm install --frozen-lockfile` passes.

## Scope note

This branch also carries the delegation work the fix sits on top of, which was uncommitted: the `/api/delegation/privy/{begin,callback}` BFF routes that keep Privy out of Better Auth's `/api/auth/*` catch-all, the Settings delegation surface, the account runtime's provider-credential exchange and retry path, and the Privy JWT verification and provider-exchange error handling in `packages/account`.

Pairs with aomi-labs/product-mono#897.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787930330&installation_model_id=12362&pr_number=419&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F419&signature=95030fd2666ca34de39a36406bfdfa6aa124bbd26560105d383083db4f69f375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->