### PR TITLE
Portal: General settings summary card

### DIFF
--- a/apps/portal/src/components/settings/settings-modal.tsx
+++ b/apps/portal/src/components/settings/settings-modal.tsx
@@ -146,7 +146,11 @@ export function SettingsModal({ onClose }: { onClose: () => void }) {
           <GateNotice status={status} onRetry={retry} />
         ) : (
           <div className="px-[22px] py-5">
-            <GeneralSettings onManageAccount={() => setTab("account")} />
+            <GeneralSettings
+              onManageAccount={() => setTab("account")}
+              onViewUsage={() => setTab("usage")}
+              onFixWallets={() => setTab("account")}
+            />
           </div>
         );
       case "account":

--- a/apps/portal/src/features/account/wallet-attention.ts
+++ b/apps/portal/src/features/account/wallet-attention.ts
@@ -1,0 +1,8 @@
+import type { WalletPolicy } from "./types";
+
+/** Wallets set to auto-signing whose provider grant is missing or expired. */
+export function countDriftedWallets(wallets: WalletPolicy[]): number {
+  return wallets.filter(
+    (wallet) => wallet.desiredMode === "auto" && !wallet.grantActive,
+  ).length;
+}

--- a/apps/portal/src/features/general/general-settings.tsx
+++ b/apps/portal/src/features/general/general-settings.tsx
@@ -1,28 +1,32 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, type ReactNode } from "react";
 import { getChainInfo } from "@aomi-labs/react";
 import { formatAuthMethod, useAomiWalletKit } from "@aomi-labs/widget-lib";
