### PR TITLE
Verify AccountBearer subjects before signing

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -31,6 +31,11 @@ mistaken for another supported environment.
 
 Progress:
 
+- 2026-07-29 AccountBearer account invariant: kept the canonical-id issuance
+  API and added a final active-account lookup inside `mintAccountBearer`, so a
+  missing or deactivated subject is refused before signing. Verified the full
+  account suite, account and Portal type-checks, and the repository lint.
+
 - 2026-07-29 integrations consolidation: moved the functional Telegram bot
   configuration from Operate into Integrations, retained Discord as an explicit
   coming-soon integration, and redirected the retired Bots route. Verified the

--- a/packages/account/src/bearer.test.ts
+++ b/packages/account/src/bearer.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DbAomiUser } from "./types";
+
+const mocks = vi.hoisted(() => ({
+  findAomiUserById: vi.fn(),
+  mint: vi.fn(),
+}));
+
+vi.mock("./db/queries", () => ({
+  findAomiUserById: mocks.findAomiUserById,
+}));
+
+vi.mock("./topology", () => ({
+  portalService: () => ({ mint: mocks.mint }),
+}));
+
+import {
+  ACCOUNT_BEARER_TTL_SECONDS,
+  AUDIENCE,
+  mintAccountBearer,
+} from "./bearer";
+
+const USER: DbAomiUser = {
+  id: "canonical-user-123",
+  betterAuthUserId: "better-auth-123",
+  displayName: null,
+  primaryEmail: null,
+  avatarUrl: null,
+  metadata: {},
+  deactivatedAt: null,
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+};
+
+describe("mintAccountBearer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("verifies the canonical account immediately before signing", async () => {
+    mocks.findAomiUserById.mockResolvedValue(USER);
+    mocks.mint.mockResolvedValue({
+      accessToken: "signed-bearer",
+      expiresAt: 1_000,
+    });
+
+    await expect(mintAccountBearer(USER.id)).resolves.toEqual({
+      bearer: "signed-bearer",
+      expiresAt: 1_000,
+    });
+    expect(mocks.findAomiUserById).toHaveBeenCalledWith(USER.id);
+    expect(mocks.mint).toHaveBeenCalledWith({
+      role: "user",
+      subject: USER.id,
+      audience: AUDIENCE,
+      ttlSeconds: ACCOUNT_BEARER_TTL_SECONDS,
+    });
+  });
+
+  it("refuses to sign a missing or deactivated account", async () => {
+    mocks.findAomiUserById.mockResolvedValue(null);
+
+    await expect(mintAccountBearer(USER.id)).rejects.toThrow(
+      "Cannot mint AccountBearer: canonical user does not exist or is deactivated",
+    );
+    expect(mocks.mint).not.toHaveBeenCalled();
+  });
+});

--- a/packages/account/src/bearer.ts
+++ b/packages/account/src/bearer.ts
@@ -1,3 +1,4 @@
+import { findAomiUserById } from "./db/queries";
 import { portalService } from "./topology";
 
 /**
@@ -22,8 +23,9 @@ export type MintedBearer = {
 };
 
 /**
- * Sign an AccountBearer for a resolved canonical user. `role` defaults to
- * `user`; the topology authorizes it against `aomi-bff`'s configured roles.
+ * Sign an AccountBearer for a resolved canonical user. The final lookup keeps
+ * the issuer from signing a subject that is missing or deactivated in the
+ * database backing this Portal environment.
  *
  * `@aomi-labs/service` is the generic JWT signer (service-mesh tokens too), so it
  * returns the neutral `accessToken`; we re-label it `bearer` here — the account
@@ -33,9 +35,16 @@ export async function mintAccountBearer(
   canonicalUserId: string,
   role: string = "user",
 ): Promise<MintedBearer> {
+  const user = await findAomiUserById(canonicalUserId);
+  if (!user) {
+    throw new Error(
+      "Cannot mint AccountBearer: canonical user does not exist or is deactivated",
+    );
+  }
+
   const { accessToken, expiresAt } = await portalService().mint({
     role,
-    subject: canonicalUserId,
+    subject: user.id,
     audience: AUDIENCE,
     ttlSeconds: ACCOUNT_BEARER_TTL_SECONDS,
   });


### PR DESCRIPTION
## Summary

- verify the canonical user is active immediately before minting an AccountBearer
- refuse missing or deactivated subjects before invoking the signing service
- preserve the existing string-based `mintAccountBearer` API and all call sites

## Why

AccountBearer issuance previously trusted a caller-supplied canonical user ID. That allowed the issuer to sign a bearer whose subject could not be resolved by the account database, with the failure surfacing later in the backend.

The normal authentication paths already resolve or create the canonical account. This change adds the final issuer-side invariant proposed in aomi-labs/aomi-scrum#246 without propagating database objects through the repository or hardcoding deployment topology.

## Impact

Valid sessions continue through the same API. Missing and deactivated canonical accounts now fail closed before a bearer is signed. Issuance adds one account lookup.

## Validation

- `pnpm exec vitest run packages/account` — 101 tests passed
- `pnpm --filter @aomi-labs/account type-check`
- `pnpm --filter portal type-check`
- `pnpm run lint`
- Prettier and `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787936126&installation_model_id=12362&pr_number=422&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F422&signature=a126f240181c71773cdc5aa5bf06eb1668ad7ef2d7102b522d0a62af4603e465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->