### PR TITLE
Read observability through the manager's account-wide batch endpoint

### DIFF
--- a/apps/build/src/server/bff/operate/routes.test.ts
+++ b/apps/build/src/server/bff/operate/routes.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BackendError } from "@aomi-labs/deploy";
 
 import {
   clearOperateCachesForTesting,
@@ -24,12 +25,20 @@ const client = {
   deleteUserBot: vi.fn(),
   getUserSourceUsage: vi.fn(),
   getUserSourceStatement: vi.fn(),
+  getUserObservability: vi.fn(),
   getUserSourceObservability: vi.fn(),
   getUserSourceAppDetail: vi.fn(),
   listUserSourceTransactions: vi.fn(),
   listUserSourceLogs: vi.fn(),
   listUserSourceDeployments: vi.fn(),
 };
+
+/** An older manager without the batch observability route. */
+function batchRouteMissing() {
+  client.getUserObservability.mockRejectedValue(
+    new BackendError("get_user_observability", 404, "not found"),
+  );
+}
 
 vi.mock("@build/server/bff/backend", () => ({
   deploymentClient: async () => client,
@@ -84,6 +93,10 @@ beforeEach(() => {
   client.deleteUserBot.mockReset();
   client.getUserSourceUsage.mockReset();
   client.getUserSourceStatement.mockReset();
+  client.getUserObservability.mockReset();
+  // Default to the pre-batch manager so the per-source fallback tests below
+  // stay representative; batch tests override this per case.
+  batchRouteMissing();
   client.getUserSourceObservability.mockReset();
   client.getUserSourceAppDetail.mockReset();
   client.listUserSourceTransactions.mockReset();
@@ -792,6 +805,114 @@ describe("operateObservabilityRoute live data", () => {
     expect(body.example).toBeUndefined();
     expect(body.apps).toEqual([]);
     expect(body.monitoring.status).toBe("unconfigured");
+  });
+
+  it("serves the whole account from one batch read when the manager has it", async () => {
+    setSession({ githubUserId: "gh-1" });
+    oneSource();
+    client.getUserObservability.mockResolvedValue([
+      {
+        source: { id: 900 },
+        platform: "community",
+        scope: "owned_applications",
+        monitoring: {
+          provider: "grafana_prometheus",
+          status: "ok",
+          windowSeconds: 900,
+        },
+        apps: [
+          {
+            applicationId: 1,
+            application: "real-bot",
+            active: true,
+            loaded: true,
+            status: "healthy",
+            metrics: null,
+          },
+        ],
+        payments: emptyPayments(),
+        dashboardLinks: [],
+        platformMetrics: [],
+      },
+      {
+        // A partner-bound source the per-source fan-out could never read
+        // under the default platform — the batch covers it.
+        source: { id: 1620 },
+        platform: "somm.finance",
+        scope: "owned_applications",
+        monitoring: {
+          provider: "grafana_prometheus",
+          status: "ok",
+          windowSeconds: 900,
+        },
+        apps: [
+          {
+            applicationId: 2,
+            application: "somm-agent",
+            active: true,
+            loaded: true,
+            status: "healthy",
+            metrics: null,
+          },
+        ],
+        payments: emptyPayments(),
+        dashboardLinks: [],
+        platformMetrics: [],
+      },
+    ]);
+
+    const first = await operateObservabilityRoute(observabilityReq());
+    const second = await operateObservabilityRoute(observabilityReq());
+    const body = await first.json();
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    // One account-wide read, cached across requests; no per-source fan-out.
+    expect(client.getUserObservability).toHaveBeenCalledTimes(1);
+    expect(client.getUserObservability).toHaveBeenCalledWith(
+      expect.objectContaining({ githubUserId: "gh-1", platform: undefined }),
+    );
+    expect(client.getUserSourceObservability).not.toHaveBeenCalled();
+    expect(body.degraded).toBeUndefined();
+    expect(
+      body.apps.map((app: { application: string }) => app.application),
+    ).toEqual(["real-bot", "somm-agent"]);
+    expect(body.monitoring.status).toBe("ok");
+  });
+
+  it("falls back to the per-source fan-out when the batch route 404s", async () => {
+    setSession({ githubUserId: "gh-1" });
+    oneSource();
+    // beforeEach already arms the 404; make the fallback observable.
+    client.getUserSourceObservability.mockResolvedValue({
+      source: { id: 900 },
+      platform: "community",
+      scope: "owned_applications",
+      monitoring: null,
+      apps: [],
+      payments: emptyPayments(),
+      dashboardLinks: [],
+      platformMetrics: [],
+    });
+
+    const res = await operateObservabilityRoute(observabilityReq());
+
+    expect(res.status).toBe(200);
+    expect(client.getUserObservability).toHaveBeenCalled();
+    expect(client.getUserSourceObservability).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces non-404 batch failures instead of silently fanning out", async () => {
+    setSession({ githubUserId: "gh-1" });
+    oneSource();
+    client.getUserObservability.mockRejectedValue(
+      new BackendError("get_user_observability", 500, "manager exploded"),
+    );
+
+    const res = await operateObservabilityRoute(observabilityReq());
+
+    expect(res.status).toBeGreaterThanOrEqual(500);
+    expect(client.getUserSourceObservability).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/build/src/server/bff/operate/routes.ts
+++ b/apps/build/src/server/bff/operate/routes.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { NextResponse } from "next/server";
+import { BackendError } from "@aomi-labs/deploy";
 import type {
   BotRegistration,
   OperateLogCursor,
@@ -310,6 +311,9 @@ const readCache = {
   statement: new TimedPromiseCache<OperateStatementResult>(CACHE_TTL_MS),
   logs: new TimedPromiseCache<OperateLogsResult>(CACHE_TTL_MS),
   observability: new TimedPromiseCache<OperateObservabilityResult>(
+    CACHE_TTL_MS,
+  ),
+  observabilityBatch: new TimedPromiseCache<OperateObservabilityResult[]>(
     CACHE_TTL_MS,
   ),
   appDetail: new TimedPromiseCache<OperateAppDetailResult>(CACHE_TTL_MS),
@@ -1030,20 +1034,46 @@ export async function operateObservabilityRoute(req: Request) {
   try {
     const owned = await ownedSources(req);
     if ("response" in owned) return owned.response;
-    const observabilityReads = await settleBySource<OperateObservabilityResult>(
-      owned.sources,
-      (source) =>
-        readCache.observability.get(
-          [owned.githubUserId, owned.platform, source.id],
-          () =>
-            owned.client.getUserSourceObservability({
-              githubUserId: owned.githubUserId,
-              platform: owned.platform,
-              appSourceId: source.id,
-            }),
-        ),
-    );
-    const results = observabilityReads.ok;
+    // One manager request for the whole account. Without an explicit
+    // `platform` filter the manager resolves each source under its own
+    // bound/loaded platform, which also covers partner-bound sources that the
+    // per-source read rejects as not launch-relevant on the default platform.
+    const requestedPlatform =
+      new URL(req.url).searchParams.get("platform") ?? undefined;
+    let results: OperateObservabilityResult[] | null = null;
+    try {
+      results = await readCache.observabilityBatch.get(
+        [owned.githubUserId, requestedPlatform ?? null],
+        () =>
+          owned.client.getUserObservability({
+            githubUserId: owned.githubUserId,
+            platform: requestedPlatform,
+          }),
+      );
+    } catch (err) {
+      // A manager without the batch route (mid-rollout) 404s; keep the page
+      // alive on the bounded per-source fan-out until the deploy completes.
+      if (!(err instanceof BackendError && err.status === 404)) throw err;
+    }
+    let degraded: OperateDegraded | undefined;
+    if (results === null) {
+      const observabilityReads =
+        await settleBySource<OperateObservabilityResult>(
+          owned.sources,
+          (source) =>
+            readCache.observability.get(
+              [owned.githubUserId, owned.platform, source.id],
+              () =>
+                owned.client.getUserSourceObservability({
+                  githubUserId: owned.githubUserId,
+                  platform: owned.platform,
+                  appSourceId: source.id,
+                }),
+            ),
+        );
+      results = observabilityReads.ok;
+      degraded = degradedFrom(owned.sources, observabilityReads.dropped);
+    }
     const apps = results.flatMap((result) =>
       result.apps.map((app) => ({
         ...app,
@@ -1055,7 +1085,7 @@ export async function operateObservabilityRoute(req: Request) {
       // Every source the account owns, not just the ones this read covered:
       // the filter dropdown is how a user retries a dropped source on its own.
       sources: owned.sources,
-      degraded: degradedFrom(owned.sources, observabilityReads.dropped),
+      degraded,
       scope: "owned_applications",
       monitoring: {
         provider: "grafana_prometheus",

--- a/packages/deploy/src/client.ts
+++ b/packages/deploy/src/client.ts
@@ -51,6 +51,7 @@ import type {
   OperateUsageResult,
   UpdateUserBotInput,
   OwnedOperateSourceInput,
+  GetUserObservabilityInput,
   SaveBuilderModelKeyInput,
   SetModelKeyGrantsInput,
   UserSource,
@@ -1198,6 +1199,37 @@ export class DeploymentClient {
       ts: Date.now(),
     });
     return camelOperateObservability(raw, platform);
+  }
+
+  /**
+   * Account-wide observability batch: every owned source in one request, each
+   * entry in the exact shape of {@link getUserSourceObservability}. Without
+   * `platform`, the manager resolves each source under its own bound/loaded
+   * platform — partner-bound sources included. Requires a manager with
+   * `GET /user/observability`; callers fall back to per-source reads when the
+   * route 404s (older manager).
+   */
+  async getUserObservability(
+    input: GetUserObservabilityInput,
+  ): Promise<OperateObservabilityResult[]> {
+    const githubUserId = required(input.githubUserId, "githubUserId");
+    const bearer = this.resolveBearer(input.bearer);
+    const params = new URLSearchParams({ github_user_id: githubUserId });
+    if (input.platform?.trim()) params.set("platform", input.platform.trim());
+    const raw = await this.get<{ results?: unknown[] }>(
+      `/api/integrations/github-app/user/observability?${params.toString()}`,
+      "get_user_observability",
+      bearer,
+    );
+    await this.audit({
+      action: "get_user_observability",
+      platform: input.platform,
+      actor: input.actor,
+      ts: Date.now(),
+    });
+    return ((raw.results ?? []) as Record<string, unknown>[]).map((entry) =>
+      camelOperateObservability(entry, input.platform?.trim() ?? ""),
+    );
   }
 
   async getUserSourceAppDetail(

--- a/packages/deploy/src/types.ts
+++ b/packages/deploy/src/types.ts
@@ -55,6 +55,7 @@ export interface AuditEvent {
     | "get_user_source_statement"
     | "list_user_source_logs"
     | "get_user_source_observability"
+    | "get_user_observability"
     | "get_user_source_app_detail"
     | "upgrade_user_source_sdk"
     | "get_source_sdk_upgrade_status"
@@ -626,6 +627,13 @@ export interface OwnedOperateSourceInput extends BearerOverride {
   githubUserId: string;
   platform: string;
   appSourceId: number;
+}
+
+/** Account-wide observability batch. Without `platform`, the manager reports
+ *  every owned source under its own bound/loaded platform. */
+export interface GetUserObservabilityInput extends BearerOverride {
+  githubUserId: string;
+  platform?: string;
 }
 
 export interface GetUserSourceAppDetailInput extends OwnedOperateSourceInput {

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,41 @@
 
 ## Last Updated
 
+2026-07-30 — Observability batch read: fan-out removed at the source (branch
+  `feat/operate-batch-observability` in BOTH repos; aomi PR #426, product-mono
+  PR #901; based on main incl. #423 + #424).
+  ROOT CAUSE (measured on staging via a minted service bearer, 113 sources):
+  one per-source observability read = ~1.9s (~9 Grafana HTTP queries); at the
+  BFF's 6-wide fan-out reads stretch to 6.1–8.6s because Grafana serializes
+  the ~54 concurrent queries — every read outlives #423's 8s per-source
+  timeout, so /operate/observability rendered "Showing 0 of 113 sources".
+  Also: partner-bound sources (somm.finance) 404 "not launch-relevant" under
+  the default platform on every unscoped page load — permanently counted in
+  the degraded banner. Probe recipe + full facts in auto-memory
+  (observability-fanout-root-cause).
+  MANAGER (product-mono #901): new service route
+  GET /api/integrations/github-app/user/observability?github_user_id=
+  [&platform=] → { results: [single-source wire shape] }. One
+  Grafana/rollup snapshot per PLATFORM (operate_monitoring generalized to a
+  source-id set; transaction_metrics_24h_for_sources ANY($1)); each source
+  resolved under its own bound/loaded platform (fixes partner 404s);
+  partner-payment ledgers in bounded waves of 8; single-source read's
+  sequential per-app current_sdk_version N+1 replaced with batched
+  current_sdk_versions; app_health_json/dashboard_links_json shared between
+  single + batch so shapes can't drift.
+  AOMI (#426): packages/deploy getUserObservability(); BFF
+  operateObservabilityRoute does ONE batch read (15s TimedPromiseCache).
+  404 (pre-batch manager, mid-rollout) → falls back to the #423 bounded
+  per-source fan-out; other errors surface. degraded unset on batch path.
+  FE untouched (same response shape).
+  DEPLOY ORDER: either PR lands first (fallback covers the gap); page gets
+  fast only once the manager deploys. FOLLOW-UPS once staging verifies:
+  delete the per-source fallback + settleBySource for observability; apply
+  the same batch pattern to transactions/usage/logs/statement (same herd);
+  then re-check the "0 of N" banner never fires.
+  Verified: manager cargo test 137+manifest, clippy/fmt clean, backend check
+  green; aomi 497/497 (apps/build + packages/deploy), type-check + lint clean.
+
 2026-07-29 — Build project-page perf: react-query ownership + parallel reads
   (worktree untitled-session-7921bd, uncommitted; based on main 0e89ece2).
   Diagnosis: /projects/:id was the last page outside react-query — hand-rolled


### PR DESCRIPTION
## Why

`/operate/observability` fans out one manager request per source. Even with the bounded fan-out (#423), a 113-source account renders **"Showing 0 of 113 sources"** on staging: one per-source read costs ~1.9s (~9 Grafana queries) and at 6-wide the reads stretch past the 8s per-source timeout because Grafana serializes the ~54 concurrent queries — every wave dies and the 20s budget expires with nothing rendered. #423 correctly bounded the blast radius; this removes the fan-out itself.

## What

The manager now exposes `GET /user/observability` (aomi-labs/product-mono#901): the whole account in one request, one Grafana/rollup snapshot per platform, each source resolved under its own bound/loaded platform.

- **packages/deploy**: `getUserObservability()` maps the batch's `results` through the same `camelOperateObservability` as the single-source read.
- **BFF**: `operateObservabilityRoute` makes **one** batch read (15s `TimedPromiseCache`). A **404** — a manager without the route, mid-rollout — falls back to the existing bounded per-source fan-out with its degraded notice; any other failure surfaces instead of silently fanning out. On the batch path `degraded` stays unset: coverage is complete by construction.
- **Partner sources fixed**: batch entries include partner-bound sources (e.g. `somm.finance`) that the per-source read 404s as "not launch-relevant" under the default platform — previously they were *permanently* counted in the "could not be read" banner; now their apps render.
- **FE: zero changes** — the response shape is unchanged.

## Rollout

Either PR can land first (the 404 fallback keeps the page on today's behavior until the manager deploys). Once the manager rollout is verified on staging, the per-source fallback + `settleBySource` for this route can be deleted in a follow-up; the same batch pattern can then retire the identical fan-outs on transactions/usage/logs/statement.

## Testing

Existing observability tests keep exercising the fallback (the mock manager defaults to a 404 batch route); new cases cover the batch path + caching + partner sources, the 404 fallback, and non-404 error surfacing. `apps/build` + `packages/deploy` suites 497/497, type-check + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787977430&installation_model_id=12362&pr_number=426&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F426&signature=13e129452b70e4ed76a6c46fdd74089c20ff2585418915aca175dea28a8b1c97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->