-import { UserRound } from "lucide-react";
+import { ChevronRight, Shield } from "lucide-react";
+import { countDriftedWallets } from "@portal/features/account/wallet-attention";
+import { useAccountAcl } from "@portal/features/account/use-account-acl";
 import { useAccountOverview } from "@portal/lib/account-overview";
 import { useSettings, type ColorMode } from "@portal/lib/use-settings";
 
 /**
- * Settings › General — the design mock's General tab, built on the `aomi-*`
- * tokens and wired to real state: identity from the wallet kit + the shared
- * /api/account overview, theme via useSettings.colorMode, network from the
- * connected chain. Renders inside the settings popup (the modal owns the tab
- * title).
+ * Settings › General — design-sync summary card (plan, allowance, identity)
+ * on live `/api/account` data, plus theme / network / wallet rows.
  */
 export function GeneralSettings({
   onManageAccount,
+  onViewUsage,
+  onFixWallets,
 }: {
   onManageAccount?: () => void;
+  onViewUsage?: () => void;
+  onFixWallets?: () => void;
 }) {
   const adapter = useAomiWalletKit();
   const identity = adapter.identity;
   const { settings, updateSetting } = useSettings();
   const account = useAccountOverview();
+  const acl = useAccountAcl();
 
   const networkTicker = identity.chainId
     ? getChainInfo(identity.chainId)?.ticker
@@ -33,11 +37,26 @@ export function GeneralSettings({
     return formatAuthMethod(identity.authMethod) ?? "Wallet";
   }, [identity.authMethod, identity.status]);
 
+  const address =
+    identity.address ?? account?.user.public_key ?? "Not connected";
+  const primary =
+    account?.user.verified_email ??
+    (identity.address ? truncateAddress(identity.address) : address);
+
+  const walletAttentionCount =
+    acl.status === "ready" ? countDriftedWallets(acl.wallets) : 0;
+
   const disconnect = (
     adapter as { disconnect?: () => void | Promise<void> }
   ).disconnect;
 
-  // Design's Dark / Light / System ↔ stored colorMode dark / light / auto.
+  const walletHint =
+    identity.address &&
+    account?.user.public_key &&
+    identity.address.toLowerCase() !== account.user.public_key.toLowerCase()
+      ? identity.address
+      : "Active signing session";
+
   const themeChoices: { mode: ColorMode; label: string }[] = [
     { mode: "dark", label: "Dark" },
     { mode: "light", label: "Light" },
@@ -45,113 +64,209 @@ export function GeneralSettings({
   ];
 
   return (
-    <div className="flex flex-col gap-[18px]">
-      {/* Identity card */}
-      <div className="border-aomi-border bg-aomi-bg/40 overflow-hidden rounded-xl border">
-        <div className="flex items-start justify-between gap-4 p-4">
-          <div className="flex min-w-0 items-center gap-3">
-            <div className="bg-aomi-surface-2 text-aomi-muted flex h-11 w-11 shrink-0 items-center justify-center rounded-full">
-              <UserRound size={20} />
-            </div>
-            <div className="flex min-w-0 flex-col gap-1">
-              <span className="truncate font-mono text-sm font-medium">
-                {identity.address ??
-                  account?.user.public_key ??
-                  "Not connected"}
-              </span>
-              <span className="text-aomi-muted truncate text-[13px]">
-                {account?.user.verified_email ??
-                  (identity.status === "connected"
-                    ? "Primary identity · Connected"
-                    : "Primary identity · Not connected")}
-              </span>
-            </div>
+    <div className="flex flex-col gap-5">
+      {walletAttentionCount > 0 && (
+        <WalletAttentionBanner
+          walletAttentionCount={walletAttentionCount}
+          onReview={onFixWallets ?? onManageAccount}
+        />
+      )}
+
+      <AccountSummaryCard
+        primary={primary}
+        identityDesc={`${identityType} · ${address}`}
+        tier={account?.user.tier}
+        memberSince={formatMemberSince(account?.user.created_at)}
+        usage={account?.usage}
+        onManageAccount={onManageAccount}
+        onViewUsage={onViewUsage}
+      />
+
+      <div className="flex flex-col">
+        <FlatSettingRow label="Theme">
+          <div className="border-aomi-border bg-aomi-surface flex h-8 items-center rounded-full border p-[3px]">
+            {themeChoices.map(({ mode, label }) => (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => updateSetting("colorMode", mode)}
+                className={`rounded-full px-3 py-1 text-[12px] leading-none transition-colors ${
+                  settings.colorMode === mode
+                    ? "bg-aomi-surface-2 text-aomi-fg font-medium"
+                    : "text-aomi-muted hover:text-aomi-fg"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
           </div>
-          <button
-            onClick={onManageAccount}
-            className="bg-aomi-fg text-aomi-bg flex-shrink-0 rounded-full border border-transparent px-4 py-2 text-[13px] font-medium transition-opacity hover:opacity-90"
-          >
-            Manage account
-          </button>
-        </div>
-        <div className="border-aomi-border bg-aomi-border grid grid-cols-2 gap-px border-t">
-          <MetaCell label="Type">{identityType}</MetaCell>
-          <MetaCell label="Network">
-            <span className="flex items-center gap-1.5">
-              <span className="bg-aomi-success h-[7px] w-[7px] rounded-full" />
-              {networkTicker ?? "—"}
-            </span>
-          </MetaCell>
-        </div>
-      </div>
+        </FlatSettingRow>
 
-      <Divider />
+        <Divider />
 
-      <SettingRow title="Theme" desc="Match system, light, or dark">
-        <div className="border-aomi-border bg-aomi-surface flex rounded-full border p-[3px]">
-          {themeChoices.map(({ mode, label }) => (
+        <FlatSettingRow label="Default network">
+          <div className="text-aomi-muted flex items-center gap-1.5 text-[13px]">
+            <span className="bg-aomi-success h-[7px] w-[7px] rounded-full" />
+            <span className="text-aomi-fg">{networkTicker ?? "—"}</span>
+          </div>
+        </FlatSettingRow>
+
+        <Divider />
+
+        <FlatSettingRow
+          label="Connected wallet"
+          hint={walletHint}
+          hintMono={walletHint !== "Active signing session"}
+        >
+          {disconnect ? (
             <button
-              key={mode}
-              onClick={() => updateSetting("colorMode", mode)}
-              className={`rounded-full px-3.5 py-[5px] text-xs transition-colors ${
-                settings.colorMode === mode
-                  ? "bg-aomi-accent-strong text-aomi-on-accent font-medium"
-                  : "text-aomi-muted hover:text-aomi-fg"
-              }`}
+              type="button"
+              onClick={() => void disconnect()}
+              className="border-aomi-border text-aomi-fg hover:bg-aomi-surface-2 rounded-full border px-3 py-1 text-[13px] font-medium transition-colors"
             >
-              {label}
+              Disconnect
             </button>
-          ))}
-        </div>
-      </SettingRow>
+          ) : (
+            <button
+              type="button"
+              onClick={() => void adapter.openAccountUI?.()}
+              className="border-aomi-border text-aomi-fg hover:bg-aomi-surface-2 rounded-full border px-3 py-1 text-[13px] font-medium transition-colors"
+            >
+              Manage wallet
+            </button>
+          )}
+        </FlatSettingRow>
+      </div>
+    </div>
+  );
+}
 
-      <Divider />
+function AccountSummaryCard({
+  primary,
+  identityDesc,
+  tier,
+  memberSince,
+  usage,
+  onManageAccount,
+  onViewUsage,
+}: {
+  primary: string;
+  identityDesc: string;
+  tier?: string;
+  memberSince?: string;
+  usage?: {
+    credit_used: number;
+    credit_paid: number;
+    period_utc_month?: string;
+  };
+  onManageAccount?: () => void;
+  onViewUsage?: () => void;
+}) {
+  const creditsUsed = usage?.credit_used ?? 0;
+  const creditsIncluded = usage?.credit_paid ?? 0;
+  const remaining = Math.max(0, creditsIncluded - creditsUsed);
+  const periodLabel = formatPeriodLabel(usage?.period_utc_month);
+  const hasAllowance = creditsIncluded > 0;
 
-      <SettingRow title="Default network" desc="Used for new chats">
-        <div className="border-aomi-border flex items-center gap-[7px] rounded-lg border px-3 py-[7px]">
-          <span className="bg-aomi-success h-[7px] w-[7px] rounded-full" />
-          <span className="text-[13px]">{networkTicker ?? "Ethereum"}</span>
-        </div>
+  return (
+    <div className="border-aomi-border bg-aomi-bg/40 overflow-hidden rounded-xl border">
+      <SettingRow
+        title={primary}
+        desc={identityDesc}
+        descMono
+        className="px-4 sm:px-5"
+      >
+        <button
+          type="button"
+          onClick={onManageAccount}
+          className="border-aomi-border text-aomi-muted hover:text-aomi-fg flex h-8 shrink-0 items-center rounded-lg border px-3 text-[13px] font-medium leading-none transition-colors"
+        >
+          Manage account
+        </button>
       </SettingRow>
 
       <Divider />
 
       <SettingRow
-        title="Connected wallet"
-        desc={identity.address ?? "Not connected"}
-        descMono
+        title="Plan"
+        desc={memberSince ? `Member since ${memberSince}` : "Account plan"}
+        className="px-4 sm:px-5"
       >
-        {disconnect ? (
-          <button
-            onClick={() => void disconnect()}
-            className="border-aomi-border text-aomi-muted hover:text-aomi-fg rounded-full border px-4 py-2 text-[13px] font-medium transition-colors"
-          >
-            Disconnect
-          </button>
-        ) : (
-          <button
-            onClick={() => void adapter.openAccountUI?.()}
-            className="border-aomi-border text-aomi-muted hover:text-aomi-fg rounded-full border px-4 py-2 text-[13px] font-medium transition-colors"
-          >
-            Manage wallet
-          </button>
-        )}
+        <span className="text-aomi-fg text-[13px] font-medium">
+          {tierLabel(tier)}
+        </span>
       </SettingRow>
+
+      {hasAllowance && (
+        <>
+          <Divider />
+          <SettingRow
+            title="Monthly allowance"
+            desc={`${periodLabel} · resets each UTC month`}
+            className="px-4 sm:px-5"
+          >
+            <div className="flex flex-col items-end gap-0.5">
+              <span className="text-aomi-fg text-[13px] font-medium tabular-nums">
+                {remaining.toLocaleString()} remaining
+              </span>
+              <span className="text-aomi-accent-strong text-[12px] tabular-nums">
+                {creditsUsed.toLocaleString()} / {creditsIncluded.toLocaleString()}{" "}
+                used
+              </span>
+            </div>
+          </SettingRow>
+        </>
+      )}
+
+      <div className="border-aomi-border flex items-start justify-between gap-3 border-t px-4 py-3 sm:px-5">
+        <p className="text-aomi-muted min-w-0 flex-1 text-[12px] leading-snug">
+          Usage shows spend by app. Overflow settles via wallet pay when allowance
+          is used.
+        </p>
+        <button
+          type="button"
+          onClick={onViewUsage}
+          className="text-aomi-muted hover:text-aomi-fg flex shrink-0 items-center gap-0.5 text-[12px] font-medium transition-colors"
+        >
+          View usage
+          <ChevronRight size={12} />
+        </button>
+      </div>
     </div>
   );
 }
 
-function MetaCell({
-  label,
-  children,
+function WalletAttentionBanner({
+  walletAttentionCount,
+  onReview,
 }: {
-  label: string;
-  children: React.ReactNode;
+  walletAttentionCount: number;
+  onReview?: () => void;
 }) {
   return (
-    <div className="bg-aomi-bg/40 flex flex-col gap-0.5 px-4 py-3">
-      <span className="text-aomi-muted text-xs">{label}</span>
-      <span className="text-[13px]">{children}</span>
+    <div className="bg-aomi-surface relative rounded-xl px-4 py-4 sm:px-5 sm:py-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-4">
+        <span className="bg-aomi-surface-2 text-aomi-muted flex h-10 w-10 shrink-0 items-center justify-center rounded-lg">
+          <Shield size={20} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-[15px] font-semibold leading-snug">
+            Review wallet signing
+          </h3>
+          <p className="text-aomi-muted mt-1.5 text-[13px] leading-relaxed">
+            {walletAttentionCount}{" "}
+            {walletAttentionCount === 1 ? "wallet needs" : "wallets need"} a renewed
+            provider grant before auto-signing can run.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onReview}
+          className="border-aomi-border text-aomi-fg hover:bg-aomi-surface-2 h-9 shrink-0 self-start rounded-full border px-4 text-[13px] font-medium transition-colors"
+        >
+          Review
+        </button>
+      </div>
     </div>
   );
 }
@@ -160,19 +275,25 @@ function SettingRow({
   title,
   desc,
   descMono,
+  className = "",
   children,
 }: {
   title: string;
   desc: string;
   descMono?: boolean;
-  children: React.ReactNode;
+  className?: string;
+  children?: ReactNode;
 }) {
   return (
-    <div className="flex items-center justify-between gap-4">
-      <div className="flex flex-col gap-0.5">
-        <span className="text-sm font-medium">{title}</span>
+    <div
+      className={`flex items-center justify-between gap-4 py-3.5 ${className}`}
+    >
+      <div className="min-w-0 flex-1">
+        <span className="text-sm font-medium leading-none">{title}</span>
         <span
-          className={`text-aomi-muted text-[13px] ${descMono ? "font-mono" : ""}`}
+          className={`text-aomi-muted mt-1 block truncate text-[13px] leading-snug ${
+            descMono ? "font-mono" : ""
+          }`}
         >
           {desc}
         </span>
@@ -182,6 +303,72 @@ function SettingRow({
   );
 }
 
+function FlatSettingRow({
+  label,
+  hint,
+  hintMono,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  hintMono?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 py-3.5">
+      <div className="min-w-0 flex-1">
+        <span className="text-sm font-medium leading-none">{label}</span>
+        {hint && (
+          <span
+            className={`text-aomi-muted mt-1 block truncate text-[12px] leading-snug ${
+              hintMono ? "font-mono" : ""
+            }`}
+          >
+            {hint}
+          </span>
+        )}
+      </div>
+      <div className="shrink-0">{children}</div>
+    </div>
+  );
+}
+
 function Divider() {
   return <div className="bg-aomi-border h-px" />;
+}
+
+function tierLabel(tier?: string): string {
+  if (!tier || tier === "free") return "Free";
+  return tier.charAt(0).toUpperCase() + tier.slice(1);
+}
+
+function formatMemberSince(createdAt?: number): string | undefined {
+  if (!createdAt) return undefined;
+  return new Date(createdAt * 1000).toLocaleDateString("en-US", {
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function formatPeriodLabel(periodUtcMonth?: string): string {
+  if (!periodUtcMonth) {
+    const now = new Date();
+    return now.toLocaleDateString("en-US", {
+      month: "short",
+      year: "numeric",
+      timeZone: "UTC",
+    });
+  }
+  const [year, month] = periodUtcMonth.split("-").map(Number);
+  const names = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+  ];
+  return `${names[month - 1] ?? periodUtcMonth} ${year}`;
+}
+
+function truncateAddress(value: string): string {
+  if (value.length <= 12) return value;
+  return `${value.slice(0, 6)}…${value.slice(-4)}`;
 }

--- a/apps/portal/src/features/settings-route-callers.test.tsx
+++ b/apps/portal/src/features/settings-route-callers.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import type {
   ButtonHTMLAttributes,
   InputHTMLAttributes,
@@ -46,6 +46,20 @@ vi.mock("@aomi-labs/widget-lib", () => ({
       status: "connected",
     },
     openAccountUI: widgetMock.openAccountUI,
+  }),
+}));
+
+vi.mock("./account/use-account-acl", () => ({
+  useAccountAcl: () => ({
+    status: "ready",
+    wallets: [],
+    grants: [],
+    refresh: vi.fn(),
+    commitMode: vi.fn(),
+    revokeGrant: vi.fn(),
+    stopAllAuto: vi.fn(),
+    regrant: vi.fn(),
+    blockedReason: () => null,
   }),
 }));
 
@@ -133,5 +147,19 @@ describe("settings route callers", () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalled());
     expect(requestPaths(calls)).toContain("/api/account");
     expect(requestPaths(calls)).not.toContain("/api/settings/account");
+  });
+
+  it("renders the summary card with plan and allowance from the account route", async () => {
+    installFetchRecorder();
+
+    render(<GeneralSettings />);
+
+    await waitFor(() =>
+      expect(screen.getByText("alice@example.com")).toBeTruthy(),
+    );
+    expect(screen.getByText("Pro")).toBeTruthy();
+    expect(screen.getByText(/88 remaining/)).toBeTruthy();
+    expect(screen.getByText(/12 \/ 100 used/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "View usage" })).toBeTruthy();
   });
 });

--- a/apps/portal/src/lib/account-overview.ts
+++ b/apps/portal/src/lib/account-overview.ts
@@ -16,6 +16,8 @@ export type AccountProfile = {
   user_id: string;
   public_key?: string;
   verified_email?: string | null;
+  tier?: string;
+  created_at?: number;
   /** The account's installed apps (`users.applications`). */
   apps?: string[];
 };


### PR DESCRIPTION
## Summary
- Replaces the flat identity card in Settings › General with the mock's **account summary card**: identity row, plan + member since, monthly allowance (from live `/api/account` usage stats), and View usage CTA
- Adds **wallet attention banner** when auto-signing wallets lack an active provider grant (drift detection via existing ACL data)
- Wires tab navigation: Manage account / Review → Account, View usage → Usage
- Extends `AccountProfile` type with `tier` and `created_at` from the account API

## Test plan
- [ ] Open Vercel chat-portal preview, sign in, open Settings → General
- [ ] Verify summary card shows email/address, plan tier, allowance remaining/used
- [ ] Click **View usage** → switches to Usage tab
- [ ] Click **Manage account** → switches to Account tab
- [ ] If any wallet is in auto mode without grant: banner shows with **Review** → Account tab
- [ ] Theme / default network / connected wallet rows still work below the card

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787987141&installation_model_id=12362&pr_number=429&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F429&signature=8d51e583b9406514b4308951f29009076cacfff52a19356911109459f545c881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->