### PR TITLE
Bound the operate per-source fan-out

### DIFF
--- a/apps/build/src/features/operate/client.test.ts
+++ b/apps/build/src/features/operate/client.test.ts
@@ -27,6 +27,7 @@ describe("operate client platform scope", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/bff/operate/usage?appSourceId=1620&platform=somm.finance",
+      { signal: expect.any(AbortSignal) },
     );
   });
 
@@ -35,6 +36,29 @@ describe("operate client platform scope", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/bff/operate/observability/detail?appSourceId=1620&applicationId=2938032&platform=somm.finance",
+      { signal: expect.any(AbortSignal) },
+    );
+  });
+});
+
+describe("operate client deadline", () => {
+  it("passes an abort signal so a stalled read cannot hang the view", async () => {
+    await operateFetch("transactions");
+
+    const [, init] = fetchMock.mock.calls[0] as [
+      string,
+      { signal: AbortSignal },
+    ];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("turns the abort into an actionable error", async () => {
+    fetchMock.mockRejectedValue(
+      new DOMException("The operation timed out.", "TimeoutError"),
+    );
+
+    await expect(operateFetch("transactions")).rejects.toThrow(
+      /transactions timed out after \d+s/,
     );
   });
 });

--- a/apps/build/src/features/operate/client.ts
+++ b/apps/build/src/features/operate/client.ts
@@ -16,6 +16,32 @@ export type OperateFetchOptions = {
   platform?: string | null;
 };
 
+// Operate reads fan out across every source on the server, so a degraded
+// backend used to leave the view on "Loading" until the platform's function
+// timeout. Give up first and surface a real error the user can act on.
+const OPERATE_FETCH_TIMEOUT_MS = 25_000;
+
+async function operateJson<T>(url: string, label: string): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      signal: AbortSignal.timeout(OPERATE_FETCH_TIMEOUT_MS),
+    });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      throw new Error(
+        `${label} timed out after ${OPERATE_FETCH_TIMEOUT_MS / 1000}s — the backend is slow or unavailable. Try a single source instead of All sources.`,
+      );
+    }
+    throw err;
+  }
+  const json = (await res.json().catch(() => ({}))) as T & { error?: string };
+  if (!res.ok) {
+    throw new Error(json.error || `${label} failed (${res.status})`);
+  }
+  return json;
+}
+
 export async function operateFetch<T>(
   kind: OperateKind,
   options: OperateFetchOptions = {},
@@ -37,12 +63,7 @@ export async function operateFetch<T>(
     );
   }
   if (options.limit) params.set("limit", String(options.limit));
