### PR TITLE
Speed up build project pages: react-query + cached single-source reads

### DIFF
--- a/apps/build/src/components/control-plane/prefetch-control-plane-route.ts
+++ b/apps/build/src/components/control-plane/prefetch-control-plane-route.ts
@@ -27,6 +27,36 @@ const OPERATE_ROUTES: Record<string, OperateKind> = {
 };
 
 /**
+ * Warm everything a project detail page reads: the server-filtered
+ * single-source read it renders from, the SDK status behind the "outdated"
+ * badge, and the Home tab's usage peek. Called on sidebar/row hover and again
+ * on page mount, so the three reads run in parallel instead of waterfalling
+ * behind the source read.
+ */
+export function prefetchProjectDetail(
+  queryClient: QueryClient,
+  accountKey: string,
+  sourceId: number,
+  platform?: string | null,
+) {
+  void queryClient.prefetchQuery({
+    queryKey: buildQueryKeys.projectSource(accountKey, sourceId, platform),
+    queryFn: () => deploymentSources(platform ?? undefined, sourceId),
+    staleTime: buildQueryStaleTime.projects,
+  });
+  void queryClient.prefetchQuery({
+    queryKey: buildQueryKeys.sdkStatus(),
+    queryFn: () => deploymentSdkStatus().catch(() => null),
+    staleTime: buildQueryStaleTime.sdkStatus,
+  });
+  void queryClient.prefetchQuery({
+    queryKey: buildQueryKeys.operate(accountKey, "usage", sourceId, platform),
+    queryFn: () => operateFetch("usage", { sourceId, platform }),
+    staleTime: buildQueryStaleTime.operate,
+  });
+}
+
+/**
  * Warm only the route a user shows intent to open. This keeps the persistent
  * sidebar from eagerly downloading every control-plane route and API payload
  * while still hiding latency between hover/focus and click.
@@ -57,6 +87,17 @@ export function prefetchControlPlaneRoute(
       });
       return true;
     }
+  }
+
+  const projectMatch = path.match(/^\/projects\/([1-9]\d*)$/);
+  if (projectMatch) {
+    prefetchProjectDetail(
+      queryClient,
+      accountKey,
+      Number(projectMatch[1]),
+      searchParams.get("platform"),
+    );
+    return true;
   }
 
   if (path === "/projects") {

--- a/apps/build/src/features/launch/client.ts
+++ b/apps/build/src/features/launch/client.ts
@@ -136,9 +136,10 @@ export function launchSdkStatus(): Promise<LaunchSdkStatus> {
 
 export function deploymentSources(
   platform?: string,
+  appSourceId?: number,
 ): Promise<DeploymentSourcesResult> {
   return launchFetch(
-    API_PATHS.bff.deployments.sources(platform),
+    API_PATHS.bff.deployments.sources(platform, appSourceId),
     "deployment sources",
   );
 }

--- a/apps/build/src/features/launch/components/deployments/project-page.test.tsx
+++ b/apps/build/src/features/launch/components/deployments/project-page.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ToastProvider } from "@build/components/control-plane/toast";
 
 const searchParams = { current: new URLSearchParams("") };
@@ -15,6 +16,12 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("@build/features/operate/client", () => ({
   operateFetch: vi.fn(async () => ({ daily: [] })),
+}));
+
+// The page warms its reads through the shared prefetch on mount; keep the
+// test offline instead of letting prefetchQuery hit real clients.
+vi.mock("@build/components/control-plane/prefetch-control-plane-route", () => ({
+  prefetchProjectDetail: vi.fn(),
 }));
 
 vi.mock("@aomi-labs/deploy/lifecycle", () => ({
@@ -70,10 +77,19 @@ vi.mock("@build/features/launch/hooks/use-project-detail", () => ({
 import { ProjectPage } from "./project-page";
 
 function renderPage(platform?: string) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   return render(
-    <ToastProvider>
-      <ProjectPage sourceId={1} platform={platform} tabBaseHref="/projects/1" />
-    </ToastProvider>,
+    <QueryClientProvider client={client}>
+      <ToastProvider>
+        <ProjectPage
+          sourceId={1}
+          platform={platform}
+          tabBaseHref="/projects/1"
+        />
+      </ToastProvider>
+    </QueryClientProvider>,
   );
 }
 

--- a/apps/build/src/features/launch/components/deployments/project-page.tsx
+++ b/apps/build/src/features/launch/components/deployments/project-page.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import { prefetchProjectDetail } from "@build/components/control-plane/prefetch-control-plane-route";
 import { useProjectDetail } from "@build/features/launch/hooks/use-project-detail";
 import { setLastProjectId } from "@build/lib/last-project";
 import { ProjectHeader } from "./project-header";
@@ -53,10 +55,24 @@ export function ProjectPage({
     return `${tabBaseHref ?? "/operate/deployments"}?${params}`;
   };
   const openEnvironment = () => router.push(projectTabHref("environment"));
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     setLastProjectId(sourceId);
   }, [sourceId]);
+
+  // Start every read this page needs in parallel on mount instead of
+  // waterfalling them behind the source list: usage/SDK warm through the same
+  // prefetch the sidebar hover uses (deduped by react-query), and secrets —
+  // which only need the source id — fire for the tabs that render them.
+  useEffect(() => {
+    if (detail.accountKey) {
+      prefetchProjectDetail(queryClient, detail.accountKey, sourceId, platform);
+    }
+  }, [detail.accountKey, platform, queryClient, sourceId]);
+  useEffect(() => {
+    if (active === "home" || active === "environment") detail.loadSecrets();
+  }, [active, detail]);
 
   return (
     <main className="bg-background text-foreground min-h-screen">

--- a/apps/build/src/features/launch/components/deployments/tabs/home-tab.test.tsx
+++ b/apps/build/src/features/launch/components/deployments/tabs/home-tab.test.tsx
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactElement } from "react";
 
 const loadSecrets = vi.fn();
 const operateFetch = vi.fn();
@@ -43,6 +45,16 @@ const detail = {
 
 import { HomeTab } from "./home-tab";
 
+// Fresh client per render so cached usage reads never leak across tests.
+function renderTab(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
+
 describe("HomeTab", () => {
   beforeEach(() => {
     loadSecrets.mockClear();
@@ -52,7 +64,7 @@ describe("HomeTab", () => {
   });
 
   it("shows status cards and a deploy next action when not live", async () => {
-    render(
+    renderTab(
       <HomeTab detail={detail} tabHref={(tab) => `/projects/1?tab=${tab}`} />,
     );
 
@@ -87,7 +99,7 @@ describe("HomeTab", () => {
         },
       ],
     });
-    render(
+    renderTab(
       <HomeTab detail={detail} tabHref={(tab) => `/projects/1?tab=${tab}`} />,
     );
     expect(await screen.findByText("1.50 credits")).toBeInTheDocument();
@@ -118,7 +130,7 @@ describe("HomeTab", () => {
       },
     ];
 
-    render(
+    renderTab(
       <HomeTab detail={detail} tabHref={(tab) => `/projects/1?tab=${tab}`} />,
     );
 
@@ -152,7 +164,7 @@ describe("HomeTab", () => {
       },
     ];
 
-    render(
+    renderTab(
       <HomeTab
         detail={detail}
         platform="somm.finance"

--- a/apps/build/src/features/launch/components/deployments/tabs/home-tab.tsx
+++ b/apps/build/src/features/launch/components/deployments/tabs/home-tab.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, type ReactNode } from "react";
 import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
 import {
   CircleArrowUp,
   ExternalLink,
@@ -10,6 +11,10 @@ import {
   Rocket,
 } from "lucide-react";
 import { useProjectDetail } from "@build/features/launch/hooks/use-project-detail";
+import {
+  buildQueryKeys,
+  buildQueryStaleTime,
+} from "@build/features/launch/query-keys";
 import { operateFetch } from "@build/features/operate/client";
 import {
   caipChainLabel,
@@ -181,28 +186,35 @@ export function HomeTab({
   platform?: string;
 }) {
   const source = detail.source;
-  const [usage, setUsage] = useState<UsagePeek | null>(null);
+  // Same key as the operate usage page and the project-detail prefetch, so a
+  // hover or page-mount warm-up serves this card from cache.
+  const usageQuery = useQuery({
+    queryKey: buildQueryKeys.operate(
+      detail.accountKey ?? "unavailable",
+      "usage",
+      source?.id ?? null,
+      platform,
+    ),
+    queryFn: () =>
+      operateFetch<{
+        daily?: Array<Record<string, unknown>>;
+      }>("usage", { sourceId: source?.id, platform }),
+    enabled: source !== null,
+    staleTime: buildQueryStaleTime.operate,
+  });
+  const usage: UsagePeek | null = useMemo(
+    () =>
+      usageQuery.data !== undefined
+        ? summarizeProjectUsage(usageQuery.data)
+        : usageQuery.isError
+          ? summarizeProjectUsage(null)
+          : null,
+    [usageQuery.data, usageQuery.isError],
+  );
 
   useEffect(() => {
     detail.loadSecrets();
   }, [detail]);
-
-  useEffect(() => {
-    if (!source) return;
-    let alive = true;
-    operateFetch<{
-      daily?: Array<Record<string, unknown>>;
-    }>("usage", { sourceId: source.id, platform })
-      .then((payload) => {
-        if (alive) setUsage(summarizeProjectUsage(payload));
-      })
-      .catch(() => {
-        if (alive) setUsage(summarizeProjectUsage(null));
-      });
-    return () => {
-      alive = false;
-    };
-  }, [platform, source]);
 
   const status = useMemo(
     () => (source ? projectDeploymentStatus(source) : null),

--- a/apps/build/src/features/launch/hooks/use-project-detail.test.ts
+++ b/apps/build/src/features/launch/hooks/use-project-detail.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+vi.mock("@build/features/launch/dashboard", () => ({
+  fetchGitHubSession: vi.fn(async () => ({
+    signedIn: true,
+    githubLogin: "alice",
+    githubUserId: "u1",
+  })),
+}));
 
 vi.mock("@build/features/launch/client", () => ({
   deploymentSources: vi.fn(async () => ({
@@ -55,6 +65,7 @@ vi.mock("@build/features/launch/client", () => ({
   })),
 }));
 
+import { GitHubSessionProvider } from "@build/components/control-plane/github-session-context";
 import { useProjectDetail } from "./use-project-detail";
 import {
   deploymentRecords,
@@ -66,11 +77,27 @@ import {
   launchPreflight,
 } from "@build/features/launch/client";
 
+// Fresh QueryClient per test so react-query cache never leaks across tests.
+function wrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client },
+      createElement(GitHubSessionProvider, null, children),
+    );
+  };
+}
+
 describe("useProjectDetail", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("resolves the source and lazily loads history once", async () => {
-    const { result } = renderHook(() => useProjectDetail(7));
+    const { result } = renderHook(() => useProjectDetail(7), {
+      wrapper: wrapper(),
+    });
     await waitFor(() => expect(result.current.source?.id).toBe(7));
     expect(deploymentHistory).not.toHaveBeenCalled();
     act(() => result.current.loadHistory());
@@ -81,7 +108,9 @@ describe("useProjectDetail", () => {
   });
 
   it("lazily loads records per app once", async () => {
-    const { result } = renderHook(() => useProjectDetail(7));
+    const { result } = renderHook(() => useProjectDetail(7), {
+      wrapper: wrapper(),
+    });
     await waitFor(() => expect(result.current.source?.id).toBe(7));
     expect(deploymentRecords).not.toHaveBeenCalled();
     act(() => result.current.loadRecords());
@@ -100,7 +129,9 @@ describe("useProjectDetail", () => {
     vi.mocked(deploymentRecords).mockRejectedValueOnce(
       new Error("deployment activations failed (401)"),
     );
-    const { result } = renderHook(() => useProjectDetail(7));
+    const { result } = renderHook(() => useProjectDetail(7), {
+      wrapper: wrapper(),
+    });
     await waitFor(() => expect(result.current.source?.id).toBe(7));
     act(() => result.current.loadRecords());
     await waitFor(() =>
@@ -124,7 +155,9 @@ describe("useProjectDetail", () => {
           },
         ],
       });
-    const { result } = renderHook(() => useProjectDetail(7));
+    const { result } = renderHook(() => useProjectDetail(7), {
+      wrapper: wrapper(),
+    });
     await waitFor(() => expect(result.current.source?.id).toBe(7));
 
     act(() => result.current.loadHistory());
@@ -144,7 +177,9 @@ describe("useProjectDetail", () => {
       .mockResolvedValueOnce({
         byApp: { demo: ["$SECRET:APP:demo::KEY"] },
       });
-    const { result } = renderHook(() => useProjectDetail(7));
+    const { result } = renderHook(() => useProjectDetail(7), {
+      wrapper: wrapper(),
+    });
     await waitFor(() => expect(result.current.source?.id).toBe(7));
 
     act(() => result.current.loadSecrets());
@@ -164,7 +199,9 @@ describe("useProjectDetail", () => {
     vi.mocked(deploymentRequiredSecrets).mockResolvedValue({
       byApp: { binance: { slots: [], missing: ["BINANCE_SECRET_KEY"] } },
     });
-    const { result } = renderHook(() => useProjectDetail(42));
+    const { result } = renderHook(() => useProjectDetail(42), {
+      wrapper: wrapper(),
+    });
     act(() => result.current.loadRequiredSecrets());
     await waitFor(() => expect(result.current.requiredSecrets).not.toBeNull());
     expect(result.current.hasMissingSecrets("binance")).toBe(true);
@@ -173,7 +210,9 @@ describe("useProjectDetail", () => {
 
   it("surfaces a required-secrets load failure instead of a false empty state", async () => {
     vi.mocked(deploymentRequiredSecrets).mockRejectedValue(new Error("boom"));
-    const { result } = renderHook(() => useProjectDetail(42));
+    const { result } = renderHook(() => useProjectDetail(42), {
+      wrapper: wrapper(),
+    });
     act(() => result.current.loadRequiredSecrets());
     await waitFor(() =>
       expect(result.current.requiredSecretsError).toBe("boom"),
@@ -231,7 +270,9 @@ describe("useProjectDetail", () => {
       },
     });
 
-    const { result } = renderHook(() => useProjectDetail(7));
+    const { result } = renderHook(() => useProjectDetail(7), {
+      wrapper: wrapper(),
+    });
     await waitFor(() => expect(result.current.source?.apps).toHaveLength(1));
 
     await act(async () => {
@@ -254,7 +295,9 @@ describe("useProjectDetail", () => {
     vi.mocked(deploymentRequiredSecrets).mockRejectedValueOnce(
       new Error("manifest unavailable"),
     );
-    const { result } = renderHook(() => useProjectDetail(42));
+    const { result } = renderHook(() => useProjectDetail(42), {
+      wrapper: wrapper(),
+    });
 
     await act(async () => {
       await expect(

--- a/apps/build/src/features/launch/hooks/use-project-detail.ts
+++ b/apps/build/src/features/launch/hooks/use-project-detail.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { UserSource, UserSourceLatestDeployment } from "@aomi-labs/deploy";
 import {
   deploymentSources,
@@ -26,10 +27,16 @@ import {
   type RequiredSecretsByApp,
 } from "@build/features/launch/required-secrets";
 import type {
-  LaunchSdkStatus,
   DeploymentPromoteResult,
   DeploymentRecord,
+  DeploymentSourcesResult,
 } from "@build/features/launch/contracts";
+import { useGitHubSession } from "@build/components/control-plane/github-session-context";
+import {
+  buildQueryKeys,
+  buildQueryStaleTime,
+  githubAccountKey,
+} from "../query-keys";
 
 /** Progress of an in-flight linked-source redeploy (deploy → CI → activate). */
 export type DeployFlowState =
