### PR TITLE
Portal: sync Usage tab UI with aomi-portal design

### DIFF
--- a/apps/portal/src/features/usage/usage-settings.test.tsx
+++ b/apps/portal/src/features/usage/usage-settings.test.tsx
@@ -92,7 +92,7 @@ describe("usage settings wiring", () => {
     expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
     expect(screen.getAllByText(/8 turns/).length).toBeGreaterThanOrEqual(1);
     // Allowance meter fed by the profile's credit position.
-    expect(screen.getByText(/Credits 80\/500/)).toBeTruthy();
+    expect(screen.getByText(/80.*500.*used/)).toBeTruthy();
   });
 
   it("recomputes a cached statement when the account allowance arrives later", async () => {
@@ -135,7 +135,7 @@ describe("usage settings wiring", () => {
       );
     });
 
-    expect(screen.getByText(/Credits 80\/500/)).toBeTruthy();
+    expect(screen.getByText(/80.*500.*used/)).toBeTruthy();
     expect(
       calls.filter((path) => path === "/api/account/statement"),
     ).toHaveLength(1);

--- a/apps/portal/src/features/usage/usage-settings.tsx
+++ b/apps/portal/src/features/usage/usage-settings.tsx
@@ -1,16 +1,21 @@
 "use client";
 
 import Link from "next/link";
-import { Loader2 } from "lucide-react";
+import { ChevronDown, Loader2 } from "lucide-react";
 import { useUsageStatement } from "./use-usage-statement";
-import { MatrixTable, Meter, usd } from "./usage-shared";
+import {
+  AllowanceSettlementSection,
+  MatrixTable,
+  PeriodTotalHero,
+  SectionHeading,
+  SpendBreakdownSection,
+  USAGE_MATRIX_HINT,
+} from "./usage-shared";
 
 /**
- * Settings › Usage — the compact popup view: the subject summary with the
- * by-app matrix directly under it, rendered from the live model statement
- * (`/api/account/statement`). Tool and on-chain subjects show "—" until their
- * ledger writers exist — absent, not zero. The itemized full statement lives
- * on its own page at /statement.
+ * Settings › Usage — design-sync hierarchy (hero, spend breakdown, allowance,
+ * by-app matrix) on the live model statement (`/api/account/statement`).
+ * Tool and on-chain subjects show "—" until their ledger writers exist.
  */
 export function UsageSettings() {
   const statement = useUsageStatement();
@@ -30,7 +35,7 @@ export function UsageSettings() {
             </button>
           </p>
         ) : (
-          <p className="flex items-center gap-2 text-[13px] text-aomi-muted">
+          <p className="text-aomi-muted flex items-center gap-2 text-[13px]">
             <Loader2 size={14} className="animate-spin" />
             Loading usage…
           </p>
@@ -39,107 +44,46 @@ export function UsageSettings() {
     );
   }
 
-  const { period, summary, payment } = month;
-  const turns = month.apps.reduce((s, a) => s + a.model.turns, 0);
-  // These subjects have no ledger writer yet — absent (—), never $0.00.
-  const hasToolData = month.apps.some((a) => a.tool !== null);
-  const hasOutcomeData = month.apps.some((a) => a.outcome !== null);
-
-  const over = payment.x402SettledUsd > 0;
-  const hasAllowance = payment.allowanceCredits.included > 0;
-  const creditsPct = hasAllowance
-    ? Math.min(
-        100,
-        (payment.allowanceCredits.used / payment.allowanceCredits.included) * 100,
-      )
-    : 0;
+  const { period } = month;
+  const hasAllowance =
+    statement.isCurrentMonth && month.payment.allowanceCredits.included > 0;
 
   return (
     <div className="flex-1 overflow-y-auto px-[22px] py-5">
-      <div className="flex flex-col gap-7">
-        {/* Summary card */}
-        <div className="overflow-hidden">
-          <div className="flex items-center justify-between border-b border-aomi-border p-4">
-            <span className="text-sm font-semibold">Usage</span>
-            <span className="text-[13px] text-aomi-muted">{period.periodLabel}</span>
-          </div>
+      <div className="flex flex-col gap-6">
+        <PeriodTotalHero periodLabel={period.periodLabel} totalUsd={month.summary.totalUsd} />
 
-          <div className="flex flex-col gap-3 p-4">
-            <SummaryRow label="Models" detail={`${turns} turns`} amount={usd(summary.modelUsd)} />
-            <SummaryRow
-              label="Tool calls"
-              detail={hasToolData ? "" : "no charges"}
-              amount={hasToolData ? usd(summary.toolUsd) : "—"}
-            />
-            <SummaryRow
-              label="On-chain fees"
-              detail={hasOutcomeData ? "" : "no charges"}
-              amount={hasOutcomeData ? usd(summary.onchainUsd) : "—"}
-            />
-            <div className="mt-1 flex items-center justify-between border-t border-aomi-border pt-3">
-              <span className="text-sm font-semibold">Total</span>
-              <span className="font-mono text-base font-semibold">{usd(summary.totalUsd)}</span>
-            </div>
-          </div>
+        <SpendBreakdownSection month={month} />
 
-          {/* Allowance position comes from the profile's monthly stats, so it's
-              only exact for the current month — hidden elsewhere. */}
-          {statement.isCurrentMonth && hasAllowance && (
-            <div className="flex flex-col gap-2 border-t border-aomi-border p-4">
-              <span className="text-[13px] text-aomi-muted">
-                Credits {Math.round(payment.allowanceCredits.used)}/
-                {Math.round(payment.allowanceCredits.included)} · paid via{" "}
-                {payment.settledVia}
-              </span>
-              <Meter pct={creditsPct} over={over} />
-              {over && (
-                <span className="text-[11px] text-aomi-muted">
-                  {usd(payment.x402SettledUsd)} settled via x402 beyond your
-                  monthly allowance.
-                </span>
-              )}
-            </div>
-          )}
+        <AllowanceSettlementSection month={month} showAllowance={hasAllowance} />
 
-          <div className="flex items-center justify-end border-t border-aomi-border p-4">
-            <Link
-              href="/statement"
-              className="text-[13px] font-medium text-aomi-accent transition-opacity hover:opacity-80"
-            >
-              View full statement →
-            </Link>
-          </div>
-        </div>
-
-        {/* By app — frameless, right under the summary */}
         {month.apps.length > 0 ? (
-          <div className="flex flex-col gap-2.5">
-            <div className="flex items-baseline justify-between">
-              <span className="text-sm font-semibold">By app</span>
-              <span className="text-[11px] text-aomi-muted">
-                hover a value for the count behind it
-              </span>
+          <section className="flex flex-col gap-2.5">
+            <SectionHeading title="By app" hint={USAGE_MATRIX_HINT} />
+            <div className="border-aomi-border bg-aomi-bg/40 overflow-hidden rounded-xl border px-4 py-3 sm:px-5">
+              <MatrixTable month={month} />
             </div>
-            <MatrixTable month={month} />
-          </div>
+          </section>
         ) : (
-          <p className="text-[13px] text-aomi-muted">
-            No usage this month yet.
-          </p>
+          <p className="text-aomi-muted text-[13px]">No usage this month yet.</p>
         )}
-      </div>
-    </div>
-  );
-}
 
-function SummaryRow({ label, detail, amount }: { label: string; detail: string; amount: string }) {
-  return (
-    <div className="flex items-center justify-between">
-      <div className="flex flex-col gap-0.5">
-        <span className="text-sm">{label}</span>
-        {detail && <span className="text-[11px] text-aomi-muted">{detail}</span>}
+        <Link
+          href="/statement"
+          className="border-aomi-border bg-aomi-bg/40 group flex items-center justify-between gap-3 rounded-xl border px-4 py-3.5 transition-colors hover:bg-aomi-surface-2/40 sm:px-5"
+        >
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <span className="text-sm font-medium leading-none">Full statement</span>
+            <span className="text-aomi-muted text-[12px] leading-snug">
+              Itemized lines, past months, and filters
+            </span>
+          </div>
+          <ChevronDown
+            size={14}
+            className="text-aomi-muted shrink-0 -rotate-90 transition-colors group-hover:text-aomi-fg"
+          />
+        </Link>
       </div>
-      <span className="font-mono text-sm">{amount}</span>
     </div>
   );
 }

--- a/apps/portal/src/features/usage/usage-shared.tsx
+++ b/apps/portal/src/features/usage/usage-shared.tsx
@@ -473,6 +473,192 @@ export function OutcomeTable({
 }
 
 /* ---------------------------------------------------------------------- */
+/* Usage + Statement summary sections                                      */
+/* ---------------------------------------------------------------------- */
+
+export function StatTile({
+  label,
+  value,
+  detail,
+  primary,
+}: {
+  label: string;
+  value: string;
+  detail?: string;
+  primary?: boolean;
+}) {
+  return (
+    <div className="border-aomi-border bg-aomi-bg/40 flex min-w-0 flex-col gap-1 rounded-xl border px-3 py-3 sm:px-4 sm:py-3.5">
+      <span className="text-aomi-muted truncate text-[11px]">{label}</span>
+      <span
+        className={`truncate font-mono font-semibold tabular-nums ${
+          primary ? "text-lg sm:text-xl" : "text-base sm:text-lg"
+        }`}
+      >
+        {value}
+      </span>
+      {detail && (
+        <span className="text-aomi-muted truncate text-[10px]">{detail}</span>
+      )}
+    </div>
+  );
+}
+
+export const USAGE_MATRIX_HINT =
+  "Hover a cell for counts · — means not billed · $0 + app key = app BYOK";
+
+export function SectionHeading({ title, hint }: { title: string; hint?: string }) {
+  return (
+    <div className="flex flex-wrap items-baseline justify-between gap-2 px-0.5">
+      <span className="text-sm font-medium leading-none">{title}</span>
+      {hint && <span className="text-aomi-muted text-[11px]">{hint}</span>}
+    </div>
+  );
+}
+
+export function PeriodTotalHero({
+  periodLabel,
+  totalUsd,
+  periodCaption = "Current period",
+}: {
+  periodLabel: string;
+  totalUsd: number;
+  periodCaption?: string;
+}) {
+  return (
+    <div className="border-aomi-border flex items-end justify-between gap-4 border-b pb-4">
+      <div className="flex min-w-0 flex-col gap-1">
+        <span className="text-aomi-muted text-[10px] font-medium uppercase tracking-[0.08em]">
+          {periodCaption}
+        </span>
+        <span className="text-lg font-semibold leading-none tracking-[-0.01em]">
+          {periodLabel}
+        </span>
+      </div>
+      <div className="shrink-0 text-right">
+        <span className="font-mono text-2xl font-semibold tabular-nums leading-none">
+          {usd(totalUsd)}
+        </span>
+        <span className="text-aomi-muted mt-1 block text-[11px]">Total spend</span>
+      </div>
+    </div>
+  );
+}
+
+function monthActivityStats(month: MonthlyStatement) {
+  const turns = month.apps.reduce((s, a) => s + a.model.turns, 0);
+  const toolCalls = month.apps.reduce((s, a) => s + (a.tool?.calls ?? 0), 0);
+  const txns = month.apps.reduce((s, a) => s + (a.outcome?.txns ?? 0), 0);
+  const hasToolData = month.apps.some((a) => a.tool !== null);
+  const hasOutcomeData = month.apps.some((a) => a.outcome !== null);
+  const { payment, summary } = month;
+  const over = payment.x402SettledUsd > 0;
+  const hasAllowance = payment.allowanceCredits.included > 0;
+  const creditsPct = hasAllowance
+    ? Math.min(
+        100,
+        (payment.allowanceCredits.used / payment.allowanceCredits.included) * 100,
+      )
+    : 0;
+  const computeShare =
+    summary.totalUsd > 0
+      ? Math.round((summary.computeUsd / summary.totalUsd) * 100)
+      : 0;
+  const onchainShare = 100 - computeShare;
+
+  return {
+    turns,
+    toolCalls,
+    txns,
+    hasToolData,
+    hasOutcomeData,
+    over,
+    hasAllowance,
+    creditsPct,
+    computeShare,
+    onchainShare,
+  };
+}
+
+export function SpendBreakdownSection({ month }: { month: MonthlyStatement }) {
+  const { summary } = month;
+  const { turns, toolCalls, txns, hasToolData, hasOutcomeData, computeShare, onchainShare } =
+    monthActivityStats(month);
+
+  return (
+    <section className="flex flex-col gap-2.5">
+      <SectionHeading
+        title="Spend breakdown"
+        hint={`${computeShare}% compute · ${onchainShare}% on-chain`}
+      />
+      <div className="grid grid-cols-3 gap-2 sm:gap-2.5">
+        <StatTile label="Models" value={usd(summary.modelUsd)} detail={`${turns} turns`} />
+        <StatTile
+          label="Tool calls"
+          value={hasToolData ? usd(summary.toolUsd) : "—"}
+          detail={hasToolData ? `${toolCalls} calls` : "no charges"}
+        />
+        <StatTile
+          label="On-chain"
+          value={hasOutcomeData ? usd(summary.onchainUsd) : "—"}
+          detail={hasOutcomeData ? `${txns} txn${txns === 1 ? "" : "s"}` : "no charges"}
+        />
+      </div>
+      <p className="text-aomi-muted px-0.5 text-[12px] leading-snug">
+        Compute subtotal {usd(summary.computeUsd)} (models + tools)
+        {summary.managedMarkupUsd > 0 && (
+          <> · includes {usd(summary.managedMarkupUsd)} managed markup on third-party apps</>
+        )}
+        . On-chain fees settle separately in-token on your transactions.
+      </p>
+    </section>
+  );
+}
+
+export function AllowanceSettlementSection({
+  month,
+  showAllowance = true,
+}: {
+  month: MonthlyStatement;
+  /** Hide when viewing a past month — profile credits only match the current month. */
+  showAllowance?: boolean;
+}) {
+  const { payment } = month;
+  const { over, hasAllowance, creditsPct } = monthActivityStats(month);
+
+  if (!showAllowance || !hasAllowance) return null;
+
+  return (
+    <section className="flex flex-col gap-2.5">
+      <SectionHeading title="Allowance & settlement" />
+      <div className="border-aomi-border bg-aomi-bg/40 overflow-hidden rounded-xl border">
+        <div className="border-aomi-border flex flex-wrap items-center justify-between gap-2 border-b px-4 py-3 sm:px-5">
+          <span className="text-[13px] font-medium text-aomi-fg">Monthly credits</span>
+          <span className="text-aomi-muted text-[13px] tabular-nums">
+            {payment.allowanceCredits.used.toLocaleString()} /{" "}
+            {payment.allowanceCredits.included.toLocaleString()} used
+          </span>
+        </div>
+        <div className="flex flex-col gap-2.5 px-4 py-3.5 sm:px-5">
+          <Meter pct={creditsPct} over={over} />
+          <span className="text-aomi-muted text-[12px] leading-snug">
+            Paid via {payment.settledVia}.{" "}
+            {over
+              ? `${usd(payment.x402SettledUsd)} billed via x402 beyond your ${usd(
+                  payment.allowanceAppliedUsd,
+                )} monthly allowance.`
+              : `Compute fully covered by your allowance (${usd(
+                  payment.allowanceAppliedUsd,
+                )} applied).`}{" "}
+            On-chain fees {payment.onchainNote}.
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ---------------------------------------------------------------------- */
 /* Meter                                                                   */
 /* ---------------------------------------------------------------------- */
 


### PR DESCRIPTION
## Summary

- Restructures the Settings › Usage tab to match the `aomi-portal` design hierarchy: period hero, spend breakdown tiles, allowance & settlement, by-app matrix, and full statement CTA
- Adds shared sections to `usage-shared.tsx` (`PeriodTotalHero`, `SpendBreakdownSection`, `AllowanceSettlementSection`, etc.)
- Keeps live data wiring via `useUsageStatement` and `/api/account/statement` — no fixtures
- Preserves honest absent subjects (tool/on-chain show "—" until ledger writers exist)

## Test plan

- [x] `pnpm exec vitest run src/features/usage/usage-settings.test.tsx`
- [ ] Vercel preview: sign in → Settings → Usage → verify real staging data
- [ ] `/statement` link opens full statement page

## Preview

Open the Vercel deployment URL on this PR (uses `api-staging.aomi.dev`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787984063&installation_model_id=12362&pr_number=427&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F427&signature=3029db510590c6ea91f019bc3f1ade6d0658ebd727e9424353cd8c31ad299433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->