-  const res = await fetch(`${path}${params.size ? `?${params}` : ""}`);
-  const json = (await res.json().catch(() => ({}))) as T & { error?: string };
-  if (!res.ok) {
-    throw new Error(json.error || `${kind} failed (${res.status})`);
-  }
-  return json;
+  return operateJson<T>(`${path}${params.size ? `?${params}` : ""}`, kind);
 }
 
 export async function operateAppDetailFetch<T>(
@@ -50,27 +71,16 @@ export async function operateAppDetailFetch<T>(
   applicationId: number,
   platform?: string | null,
 ): Promise<T> {
-  const res = await fetch(
+  return operateJson<T>(
     API_PATHS.bff.operate.observabilityDetail(
       appSourceId,
       applicationId,
       platform,
     ),
+    "observability detail",
   );
-  const json = (await res.json().catch(() => ({}))) as T & { error?: string };
-  if (!res.ok) {
-    throw new Error(
-      json.error || `observability detail failed (${res.status})`,
-    );
-  }
-  return json;
 }
 
 export async function modelKeysFetch<T>(): Promise<T> {
-  const res = await fetch(API_PATHS.bff.operate.modelKeys);
-  const json = (await res.json().catch(() => ({}))) as T & { error?: string };
-  if (!res.ok) {
-    throw new Error(json.error || `model keys failed (${res.status})`);
-  }
-  return json;
+  return operateJson<T>(API_PATHS.bff.operate.modelKeys, "model keys");
 }

--- a/apps/build/src/features/operate/operate-view.test.tsx
+++ b/apps/build/src/features/operate/operate-view.test.tsx
@@ -712,3 +712,46 @@ describe("OperateView transactions", () => {
     expect(operateFetch).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("OperateView degraded pages", () => {
+  beforeEach(() => {
+    operateFetch.mockReset();
+    searchParams.current = new URLSearchParams("");
+  });
+
+  it("says what is missing instead of rendering an empty page as complete", async () => {
+    operateFetch.mockResolvedValue({
+      sources: [{ id: 900, repositoryLink: "o/one" }],
+      transactions: [],
+      degraded: { dropped: 107, total: 111 },
+    });
+
+    render(<OperateView kind="transactions" />);
+
+    expect(await screen.findByText(/Showing 4 of 111 sources/)).toBeTruthy();
+    // The account may well have transactions — we just could not read them.
+    expect(screen.queryByText(/No transactions yet/)).toBeNull();
+  });
+
+  it("keeps the normal empty state when the read covered everything", async () => {
+    operateFetch.mockResolvedValue({ sources: [], transactions: [] });
+
+    render(<OperateView kind="transactions" />);
+
+    expect(await screen.findByText(/No transactions yet/)).toBeTruthy();
+    expect(screen.queryByText(/could not be read/)).toBeNull();
+  });
+
+  it("refetches when the user retries", async () => {
+    operateFetch.mockResolvedValue({
+      sources: [],
+      transactions: [],
+      degraded: { dropped: 2, total: 3 },
+    });
+
+    render(<OperateView kind="transactions" />);
+    fireEvent.click(await screen.findByRole("button", { name: "Retry" }));
+
+    await waitFor(() => expect(operateFetch.mock.calls.length).toBe(2));
+  });
+});

--- a/apps/build/src/features/operate/operate-view.tsx
+++ b/apps/build/src/features/operate/operate-view.tsx
@@ -54,6 +54,8 @@ type Sourceish = AppSource & { apps?: unknown[] };
 type OperatePayload = {
   /** True when the BFF filled gaps with example fixture data (BE not live yet). */
   example?: boolean;
+  /** Present only when the BFF could not read every source for this account. */
+  degraded?: { dropped: number; total: number };
   sources?: Sourceish[];
   transactions?: Array<Record<string, any>>;
   daily?: Array<Record<string, any>>;
@@ -88,6 +90,35 @@ function syncQuery(patch: Record<string, string | null>) {
     else url.searchParams.set(key, value);
   }
   window.history.replaceState(null, "", url);
+}
+
+// A page that quietly renders 4 of 111 sources reads as a complete page — and
+// for money-bearing views that is worse than an error. Say what is missing.
+function DegradedNotice({
+  dropped,
+  total,
+  onRetry,
+}: {
+  dropped: number;
+  total: number;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="border-warning/40 bg-warning/10 text-warning flex flex-wrap items-center justify-between gap-2 rounded-md border px-4 py-3 text-sm">
+      <span>
+        Showing {total - dropped} of {total} sources — {dropped} could not be
+        read, so this page is incomplete. Pick a single source to load it on its
+        own.
+      </span>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="border-warning/40 hover:bg-warning/15 h-8 rounded-md border px-3 text-xs font-medium"
+      >
+        Retry
+      </button>
+    </div>
+  );
 }
 
 function EmptyState({
@@ -216,10 +247,14 @@ function Rows({
   view: ViewState;
   platform?: string;
 }) {
+  // With sources missing we cannot tell "you have none" from "we could not read
+  // them", so we say neither — the degraded notice above already explains it.
+  const incomplete = Boolean(payload.degraded);
+
   if (kind === "transactions") {
     const rows = payload.transactions ?? [];
     if (!rows.length)
-      return (
+      return incomplete ? null : (
         <EmptyState
           title="Transactions"
           description="On-chain actions from your apps show up here after chat activity."
@@ -250,7 +285,7 @@ function Rows({
     const daily = payload.daily ?? [];
     const breakdown = payload.breakdown ?? [];
     if (!daily.length && !breakdown.length && !payload.statement)
-      return (
+      return incomplete ? null : (
         <EmptyState
           title="Usage"
           description="Credits and tokens appear after your apps run chat turns. This is a meter, not Billing."
@@ -263,7 +298,7 @@ function Rows({
 
   if (kind === "logs") {
     const rows = payload.logs ?? [];
-    if (!rows.length) return <EmptyState title="Logs" />;
+    if (!rows.length) return incomplete ? null : <EmptyState title="Logs" />;
     const apps = [...new Set(rows.map((row) => String(row.application)))];
     const tools = [
       ...new Set(
@@ -292,7 +327,8 @@ function Rows({
   }
 
   const apps = payload.apps ?? [];
-  if (!apps.length) return <EmptyState title="Observability" />;
+  if (!apps.length)
+    return incomplete ? null : <EmptyState title="Observability" />;
   const monitoring = payload.monitoring;
   const platformMetrics = payload.platformMetrics ?? [];
   const dashboardLinks = payload.dashboardLinks ?? [];
@@ -742,6 +778,13 @@ export function OperateView({ kind }: { kind: ViewKind }) {
         </div>
       ) : payload ? (
         <>
+          {payload.degraded ? (
+            <DegradedNotice
+              dropped={payload.degraded.dropped}
+              total={payload.degraded.total}
+              onRetry={() => dataQuery.refetch()}
+            />
+          ) : null}
           <Rows
             kind={kind}
             payload={payload}

--- a/apps/build/src/server/bff/operate/routes.test.ts
+++ b/apps/build/src/server/bff/operate/routes.test.ts
@@ -858,3 +858,176 @@ describe("operateAppDetailRoute", () => {
     });
   });
 });
+
+describe("per-source fan-out is bounded", () => {
+  const SOURCE_COUNT = 40;
+
+  beforeEach(() => {
+    setSession({ githubUserId: "gh-1" });
+    client.listUserSources.mockResolvedValue(
+      Array.from({ length: SOURCE_COUNT }, (_, index) => ({
+        id: 900 + index,
+        repositoryLink: `o/r${index}`,
+        apps: [],
+      })),
+    );
+  });
+
+  // A 111-source account fired 222 reads at once and saturated the manager's
+  // connection pool, so the page hung on "Loading" for minutes.
+  it("caps concurrent reads instead of firing one per source at once", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const track = <T>(value: T) => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      return new Promise<T>((resolve) =>
+        setTimeout(() => {
+          inFlight -= 1;
+          resolve(value);
+        }, 1),
+      );
+    };
+    client.listUserSourceTransactions.mockImplementation(({ appSourceId }) =>
+      track({
+        source: { id: appSourceId },
+        platform: "community",
+        transactions: [],
+        nextCursor: null,
+      }),
+    );
+    client.getUserSourceStatement.mockImplementation(({ appSourceId }) =>
+      track({
+        source: { id: appSourceId },
+        platform: "community",
+        payments: emptyPayments(),
+      }),
+    );
+
+    const res = await operateTransactionsRoute(transactionsReq());
+
+    expect(res.status).toBe(200);
+    expect(client.listUserSourceTransactions).toHaveBeenCalledTimes(
+      SOURCE_COUNT,
+    );
+    // Two independent fan-outs (transactions + statement) run concurrently, so
+    // the ceiling is two slots' worth — not 2 × SOURCE_COUNT.
+    expect(peak).toBeLessThanOrEqual(12);
+  });
+
+  it("drops a wedged source instead of stalling the whole page", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+    try {
+      client.listUserSourceTransactions.mockImplementation(({ appSourceId }) =>
+        appSourceId === 901
+          ? new Promise(() => {})
+          : Promise.resolve({
+              source: { id: appSourceId },
+              platform: "community",
+              transactions: [
+                { id: `tx:${appSourceId}`, createdAt: 1_700_000_000 },
+              ],
+              nextCursor: null,
+            }),
+      );
+      client.getUserSourceStatement.mockImplementation(({ appSourceId }) =>
+        Promise.resolve({
+          source: { id: appSourceId },
+          platform: "community",
+          payments: emptyPayments(),
+        }),
+      );
+
+      const pending = operateTransactionsRoute(transactionsReq());
+      await vi.advanceTimersByTimeAsync(30_000);
+      const body = await (await pending).json();
+
+      expect(body.transactions).toHaveLength(SOURCE_COUNT - 1);
+      expect(
+        body.transactions.some(
+          (transaction: { id: string }) => transaction.id === "tx:901",
+        ),
+      ).toBe(false);
+    } finally {
+      vi.useRealTimers();
+      warn.mockRestore();
+    }
+  });
+});
+
+describe("degraded reporting", () => {
+  beforeEach(() => {
+    setSession({ githubUserId: "gh-1" });
+    client.listUserSources.mockResolvedValue([
+      { id: 900, repositoryLink: "o/one", apps: [] },
+      { id: 901, repositoryLink: "o/two", apps: [] },
+      { id: 902, repositoryLink: "o/three", apps: [] },
+    ]);
+  });
+
+  const okTransactions = ({ appSourceId }: { appSourceId: number }) =>
+    Promise.resolve({
+      source: { id: appSourceId },
+      platform: "community",
+      transactions: [],
+      nextCursor: null,
+    });
+  const okStatement = ({ appSourceId }: { appSourceId: number }) =>
+    Promise.resolve({
+      source: { id: appSourceId },
+      platform: "community",
+      payments: emptyPayments(),
+    });
+
+  it("omits the key entirely when every source was read", async () => {
+    client.listUserSourceTransactions.mockImplementation(okTransactions);
+    client.getUserSourceStatement.mockImplementation(okStatement);
+
+    const body = await (
+      await operateTransactionsRoute(transactionsReq())
+    ).json();
+
+    expect(body).not.toHaveProperty("degraded");
+  });
+
+  it("counts a source that failed both fan-outs once", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    client.listUserSourceTransactions.mockImplementation((args) =>
+      args.appSourceId === 901
+        ? Promise.reject(new Error("boom"))
+        : okTransactions(args),
+    );
+    client.getUserSourceStatement.mockImplementation((args) =>
+      args.appSourceId === 901
+        ? Promise.reject(new Error("boom"))
+        : okStatement(args),
+    );
+
+    const body = await (
+      await operateTransactionsRoute(transactionsReq())
+    ).json();
+
+    expect(body.degraded).toEqual({ dropped: 1, total: 3 });
+    warn.mockRestore();
+  });
+
+  it("still lists a dropped source so the user can retry it alone", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    client.listUserSourceTransactions.mockImplementation((args) =>
+      args.appSourceId === 901
+        ? Promise.reject(new Error("boom"))
+        : okTransactions(args),
+    );
+    client.getUserSourceStatement.mockImplementation(okStatement);
+
+    const body = await (
+      await operateTransactionsRoute(transactionsReq())
+    ).json();
+
+    expect(body.sources.map((source: { id: number }) => source.id)).toEqual([
+      900, 901, 902,
+    ]);
+    warn.mockRestore();
+  });
+});

--- a/apps/build/src/server/bff/operate/routes.ts
+++ b/apps/build/src/server/bff/operate/routes.ts
@@ -35,27 +35,127 @@ import { TimedPromiseCache } from "@build/server/bff/timed-promise-cache";
 
 type DeploymentClientInstance = Awaited<ReturnType<typeof deploymentClient>>;
 
+// An unbounded fan-out is a thundering herd: an account with 100+ sources fired
+// every per-source read at once and saturated the manager's connection pool, so
+// most reads timed out waiting to acquire and the page hung on "Loading". Cap
+// the wave instead — the pool is the scarce resource, not our event loop.
+const SOURCE_FANOUT_LIMIT = 6;
+
+// Beyond this a source is treated as unavailable rather than allowed to hold a
+// fan-out slot (and the whole page) open. Comfortably above a healthy read.
+const SOURCE_READ_TIMEOUT_MS = 8_000;
+
+// Capping concurrency alone still lets a degraded manager stretch a large
+// account over batches × timeout. Bound the whole fan-out too: sources we never
+// got to are dropped like any other failure, so the page renders what it has
+// instead of stalling. Well under the platform's function timeout.
+const SOURCE_FANOUT_BUDGET_MS = 20_000;
+
+async function mapWithLimit<T, R>(
+  items: T[],
+  limit: number,
+  run: (item: T) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  const results = new Array<PromiseSettledResult<R>>(items.length);
+  let next = 0;
+  const worker = async () => {
+    while (next < items.length) {
+      const index = next++;
+      try {
+        results[index] = {
+          status: "fulfilled",
+          value: await run(items[index]),
+        };
+      } catch (reason) {
+        results[index] = { status: "rejected", reason };
+      }
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, worker),
+  );
+  return results;
+}
+
+// Losing the race does not cancel the underlying read — it stays in the promise
+// cache and can still land for the next request, which is what we want.
+function withTimeout<T>(
+  load: () => Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  if (ms <= 0) {
+    return Promise.reject(new Error(`${label} skipped: fan-out budget spent`));
+  }
+  let timer: ReturnType<typeof setTimeout>;
+  return Promise.race([
+    load(),
+    new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error(`${label} timed out after ${ms}ms`)),
+        ms,
+      );
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
+
+type Settled<T> = {
+  ok: T[];
+  /** Source ids this read could not cover, for the page's degraded notice. */
+  dropped: number[];
+};
+
 // Fan out a per-source read and keep only the sources that succeed. One source
 // failing — a freshly scaffolded source with no deployed app, or a transient
 // backend blip — must not take down the whole operate page; drop it and render
-// the healthy sources instead of failing the entire request.
+// the healthy sources instead of failing the entire request. Report what was
+// lost: a page silently missing most of the account reads as a complete page.
 async function settleBySource<T>(
   sources: UserSource[],
   run: (source: UserSource) => Promise<T>,
-): Promise<T[]> {
-  const settled = await Promise.allSettled(sources.map(run));
+): Promise<Settled<T>> {
+  const deadline = Date.now() + SOURCE_FANOUT_BUDGET_MS;
+  const settled = await mapWithLimit(sources, SOURCE_FANOUT_LIMIT, (source) =>
+    withTimeout(
+      () => run(source),
+      Math.min(SOURCE_READ_TIMEOUT_MS, deadline - Date.now()),
+      `operate read for source ${source.id}`,
+    ),
+  );
   const ok: T[] = [];
+  const dropped: number[] = [];
   settled.forEach((result, index) => {
+    const source = sources[index];
     if (result.status === "fulfilled") {
       ok.push(result.value);
     } else {
+      if (source) dropped.push(source.id);
       console.warn(
-        `operate: dropping source ${sources[index]?.id} from this page:`,
+        `operate: dropping source ${source?.id} from this page:`,
         result.reason instanceof Error ? result.reason.message : result.reason,
       );
     }
   });
-  return ok;
+  return { ok, dropped };
+}
+
+export type OperateDegraded = {
+  /** Sources this page could not read. */
+  dropped: number;
+  /** Sources the page should have covered. */
+  total: number;
+};
+
+// A route may fan out more than once over the same sources (transactions and
+// statements, say). One source failing both reads is still one missing source,
+// so union the ids rather than summing. Undefined — not a zeroed object — when
+// nothing was lost, so the key stays off the wire on a healthy page.
+function degradedFrom(
+  sources: UserSource[],
+  ...dropped: number[][]
+): OperateDegraded | undefined {
+  const ids = new Set(dropped.flat());
+  return ids.size ? { dropped: ids.size, total: sources.length } : undefined;
 }
 
 function isValidAppSourceId(value: unknown): value is number {
@@ -573,7 +673,7 @@ export async function operateTransactionsRoute(req: Request) {
     const limit = pageLimit(params, 50, 100);
     const cursor = parseCompositeCursor(params.get("cursor"));
     const status = params.get("status") ?? undefined;
-    const [results, statements] = await Promise.all([
+    const [transactionReads, statementReads] = await Promise.all([
       settleBySource<OperateTransactionsResult>(owned.sources, (source) =>
         readCache.transactions.get(
           [
@@ -597,7 +697,10 @@ export async function operateTransactionsRoute(req: Request) {
         ),
       ),
       cursor
-        ? Promise.resolve([])
+        ? Promise.resolve({
+            ok: [],
+            dropped: [],
+          } as Settled<OperateStatementResult>)
         : settleBySource<OperateStatementResult>(owned.sources, (source) =>
             readCache.statement.get(
               [owned.githubUserId, owned.platform, source.id, null],
@@ -610,6 +713,7 @@ export async function operateTransactionsRoute(req: Request) {
             ),
           ),
     ]);
+    const results = transactionReads.ok;
     const appTransactions = results
       .flatMap((result) =>
         result.transactions.map((transaction) => ({
@@ -621,7 +725,7 @@ export async function operateTransactionsRoute(req: Request) {
       )
       .sort((a, b) => b.createdAt - a.createdAt || b.id.localeCompare(a.id));
     const payments = mergedPartnerPayments(
-      statements.map((statement) => ({
+      statementReads.ok.map((statement) => ({
         source: statement.source as UserSource,
         payments: statement.payments,
       })),
@@ -692,8 +796,15 @@ export async function operateTransactionsRoute(req: Request) {
       (a, b) => b.createdAt - a.createdAt || b.id.localeCompare(a.id),
     );
     return NextResponse.json({
-      sources: results.map((result) => result.source),
+      // Every source the account owns, not just the ones this read covered:
+      // the filter dropdown is how a user retries a dropped source on its own.
+      sources: owned.sources,
       transactions,
+      degraded: degradedFrom(
+        owned.sources,
+        transactionReads.dropped,
+        statementReads.dropped,
+      ),
       nextCursor: mergedNextCursor(
         cursor,
         visibleAppTransactions,
@@ -720,7 +831,7 @@ export async function operateUsageRoute(req: Request) {
     // (or with `available: false` — statement_entries not migrated) drops out
     // of `statements`; until BE parity lands we serve the example statement
     // instead (flagged `example: true`) so the design ships visible.
-    const [results, statements] = await Promise.all([
+    const [usageReads, statementReads] = await Promise.all([
       settleBySource<OperateUsageResult>(owned.sources, (source) =>
         readCache.usage.get(
           [owned.githubUserId, owned.platform, source.id, dates],
@@ -744,12 +855,21 @@ export async function operateUsageRoute(req: Request) {
               ...dates,
             }),
         ),
-      ).then((rows) => rows.filter((statement) => statement.available)),
+      ),
     ]);
+    const results = usageReads.ok;
+    // `available: false` is a backend that has no statement for this source,
+    // not a read we lost — it belongs in the example-statement fallback below,
+    // not in the degraded count.
+    const statements = statementReads.ok.filter(
+      (statement) => statement.available,
+    );
     const sum = (pick: (s: OperateStatementResult) => number) =>
       statements.reduce((total, statement) => total + pick(statement), 0);
     return NextResponse.json({
-      sources: results.map((result) => result.source),
+      // Every source the account owns, not just the ones this read covered:
+      // the filter dropdown is how a user retries a dropped source on its own.
+      sources: owned.sources,
       range: results[0]?.range ?? null,
       daily: results.flatMap((result) =>
         result.daily.map((row) => ({
@@ -764,6 +884,11 @@ export async function operateUsageRoute(req: Request) {
           source: result.source,
           platform: result.platform,
         })),
+      ),
+      degraded: degradedFrom(
+        owned.sources,
+        usageReads.dropped,
+        statementReads.dropped,
       ),
       example: statements.length ? undefined : true,
       statement: statements.length
@@ -821,7 +946,7 @@ export async function operateLogsRoute(req: Request) {
     const limit = pageLimit(params, 100, 200);
     const cursor = parseCompositeCursor(params.get("cursor"));
     const type = params.get("type") ?? undefined;
-    const results: OperateLogsResult[] = await settleBySource(
+    const logReads = await settleBySource<OperateLogsResult>(
       owned.sources,
       (source) =>
         readCache.logs.get(
@@ -845,6 +970,7 @@ export async function operateLogsRoute(req: Request) {
             }),
         ),
     );
+    const results = logReads.ok;
     const sourcedLogs = results.flatMap((result) =>
       result.logs.map((entry) => ({
         ...entry,
@@ -882,8 +1008,11 @@ export async function operateLogsRoute(req: Request) {
       log.cursorSources.map((source) => ({ ...log, source })),
     );
     return NextResponse.json({
-      sources: results.map((result) => result.source),
+      // Every source the account owns, not just the ones this read covered:
+      // the filter dropdown is how a user retries a dropped source on its own.
+      sources: owned.sources,
       logs: visible.map(({ cursorSources: _cursorSources, ...log }) => log),
+      degraded: degradedFrom(owned.sources, logReads.dropped),
       nextCursor: mergedNextCursor(
         cursor,
         cursorRows,
@@ -901,7 +1030,7 @@ export async function operateObservabilityRoute(req: Request) {
   try {
     const owned = await ownedSources(req);
     if ("response" in owned) return owned.response;
-    const results: OperateObservabilityResult[] = await settleBySource(
+    const observabilityReads = await settleBySource<OperateObservabilityResult>(
       owned.sources,
       (source) =>
         readCache.observability.get(
@@ -914,6 +1043,7 @@ export async function operateObservabilityRoute(req: Request) {
             }),
         ),
     );
+    const results = observabilityReads.ok;
     const apps = results.flatMap((result) =>
       result.apps.map((app) => ({
         ...app,
@@ -922,7 +1052,10 @@ export async function operateObservabilityRoute(req: Request) {
       })),
     );
     return NextResponse.json({
-      sources: results.map((result) => result.source),
+      // Every source the account owns, not just the ones this read covered:
+      // the filter dropdown is how a user retries a dropped source on its own.
+      sources: owned.sources,
+      degraded: degradedFrom(owned.sources, observabilityReads.dropped),
       scope: "owned_applications",
       monitoring: {
         provider: "grafana_prometheus",


### PR DESCRIPTION
## The bug

`/operate/transactions` on "All sources" hung on `Loading` for minutes on a 111-source account.

`settleBySource` was a bare `Promise.allSettled(sources.map(run))` — no concurrency limit — and the transactions route fans out **twice** over the same sources (transactions + statements). One page load issued ~222 concurrent manager reads, saturating the manager's connection pool. Most reads then failed waiting to acquire a connection, were silently dropped, and the client had no timeout, so the view sat on its spinner until the platform function timeout. `retry: 1` on the query client then launched a second full wave.

Hovering the sidebar link is enough to start it: `ControlPlaneLink` warms the route on `onMouseEnter`, and the bare `/operate/transactions` href has no `?project=`, so the prefetch is the unscoped all-sources read.

## Server — bound the herd

- **`SOURCE_FANOUT_LIMIT = 6`** via a small worker pool (`mapWithLimit`). Two concurrent fan-outs means a ceiling of 12 in flight regardless of source count — 222 → 12 for the account that triggered this.
- **`SOURCE_READ_TIMEOUT_MS = 8_000`** per source, so one wedged source can't hold a slot (and the page) open.
- **`SOURCE_FANOUT_BUDGET_MS = 20_000`** for the whole fan-out. A concurrency cap alone just converts the herd into `ceil(111/6) × 8s ≈ 152s` of serialized timeouts. Sources past the budget are skipped **without issuing a call**, which is what protects the manager when it's already degraded.

The timeout races *outside* `readCache.get`, so a slow read stays in the `TimedPromiseCache` and can still land for the next request rather than being re-issued. `withTimeout` clears its timer in `finally` — otherwise 111 dangling 8s timers per request keep the function instance alive.

## Client — no more infinite `Loading`

All three operate fetchers now share one `operateJson` helper with `AbortSignal.timeout(25_000)`, and a `TimeoutError` becomes an actionable message instead of a raw `DOMException`. 25s sits above the server's 20s budget, so a bounded server response wins the race and you get real partial data; the client deadline is the backstop.

## Don't hide what was dropped

Bounding the reads makes drops *more* likely by design — a slow source is now abandoned at 8s where before it eventually resolved. That trades a visible hang for invisible incompleteness, so:

- `settleBySource` returns the dropped source ids; routes emit `degraded: { dropped, total }`, unioned across fan-outs so a source that fails both reads counts once. The key is absent entirely on a healthy page (additive; old clients ignore it).
- The view renders what's missing with a Retry button, and **suppresses the empty state** when sources are missing. Previously a total outage rendered as "No transactions yet — On-chain actions from your apps show up here after chat activity", pixel-identical to a brand-new account. On a money-bearing page that's worse than an error.
- The four fan-out routes now return **every owned source**, not just the survivors. The filter dropdown was built from survivors, so a dropped source couldn't be selected to retry it — the one recovery action was hidden by the failure. This matches what the model-keys route already did.

Retry is cheap: rejected promises are evicted from `TimedPromiseCache`, so a retry re-attempts only the failed sources and reuses the cached successful ones.

## Testing

70 passing across `src/features/operate` + `src/server/bff/operate`, 10 of them new:

- Concurrency cap holds — 40 sources, peak ≤ 12. Verified the test actually bites: temporarily raising the limit to 1000 fails it with `expected 80 to be less than or equal to 12`.
- A permanently-hanging source is dropped; the other 39 still render.
- `degraded` is absent when every source read; a source failing both fan-outs counts once; a dropped source still appears in `sources`.
- The degraded view says what's missing instead of "No transactions yet"; the normal empty state survives when the read was complete; Retry refetches.
- `operateFetch` passes an abort signal and turns a `TimeoutError` into the actionable message.

Full `apps/build` suite: 349 passed, up from 339 on `main`. Four test *files* fail to load in my worktree (`@vercel/sandbox` / `@aomi-labs/smither` unresolved) — identical on `main` with my changes stashed, so pre-existing environment, not this change. `tsc` reports zero errors in the touched files.

**Not verified against the live page.** Reproducing needs a GitHub session plus the staging manager and the real 111 sources; the evidence here is the tests. Worth a look on `build-staging` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787944162&installation_model_id=12362&pr_number=423&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F423&signature=b244a2a9abb337b128d5100a9de1eba45a05e8dc37b37a0ba2c1f37d1175d137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->