@@ -44,10 +51,61 @@ const DEPLOY_POLL_MS = 4000;
 const DEPLOY_TIMEOUT_MS = 8 * 60 * 1000;
 
 export function useProjectDetail(sourceId: number, platform?: string) {
-  const [source, setSource] = useState<UserSource | null>(null);
-  const [sdk, setSdk] = useState<LaunchSdkStatus | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { account } = useGitHubSession();
+  const accountKey = githubAccountKey(account.githubLogin);
+  const queryClient = useQueryClient();
+  const sourceKey = useMemo(
+    () =>
+      buildQueryKeys.projectSource(
+        accountKey ?? "unavailable",
+        sourceId,
+        platform,
+      ),
+    [accountKey, platform, sourceId],
+  );
+  const projectsKey = buildQueryKeys.projects(accountKey ?? "unavailable");
+
+  // Source + SDK status live in react-query. The source is a server-filtered
+  // single-source read (`appSourceId` on the sources BFF route) — a project
+  // page never transfers the whole account. Warm navigations skip even that:
+  // `initialData` seeds from the `/projects` list the index already fetched,
+  // stamped with that list's own freshness, so list → project paints from
+  // cache and doesn't refetch while the list is still fresh.
+  // `enabled: !account.loading` fires the read once the session is known
+  // (signed-out surfaces the auth error, as the hand-rolled version did),
+  // never gating on the SDK badge.
+  const sourcesQuery = useQuery({
+    queryKey: sourceKey,
+    queryFn: () => deploymentSources(platform, sourceId),
+    enabled: !account.loading,
+    staleTime: buildQueryStaleTime.projects,
+    initialData: () => {
+      const list =
+        queryClient.getQueryData<DeploymentSourcesResult>(projectsKey);
+      const seeded = list?.sources.find((s) => s.id === sourceId);
+      return seeded ? { ...list, sources: [seeded] } : undefined;
+    },
+    initialDataUpdatedAt: () =>
+      queryClient.getQueryState(projectsKey)?.dataUpdatedAt,
+  });
+  const sdkQuery = useQuery({
+    queryKey: buildQueryKeys.sdkStatus(),
+    queryFn: () => deploymentSdkStatus().catch(() => null),
+    enabled: !account.loading,
+    staleTime: buildQueryStaleTime.sdkStatus,
+  });
+  const source = useMemo(
+    () => sourcesQuery.data?.sources.find((s) => s.id === sourceId) ?? null,
+    [sourcesQuery.data, sourceId],
+  );
+  const sdk = sdkQuery.data ?? null;
+  const loading = account.loading || sourcesQuery.isPending;
+  const error = sourcesQuery.error
+    ? sourcesQuery.error instanceof Error
+      ? sourcesQuery.error.message
+      : "Failed to load project"
+    : null;
+
   const [history, setHistory] = useState<UserSourceLatestDeployment[] | null>(
     null,
   );
@@ -74,9 +132,9 @@ export function useProjectDetail(sourceId: number, platform?: string) {
   const recordsReq = useRef(false);
   const requiredSecretsReq = useRef(false);
 
+  // Refetch source + SDK status. Kept stable (keyed via the query client, not
+  // the query objects) so callbacks depending on it don't churn every render.
   const reload = useCallback(async () => {
-    setLoading(true);
-    setError(null);
     // Clear the records latch so "Refresh" actually recovers a failed
     // deployment-activity load. On error `fetchRecords` sets `recordsByApp` to
     // `{}` (non-null), which otherwise makes `loadRecords` no-op forever and
@@ -84,23 +142,20 @@ export function useProjectDetail(sourceId: number, platform?: string) {
     recordsReq.current = false;
     setRecords(null);
     setRecordsError(null);
-    try {
-      const [{ sources }, sdkStatus] = await Promise.all([
-        deploymentSources(platform),
-        deploymentSdkStatus().catch(() => null),
-      ]);
-      setSource(sources.find((s) => s.id === sourceId) ?? null);
-      setSdk(sdkStatus);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load project");
-    } finally {
-      setLoading(false);
-    }
-  }, [platform, sourceId]);
+    await Promise.all([
+      queryClient.refetchQueries({ queryKey: sourceKey }),
+      queryClient.refetchQueries({ queryKey: buildQueryKeys.sdkStatus() }),
+    ]);
+  }, [queryClient, sourceKey]);
 
+  // Reset the deployment-activity latch when the project changes so a same-route
+  // navigation (…/projects/1 → …/projects/2, no unmount) doesn't strand the
+  // previous project's records. The source itself refreshes via react-query.
   useEffect(() => {
-    void reload();
-  }, [reload]);
+    recordsReq.current = false;
+    setRecords(null);
+    setRecordsError(null);
+  }, [sourceId, platform]);
 
   const loadHistory = useCallback(() => {
     if (historyReq.current || history !== null) return;
@@ -416,6 +471,8 @@ export function useProjectDetail(sourceId: number, platform?: string) {
     loading,
     error,
     sdk,
+    /** Cache namespace for account-scoped queries (null until session resolves). */
+    accountKey,
     history,
     historyError,
     secretsByApp,

--- a/apps/build/src/features/launch/query-keys.ts
+++ b/apps/build/src/features/launch/query-keys.ts
@@ -3,6 +3,20 @@ export const buildQueryKeys = {
   sdkStatus: () => [...buildQueryKeys.all, "sdk-status"] as const,
   projects: (account: string) =>
     [...buildQueryKeys.all, "account", account, "projects"] as const,
+  // Server-filtered single-source read backing a project detail page. Nested
+  // under the `projects` key so invalidating the projects prefix covers detail
+  // pages too. Warm navigations seed it from the `projects` list cache.
+  projectSource: (
+    account: string,
+    sourceId: number,
+    platform?: string | null,
+  ) =>
+    [
+      ...buildQueryKeys.projects(account),
+      "source",
+      platform?.trim() || "default",
+      sourceId,
+    ] as const,
   deployments: (account: string) =>
     [...buildQueryKeys.all, "account", account, "deployments"] as const,
   operate: (

--- a/apps/build/src/lib/api-paths.ts
+++ b/apps/build/src/lib/api-paths.ts
@@ -15,6 +15,13 @@ function withPlatform(path: string, platform?: string): string {
   return `${path}${separator}platform=${encodeURIComponent(platform)}`;
 }
 
+// Sources read, optionally narrowed server-side to a single app source.
+function sourcesPath(base: string, appSourceId?: number): string {
+  return appSourceId === undefined
+    ? base
+    : `${base}?appSourceId=${appSourceId}`;
+}
+
 export const API_PATHS = {
   bff: {
     auth: {
@@ -37,8 +44,11 @@ export const API_PATHS = {
       redeploy: `${BFF}/launch/redeploy`,
       create: `${BFF}/launch/create`,
       activate: `${BFF}/launch/activate`,
-      sources: (platform?: string) =>
-        withPlatform(`${BFF}/launch/sources`, platform),
+      sources: (platform?: string, appSourceId?: number) =>
+        withPlatform(
+          sourcesPath(`${BFF}/launch/sources`, appSourceId),
+          platform,
+        ),
       sdkStatus: `${BFF}/launch/sdk-status`,
       status: (deploymentId: string, platform?: string) =>
         withPlatform(
@@ -56,8 +66,11 @@ export const API_PATHS = {
       deploy: `${BFF}/deployments/deploy`,
       redeploy: `${BFF}/deployments/redeploy`,
       promote: `${BFF}/deployments/promote`,
-      sources: (platform?: string) =>
-        withPlatform(`${BFF}/deployments/sources`, platform),
+      sources: (platform?: string, appSourceId?: number) =>
+        withPlatform(
+          sourcesPath(`${BFF}/deployments/sources`, appSourceId),
+          platform,
+        ),
       feed: (
         limit: number,
         cursor?: { createdAt: number; id: number } | null,

--- a/apps/build/src/server/bff/launch/routes.ts
+++ b/apps/build/src/server/bff/launch/routes.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { randomBytes } from "crypto";
 import { NextResponse } from "next/server";
 import { deploymentClient } from "@build/server/bff/backend";
+import { TimedPromiseCache } from "@build/server/bff/timed-promise-cache";
 import { configuredBackendUrl } from "@build/server/backend-url";
 import { launchErrorResponse } from "./errors";
 import { launchConfig, resolveLaunchPlatform } from "./config";
@@ -23,6 +24,23 @@ import { authorize, rateLimit } from "@build/server/bff/auth";
 
 const CREATED_REPO_PREFIX = "my-playground";
 
+// Server-side timing for the manager reads on the project page's critical
+// path. Read these off a staging load to tell a heavy manager query from a
+// fat payload or pool contention — they want different fixes.
+async function timedManagerRead<T>(
+  label: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  const startedAt = performance.now();
+  try {
+    return await run();
+  } finally {
+    console.info(
+      `launch bff: ${label} took ${Math.round(performance.now() - startedAt)}ms`,
+    );
+  }
+}
+
 type DeploymentClientInstance = Awaited<ReturnType<typeof deploymentClient>>;
 
 /** Whether `appSourceId` belongs to the signed-in user. The backend scopes
@@ -41,6 +59,25 @@ async function ownsAppSource(
 type OwnedSource = Awaited<
   ReturnType<DeploymentClientInstance["listUserSources"]>
 >[number];
+
+// Read cache for the hot project-page GETs. Same 15s TTL as operate's, and it
+// coalesces concurrent mounts onto one manager call — but unlike operate's
+// read-only routes, launch mutations CHANGE what these reads return (preflight
+// re-syncs the source and can register apps; activate/promote/deactivate move
+// the live release), so every source-mutating route clears it. Without that,
+// the redeploy flow's `reload()` after preflight would read a stale list and
+// the required-secrets gate could fail for an app the UI has no row for.
+const READ_CACHE_TTL_MS = 15_000;
+const readCache = {
+  sources: new TimedPromiseCache<OwnedSource[]>(READ_CACHE_TTL_MS),
+  serverTags: new TimedPromiseCache<
+    Awaited<ReturnType<DeploymentClientInstance["serverTags"]>>
+  >(READ_CACHE_TTL_MS),
+};
+
+export function clearLaunchReadCache() {
+  Object.values(readCache).forEach((cache) => cache.clear());
+}
 
 /** The signed-in user's source with `appSourceId`, or null if not theirs. */
 async function findOwnedSource(
@@ -360,6 +397,9 @@ export function launchDeployRoute(preflight: boolean) {
       const { deployment } = preflight
         ? await client.preflight(deployInput)
         : await client.deploy(deployInput);
+      // Preflight re-syncs the source (and can register new apps); deploy
+      // records a new deployment. The next sources read must see it.
+      clearLaunchReadCache();
       const projectUrl = new URL(`/projects/${appSourceId}`, req.url);
       projectUrl.searchParams.set("platform", platform);
       projectUrl.searchParams.set("tab", "deployments");
@@ -412,6 +452,7 @@ export async function createLaunchRepoRoute(req: Request) {
       githubUserId: session.githubUserId,
       private: config.createdRepoPrivate,
     });
+    clearLaunchReadCache();
     if (!source.repositoryLink || !source.installationId) {
       return NextResponse.json(
         { error: "backend did not return a created source repo" },
@@ -566,6 +607,7 @@ export async function activateLaunchRoute(req: Request) {
       targetTags: config.targetTags,
       actor: typeof body.actor === "string" ? body.actor : undefined,
     });
+    clearLaunchReadCache();
     return NextResponse.json(result);
   } catch (err) {
     return launchErrorResponse(err);
@@ -632,7 +674,9 @@ export async function launchSdkStatusRoute(req: Request) {
 
   try {
     const client = await deploymentClient();
-    const status = await client.serverTags();
+    const status = await readCache.serverTags.get(["server_tags"], () =>
+      timedManagerRead("server_tags", () => client.serverTags()),
+    );
     const requiredVersion = status.sdkVersion;
     return NextResponse.json({
       ok: true,
@@ -1050,6 +1094,7 @@ export async function deploymentPromoteRoute(req: Request) {
       targetTags: config.targetTags,
       actor,
     });
+    clearLaunchReadCache();
     return NextResponse.json(result, { status: result.ok ? 202 : 409 });
   } catch (err) {
     return launchErrorResponse(err);
@@ -1114,6 +1159,7 @@ export async function deploymentDeactivateRoute(req: Request) {
         actor,
       });
     }
+    clearLaunchReadCache();
     return NextResponse.json({ ok: true, apps }, { status: 202 });
   } catch (err) {
     return launchErrorResponse(err);
@@ -1161,6 +1207,7 @@ export async function redeployLaunchRoute(req: Request) {
       deploymentId,
       githubUserId: session.githubUserId,
     });
+    clearLaunchReadCache();
     return NextResponse.json({
       ok: rerun.ok,
       appSourceId: body.appSourceId,
@@ -1176,7 +1223,9 @@ export async function redeployLaunchRoute(req: Request) {
 // GET /api/bff/launch/sources — the signed-in user's source repos + their apps,
 // merged across installations and platforms unless `platform` is explicit.
 // Scoped to the github_user_id in the session cookie; a client can never
-// request someone else's sources.
+// request someone else's sources. `appSourceId` narrows the response to one
+// source — the manager has no single-source read, so the filter happens here,
+// off the cached list: a project page stops transferring the whole account.
 export async function userSourcesRoute(req: Request) {
   const auth = await authorize(req);
   if ("response" in auth) return auth.response;
@@ -1184,7 +1233,8 @@ export async function userSourcesRoute(req: Request) {
 
   try {
     const config = launchConfig();
-    const requestedPlatform = new URL(req.url).searchParams.get("platform");
+    const params = new URL(req.url).searchParams;
+    const requestedPlatform = params.get("platform");
     const platform =
       requestedPlatform === null
         ? undefined
@@ -1192,12 +1242,33 @@ export async function userSourcesRoute(req: Request) {
     if (requestedPlatform !== null && !platform) {
       return invalidPlatformResponse();
     }
+    const requestedSourceId = params.get("appSourceId");
+    const appSourceId =
+      requestedSourceId === null ? undefined : Number(requestedSourceId);
+    if (appSourceId !== undefined && !isValidAppSourceId(appSourceId)) {
+      return NextResponse.json(
+        { error: "invalid `appSourceId`" },
+        { status: 400 },
+      );
+    }
     const client = await deploymentClient();
-    const sources = await client.listUserSources({
-      githubUserId: session.githubUserId,
-      platform: platform ?? undefined,
+    const sources = await readCache.sources.get(
+      [session.githubUserId, platform ?? null],
+      () =>
+        timedManagerRead("list_user_sources", () =>
+          client.listUserSources({
+            githubUserId: session.githubUserId,
+            platform: platform ?? undefined,
+          }),
+        ),
+    );
+    return NextResponse.json({
+      sources:
+        appSourceId === undefined
+          ? sources
+          : sources.filter((source) => source.id === appSourceId),
+      githubLogin: session.githubLogin,
     });
-    return NextResponse.json({ sources, githubLogin: session.githubLogin });
   } catch (err) {
     return launchErrorResponse(err);
   }

--- a/apps/build/src/server/bff/launch/source-upgrade.ts
+++ b/apps/build/src/server/bff/launch/source-upgrade.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 import { deploymentClient } from "@build/server/bff/backend";
 import { resolveLaunchPlatform } from "./config";
 import { launchErrorResponse } from "./errors";
+import { clearLaunchReadCache } from "./routes";
 import { authorize } from "@build/server/bff/auth";
 
 export async function sourceSdkUpgradeRoute(req: Request) {
@@ -41,6 +42,9 @@ export async function sourceSdkUpgradeRoute(req: Request) {
       githubUserId: session.githubUserId,
       platform,
     });
+    // The upgrade mutates the source repo; the merged PR changes the source's
+    // stamped SDK version, which the cached source list carries.
+    clearLaunchReadCache();
     return NextResponse.json(result);
   } catch (error) {
     return launchErrorResponse(error);

--- a/apps/build/src/server/bff/launch/user-sources.test.ts
+++ b/apps/build/src/server/bff/launch/user-sources.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { userSourcesRoute } from "./routes";
+import { clearLaunchReadCache, userSourcesRoute } from "./routes";
 
 vi.mock("@aomi-labs/account", () => ({
   portalService: () => ({
@@ -18,10 +18,21 @@ vi.mock("@build/server/cookies/github", () => ({
   getGitHubCliSessionFromRequest: () => getGitHubSession(),
 }));
 
-function req(platform?: string) {
+function req(platform?: string, appSourceId?: string) {
   const url = new URL("http://localhost:3000/api/bff/launch/sources");
   if (platform) url.searchParams.set("platform", platform);
+  if (appSourceId) url.searchParams.set("appSourceId", appSourceId);
   return new Request(url);
+}
+
+function sourceRow(id: number) {
+  return {
+    id,
+    installation_id: 555,
+    repository_link: `https://github.com/alice/bot-${id}`,
+    github_user_id: "42",
+    apps: [],
+  };
 }
 
 describe("userSourcesRoute", () => {
@@ -30,6 +41,9 @@ describe("userSourcesRoute", () => {
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
     getGitHubSession.mockReset();
+    // The sources read cache is module state — don't leak one test's list
+    // into the next.
+    clearLaunchReadCache();
   });
 
   it("401s when there is no GitHub session", async () => {
@@ -99,5 +113,56 @@ describe("userSourcesRoute", () => {
     expect(String(fetchMock.mock.calls[0][0])).toContain(
       "github_user_id=42&platform=somm.finance",
     );
+  });
+
+  it("narrows to one source on `appSourceId` without leaking it to the manager", async () => {
+    getGitHubSession.mockResolvedValueOnce({
+      githubUserId: "42",
+      githubLogin: "alice",
+    });
+    const fetchMock = vi.fn(async () =>
+      Response.json({ sources: [sourceRow(99), sourceRow(100)] }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await userSourcesRoute(req(undefined, "99"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sources).toHaveLength(1);
+    expect(body.sources[0].id).toBe(99);
+    expect(body.githubLogin).toBe("alice");
+
+    // The filter is BFF-side; the manager still gets the plain list read.
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain("appSourceId");
+  });
+
+  it("400s on a malformed appSourceId", async () => {
+    getGitHubSession.mockResolvedValueOnce({
+      githubUserId: "42",
+      githubLogin: "alice",
+    });
+    const res = await userSourcesRoute(req(undefined, "not-a-number"));
+    expect(res.status).toBe(400);
+  });
+
+  it("coalesces repeat reads onto the cache and refetches once cleared", async () => {
+    getGitHubSession.mockResolvedValue({
+      githubUserId: "42",
+      githubLogin: "alice",
+    });
+    const fetchMock = vi.fn(async () =>
+      Response.json({ sources: [sourceRow(99)] }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await userSourcesRoute(req());
+    const narrowed = await userSourcesRoute(req(undefined, "99"));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((await narrowed.json()).sources).toHaveLength(1);
+
+    // Mutations clear the cache so post-deploy reloads see fresh sources.
+    clearLaunchReadCache();
+    await userSourcesRoute(req());
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,70 @@
 
 ## Last Updated
 
+2026-07-29 — Build project-page perf: react-query ownership + parallel reads
+  (worktree untitled-session-7921bd, uncommitted; based on main 0e89ece2).
+  Diagnosis: /projects/:id was the last page outside react-query — hand-rolled
+  fetch of ALL sources per mount, first paint gated on `Promise.all(sources,
+  sdkStatus)`, no prefetch entry, then a strict depth-2 waterfall for HomeTab's
+  secrets+usage. Changes (apps/build):
+  - `use-project-detail.ts`: source/sdk/loading/error now `useQuery`-owned.
+    Source list keyed by NEW `buildQueryKeys.projectSources(account, platform)`
+    — identical to the `projects` key when unbound (shares the /projects index
+    cache + hover prefetch; nav list→project reads cache), platform-scoped for
+    bound projects (1620/somm.finance would `.find()` nothing in the unbound
+    list). sdkStatus is its own query and NO LONGER gates first paint (badge
+    fills in; `sdkCompatibility(_, null)`="unknown" so nothing flashes).
+    `reload()` → `refetchQueries`; records-latch reset preserved on
+    [sourceId, platform] change. Hook also returns `accountKey`.
+  - `prefetch-control-plane-route.ts`: NEW `prefetchProjectDetail()` (sources +
+    sdk + usage) + a /projects/:id matcher case — hover now warms the detail
+    page; ProjectPage calls the same helper on mount so cold loads run all
+    reads in parallel; ProjectPage also fires `loadSecrets()` for home/env tabs
+    at mount instead of after the source read.
+  - `home-tab.tsx`: usage peek moved from useState/useEffect onto `useQuery`
+    with the operate usage key (shared with /operate/usage + prefetch).
+  - `server/bff/launch/routes.ts`: `timedManagerRead()` logs around
+    `list_user_sources` + `server_tags` — read off one staging load to decide
+    whether the manager needs a single-source/filtered read (fix #4).
+  Behavior deltas: manual refresh no longer shows the full-tab spinner when
+  data exists (SWR semantics via isPending); cold DIRECT loads wait for the
+  GitHub session before the source read (cache key needs accountKey).
+  Second pass (same session) — the two items first skipped, now done properly:
+  - BFF launch read cache WITH mutation invalidation (`launch/routes.ts`):
+    `readCache.{sources,serverTags}` (TimedPromiseCache, 15s) behind
+    userSourcesRoute + launchSdkStatusRoute; unlike operate's read-only cache,
+    every source-mutating route clears it via exported `clearLaunchReadCache()`
+    — deploy/preflight factory, create-repo, activate, promote, deactivate,
+    redeploy, and sourceSdkUpgradeRoute (source-upgrade.ts). This is what makes
+    the cache safe for the redeploy→reload() flow (preflight registers apps;
+    the next sources read must see them). timedManagerRead sits INSIDE the
+    cache loader, so timing logs now measure only real manager calls.
+  - Single-source read WITHOUT losing cache sharing: `?appSourceId=` on the
+    sources BFF route filters BFF-side off the cached list (manager has no
+    single-source endpoint; manager URL unchanged). Client chain:
+    `API_PATHS...sources(platform, appSourceId)` → `deploymentSources(platform,
+    appSourceId)`. Hook now queries `buildQueryKeys.projectSource(account,
+    sourceId, platform)` (nested under the projects prefix) with
+    `initialData`/`initialDataUpdatedAt` seeded from the `projects` LIST cache
+    — warm list→project nav paints from cache with zero fetch while the list
+    is fresh; cold loads transfer ONE source instead of the whole account.
+    `projectSources` key helper replaced by `projectSource`; prefetch warms the
+    slim read.
+  Tests: use-project-detail.test.ts + home-tab.test.tsx + project-page.test.tsx
+  gained QueryClientProvider/GitHubSessionProvider harnesses (pattern from
+  use-projects.test.ts); user-sources.test.ts +3 (appSourceId filter + no
+  manager leak, malformed→400, cache coalesce + clear seam; afterEach clears
+  the module-level cache). Verified: aomi-build type-check, eslint, prettier,
+  full suite 353/353. NOTE for worktree sessions: vitest excludes
+  `**/.claude/**` so running tests INSIDE a .claude worktree needs a throwaway
+  config that drops that exclude + cwd at worktree root; `@aomi-labs/widget-lib`
+  = apps/shadcn-registry and needs `pnpm run build:package` THERE (root
+  build:lib builds packages/react, not it); root build:lib also dirties
+  committed packages/client/dist maps — revert those.
+  Related: PR #423 (unmerged) bounds the operate settleBySource fan-out
+  (6-way cap / 8s per-source / 20s budget) — covers /operate/observability;
+  nothing here overlaps it.
+
 2026-07-27 — Light/dark token sweep. Dark mode was losing all structure: in
   `themes/default.css` the dark block collapsed `--aomi-surface-2`, `--aomi-raised`
   and `--aomi-border` onto a single `#27272a`, so every hairline drawn on a panel


### PR DESCRIPTION
## Why

`/projects/:id` was the last control-plane page outside react-query: a hand-rolled fetch of **all** sources per mount, first paint gated on `Promise.all(sources, sdkStatus)`, no hover prefetch, then a depth-2 waterfall for the Home tab's secrets + usage. This makes it feel instant on navigation and stops it transferring the whole account to draw one project.

## What

**Frontend**
- `useProjectDetail` now owns `source`/`sdk`/`loading`/`error` via react-query. The source is a **server-filtered single-source read**; warm list→project navigation seeds from the `/projects` list cache (`initialData`) and paints with **zero fetch** while that list is fresh. Bound-platform projects (e.g. `somm.finance`) get their own platform-scoped key so they resolve correctly.
- `sdkStatus` is its own query and no longer gates first paint — the SDK badge fills in on its own (`sdkCompatibility(_, null)` = `"unknown"`, so nothing wrong flashes).
- New `prefetchProjectDetail()` (source + sdk + usage) wired into a `/projects/:id` **hover matcher** and called again on page mount, so the reads run in parallel instead of behind the source read. `ProjectPage` also starts `loadSecrets()` for the home/environment tabs at mount.
- Home tab's usage peek moved onto react-query, sharing the operate-usage key with `/operate/usage` and the prefetch.

**BFF** (`apps/build` only — the `apps/portal` twin is intentionally untouched)
- Sources + `serverTags` reads go through a 15s `TimedPromiseCache` that coalesces concurrent mounts. Unlike operate's read-only cache, **every source-mutating route clears it** via `clearLaunchReadCache()` (deploy/preflight, create, activate, promote, deactivate, redeploy, SDK upgrade) — so the redeploy→`reload()` flow never reads a stale list (which would fail the required-secrets gate for a freshly-registered app).
- Sources route accepts `?appSourceId=` and filters **BFF-side off the cached list** (the manager has no single-source endpoint; the manager URL is unchanged), so a project page stops transferring the whole account.
- `timedManagerRead()` logs `list_user_sources` / `server_tags` latency (inside the cache loaders, so only real manager calls are timed) to decide whether a manager-side filter is worth adding.

## Behavior deltas worth a look on review
- Manual refresh no longer shows the full-tab spinner when data already exists (SWR semantics via `isPending`).
- Cold **direct** loads to a project URL wait for the GitHub session before the source read (the cache key needs `accountKey`); list-nav and hover paths are unaffected.

## Backend follow-up (deliberately not in this PR)
No Rust/manager change here. BFF caching + filtering already remove the payload and herd problems; a manager `?app_source_id=` filter would only cut cold-read query cost. The `timedManagerRead` logs decide it: `<150ms` → leave it; `500ms+` → add an additive filter param in `product-mono`.

## Testing
- Hook / home-tab / project-page suites gained `QueryClient` + `GitHubSession` harnesses.
- `user-sources.test.ts` covers the `appSourceId` filter (and that it is **not** leaked to the manager), malformed id → 400, and cache coalesce + clear.
- Full `aomi-build` suite **363/363**, `type-check` + `eslint` + `prettier` clean. Rebased onto current `main` (on top of #423, zero file overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787953671&installation_model_id=12362&pr_number=424&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F424&signature=d361689d658d7ea8d0856198b46cd321a5fb17a8ddaba9ae0c1bd8bb190435dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->