### PR TITLE
Portal: Account tab endpoint polish (bind, Para agent wallet)

### DIFF
--- a/apps/portal/src/features/account/account-acl.test.tsx
+++ b/apps/portal/src/features/account/account-acl.test.tsx
@@ -14,6 +14,13 @@ const walletKit = vi.hoisted(() => ({
   signSolanaMessage: vi.fn(async () => ({ signature: "c2ln" })),
   openAccountUI: vi.fn(async () => undefined),
   identity: { address: "", svmAddress: undefined as string | undefined },
+  accounts: [] as Array<{
+    id: string;
+    family: "evm" | "svm";
+    address: string;
+    walletName?: string;
+    active: boolean;
+  }>,
 }));
 
 vi.mock("@aomi-labs/widget-lib", () => ({
@@ -105,6 +112,22 @@ function installFetchRecorder(overrides: Record<string, () => Response> = {}) {
       if (url.pathname.endsWith("/grant") && method === "DELETE") {
         return Response.json({ status: "revoked", provider: "privy" });
       }
+      if (url.pathname === "/api/account/providers/para/agent-wallet" && method === "POST") {
+        return Response.json({
+          wallet: {
+            address: "ParaAgentWallet111111111111111111111111111",
+            chain_type: "svm",
+            wallet_provider: "para",
+            signing: "delegated",
+            is_primary: false,
+            signing_mode: "manual",
+            authorization_version: 0,
+            has_delegated_grant: false,
+            provider_managed: true,
+            can_use_auto: false,
+          },
+        });
+      }
       return new Response(`Unexpected ${method} ${url.pathname}`, { status: 500 });
     },
   );
@@ -140,6 +163,7 @@ const bodyOf = (calls: FetchCall[], path: string) => {
 describe("account ACL wiring", () => {
   beforeEach(() => {
     walletKit.identity = { address: CONNECTED_EVM, svmAddress: undefined };
+    walletKit.accounts = [];
     walletKit.signTypedData.mockClear();
     // The overview store is module-level; seed it so the tab doesn't also
     // depend on /api/account here.
@@ -162,7 +186,7 @@ describe("account ACL wiring", () => {
     expect(paths(calls)).toContain("/api/account/wallets");
     expect(paths(calls)).toContain("/api/account/grants");
     // Privy provenance + live grant render from the wire, not fixtures.
-    expect(screen.getByText(/Privy · session delegation/)).toBeTruthy();
+    expect(screen.getByText(/Privy · Session delegation/)).toBeTruthy();
   });
 
   it("runs challenge → sign → commit and reloads on a mode change", async () => {
@@ -283,6 +307,69 @@ describe("account ACL wiring", () => {
 
     await waitFor(() =>
       expect(paths(calls)).toContain("/api/account/providers/privy/grant"),
+    );
+  });
+
+  it("shows unbound connected wallets and runs the bind ceremony", async () => {
+    const UNBOUND = "0xUnboundWallet00000000000000000000000001";
+    walletKit.accounts = [
+      {
+        id: "rabby",
+        family: "evm",
+        address: UNBOUND,
+        walletName: "Rabby",
+        active: false,
+      },
+    ];
+    const { calls } = installFetchRecorder({
+      "/api/account/authorization/challenge": () =>
+        Response.json({
+          permit: {
+            account: "acct-1",
+            chain_type: "evm",
+            wallet: UNBOUND,
+            mode: "bind",
+            version: 0,
+            expiry: 1_800_000_000,
+          },
+          typed_data: { primaryType: "AuthorizationPermit" },
+        }),
+    });
+
+    await renderAcl();
+    await click(await screen.findByRole("button", { name: "Link to account" }));
+
+    await waitFor(() =>
+      expect(paths(calls)).toContain("/api/account/authorization/commit"),
+    );
+    expect(bodyOf(calls, "/api/account/authorization/challenge")).toEqual({
+      chain_type: "evm",
+      wallet: UNBOUND,
+      mode: "bind",
+    });
+  });
+
+  it("provisions a Para agent wallet through the provider route", async () => {
+    const paraWallets = {
+      wallets: [
+        {
+          ...WALLETS.wallets[0],
+          wallet_provider: "para",
+          provider_managed: false,
+          can_use_auto: false,
+        },
+      ],
+    };
+    const { calls } = installFetchRecorder({
+      "/api/account/wallets": () => Response.json(paraWallets),
+      "/api/account/grants": () => Response.json({ grants: [] }),
+    });
+
+    await renderAcl();
+    await click(await screen.findByRole("button", { name: "Provision agent wallet" }));
+
+    await waitFor(() =>
+      expect(paths(calls)).toContain("/api/account/providers/para/agent-wallet"),
     );
   });
 });

--- a/apps/portal/src/features/account/account-api.ts
+++ b/apps/portal/src/features/account/account-api.ts
@@ -79,6 +79,25 @@ export function revokeProviderGrant(providerKey: string): Promise<unknown> {
   );
 }
 
+/** Provision a provider-managed agent wallet (Para auto-signing prerequisite). */
+export async function provisionAgentWallet(provider: string): Promise<AccountWalletRow> {
+  const data = await accountScopedFetch<{ wallet: AccountWalletRow }>(
+    `/api/account/providers/${encodeURIComponent(provider)}/agent-wallet`,
+    { method: "POST", body: JSON.stringify({}) },
+  );
+  return data.wallet;
+}
+
+const GRANT_KIND_LABELS: Record<string, string> = {
+  session_delegation: "Session delegation",
+  agent_delegation: "Agent delegation",
+  signing_delegation: "Signing delegation",
+};
+
+export function grantKindLabel(kind: string): string {
+  return GRANT_KIND_LABELS[kind] ?? kind.replace(/_/g, " ");
+}
+
 /**
  * Normalize the kernel's `signing_mode` to the view's `SignerMode`, absorbing
  * the pre-rename wire values (`human_sync` / `agent_sync`) that `from_db` still
@@ -140,7 +159,7 @@ function toDelegationGrant(row: AccountGrantRow): DelegationGrant {
     provider: titleCase(row.provider),
     providerKey: row.provider,
     scope: grantScope(row),
-    kind: row.grant_kind.replace(/_/g, " "),
+    kind: grantKindLabel(row.grant_kind),
     status: row.status,
     expiresLabel:
       row.status === "revoked"

--- a/apps/portal/src/features/account/account-settings.tsx
+++ b/apps/portal/src/features/account/account-settings.tsx
@@ -44,7 +44,11 @@ export function AccountSettings() {
       email={email}
       wallets={acl.wallets}
       grants={acl.grants}
+      unboundWallets={acl.unboundWallets}
+      needsParaAgentWallet={acl.needsParaAgentWallet}
       onCommit={acl.commitMode}
+      onBindWallet={acl.bindWallet}
+      onProvisionParaAgentWallet={acl.provisionParaAgentWallet}
       onRevokeGrant={acl.revokeGrant}
       onStopAllAuto={acl.stopAllAuto}
       onRegrant={acl.regrant}

--- a/apps/portal/src/features/account/account-signing.tsx
+++ b/apps/portal/src/features/account/account-signing.tsx
@@ -14,6 +14,7 @@ import type {
   WalletPolicy,
 } from "./types";
 import { shortenAddress } from "./account-api";
+import type { UnboundWallet } from "./use-account-acl";
 import {
   TriangleAlert as Alert,
   Zap as Bolt,
@@ -33,8 +34,12 @@ interface AccountSigningViewProps {
   email: string;
   wallets: WalletPolicy[];
   grants: DelegationGrant[];
+  unboundWallets: UnboundWallet[];
+  needsParaAgentWallet: boolean;
   /** Run the permit ceremony. Rejects with a user-facing message. */
   onCommit: (wallet: WalletPolicy, mode: SignerMode) => Promise<void>;
+  onBindWallet: (wallet: UnboundWallet) => Promise<"bound" | "already_bound">;
+  onProvisionParaAgentWallet: () => Promise<void>;
   onRevokeGrant: (grant: DelegationGrant) => Promise<void>;
   onStopAllAuto: () => Promise<void>;
   onRegrant: (wallet: WalletPolicy) => Promise<void>;
@@ -95,6 +100,7 @@ const EMBEDDED_PROVIDERS: Partial<Record<LinkedVia, ProviderIdentity>> = {
 
 /** Busy/error key for the account-wide "stop all auto-signing" action. */
 const STOP_ALL_KEY = "__stop_all__";
+const PARA_AGENT_KEY = "__para_agent__";
 
 const CUSTODY_GROUPS: { key: Custody; label: string }[] = [
   { key: "self", label: "Self-custody wallets" },
@@ -163,8 +169,8 @@ function reconcile(wallet: WalletPolicy): Recon {
           }
         : {
             status: "drifted",
-            detail: "You want auto — the runtime fell back to manual.",
-            action: "Re-grant",
+            detail: "You want auto — reconnect the provider to mint a new grant.",
+            action: "Reconnect provider",
           };
   }
 }
@@ -174,7 +180,11 @@ export function AccountSigningView({
   email,
   wallets,
   grants,
+  unboundWallets,
+  needsParaAgentWallet,
   onCommit,
+  onBindWallet,
+  onProvisionParaAgentWallet,
   onRevokeGrant,
   onStopAllAuto,
   onRegrant,
@@ -340,6 +350,18 @@ export function AccountSigningView({
     void run(STOP_ALL_KEY, onStopAllAuto);
   };
 
+  const bindWallet = (id: string) => {
+    const wallet = unboundWallets.find((entry) => entry.id === id);
+    if (!wallet) return;
+    void run(id, async () => {
+      await onBindWallet(wallet);
+    });
+  };
+
+  const provisionParaAgent = () => {
+    void run(PARA_AGENT_KEY, onProvisionParaAgentWallet);
+  };
+
   return (
     <div className="flex-1 overflow-y-auto px-[22px] py-5">
       <div className="flex flex-col gap-6">
@@ -388,6 +410,68 @@ export function AccountSigningView({
             to match — changes are signed authorizations, not toggles.
           </p>
         </div>
+
+        {needsParaAgentWallet && (
+          <div className="border-aomi-border bg-aomi-bg/40 flex items-start justify-between gap-4 rounded-xl border px-4 py-4 sm:px-5">
+            <div className="min-w-0 flex-1">
+              <h3 className="text-[15px] font-semibold leading-snug">
+                Provision Para agent wallet
+              </h3>
+              <p className="text-aomi-muted mt-1.5 text-[13px] leading-relaxed">
+                Para auto-signing uses a separate provider-managed agent wallet.
+                Your login wallet stays on-device; Aomi provisions the signer
+                that can run in the background.
+              </p>
+              {errors[PARA_AGENT_KEY] && (
+                <p className="text-aomi-danger mt-2 text-[13px]">
+                  {errors[PARA_AGENT_KEY]}
+                </p>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={provisionParaAgent}
+              disabled={Boolean(busy[PARA_AGENT_KEY])}
+              className="border-aomi-border text-aomi-fg hover:bg-aomi-surface-2 flex h-9 shrink-0 items-center gap-1.5 self-start rounded-full border px-4 text-[13px] font-medium transition-colors disabled:opacity-50"
+            >
+              {busy[PARA_AGENT_KEY] && <Loader2 size={13} className="animate-spin" />}
+              {busy[PARA_AGENT_KEY] ? "Provisioning…" : "Provision agent wallet"}
+            </button>
+          </div>
+        )}
+
+        {unboundWallets.length > 0 && (
+          <Section
+            title="Link connected wallets"
+            desc="These wallets are connected in your browser but not yet linked to your account for signing."
+          >
+            {unboundWallets.map((wallet) => (
+              <div
+                key={wallet.id}
+                className="border-aomi-border bg-aomi-bg/40 flex items-center justify-between gap-3 rounded-xl border px-4 py-3"
+              >
+                <div className="min-w-0 flex-1">
+                  <span className="block truncate font-mono text-sm font-medium">
+                    {shortenAddress(wallet.address)}
+                  </span>
+                  <span className="text-aomi-muted text-[12px]">
+                    {wallet.walletName ?? (wallet.chain === "evm" ? "Ethereum" : "Solana")}
+                    {wallet.active ? " · active" : ""}
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => bindWallet(wallet.id)}
+                  disabled={Boolean(busy[wallet.id])}
+                  className="border-aomi-border text-aomi-fg hover:bg-aomi-surface-2 flex shrink-0 items-center gap-1.5 rounded-full border px-4 py-2 text-[13px] font-medium transition-colors disabled:opacity-50"
+                >
+                  {busy[wallet.id] && <Loader2 size={13} className="animate-spin" />}
+                  {busy[wallet.id] ? "Waiting for signature…" : "Link to account"}
+                </button>
+              </div>
+            ))}
+          </Section>
+        )}
 
         {/* Wallet policies */}
         <div className="flex flex-col gap-3">

--- a/apps/portal/src/features/account/use-account-acl.ts
+++ b/apps/portal/src/features/account/use-account-acl.ts
@@ -13,8 +13,10 @@ import {
   explainAccountError,
   fetchGrants,
   fetchWalletPolicies,
+  provisionAgentWallet,
   revokeProviderGrant,
 } from "./account-api";
+import { bindWalletVia } from "./wallet-bind";
 import type { DelegationGrant, SignerMode, WalletPolicy } from "./types";
 
 const post: AuthorizationPoster = (path, body) =>
@@ -49,14 +51,31 @@ export function isLoosening(from: SignerMode, to: SignerMode): boolean {
 
 export type AclStatus = "loading" | "ready" | "error";
 
+export type UnboundWallet = {
+  id: string;
+  chain: "evm" | "svm";
+  address: string;
+  walletName?: string;
+  provider?: string;
+  active: boolean;
+};
+
 export type AccountAcl = {
   status: AclStatus;
   error?: string;
   wallets: WalletPolicy[];
   grants: DelegationGrant[];
+  /** Connected adapter accounts not yet linked via the bind ceremony. */
+  unboundWallets: UnboundWallet[];
+  /** Para login wallet exists but no provider-managed agent wallet yet. */
+  needsParaAgentWallet: boolean;
   refresh: () => Promise<void>;
   /** Run the permit ceremony; resolves once the new mode is committed. */
   commitMode: (wallet: WalletPolicy, mode: SignerMode) => Promise<void>;
+  /** Link a connected wallet to the account (bind ceremony). */
+  bindWallet: (wallet: UnboundWallet) => Promise<"bound" | "already_bound">;
+  /** Provision a Para agent wallet for auto-signing. */
+  provisionParaAgentWallet: () => Promise<void>;
   revokeGrant: (grant: DelegationGrant) => Promise<void>;
   stopAllAuto: () => Promise<void>;
   /** Re-open the provider so a fresh grant can be minted, then reload. */
@@ -65,13 +84,53 @@ export type AccountAcl = {
   blockedReason: (wallet: WalletPolicy, mode: SignerMode) => string | null;
 };
 
+type AdapterAccount = {
+  family: "evm" | "svm";
+  address: string;
+  walletName?: string;
+  provider?: string;
+  active: boolean;
+};
+
+function unboundFromAccounts(
+  accounts: AdapterAccount[],
+  wallets: WalletPolicy[],
+): UnboundWallet[] {
+  const bound = new Set(
+    wallets.map((wallet) => `${wallet.chain}:${wallet.address.toLowerCase()}`),
+  );
+  return accounts
+    .filter((account) => account.address)
+    .filter((account) => {
+      const chain = account.family;
+      return !bound.has(`${chain}:${account.address.toLowerCase()}`);
+    })
+    .map((account) => ({
+      id: `${account.family}:${account.address}`,
+      chain: account.family,
+      address: account.address,
+      walletName: account.walletName,
+      provider: account.provider,
+      active: account.active,
+    }));
+}
+
+function detectNeedsParaAgentWallet(wallets: WalletPolicy[]): boolean {
+  const hasParaLogin = wallets.some(
+    (wallet) => wallet.linkedVia === "para" && !wallet.providerManaged,
+  );
+  const hasParaAgent = wallets.some(
+    (wallet) => wallet.linkedVia === "para" && wallet.providerManaged,
+  );
+  return hasParaLogin && !hasParaAgent;
+}
+
 export function useAccountAcl(): AccountAcl {
   const adapter = useAomiWalletKit();
   const [wallets, setWallets] = useState<WalletPolicy[]>([]);
   const [grants, setGrants] = useState<DelegationGrant[]>([]);
   const [status, setStatus] = useState<AclStatus>("loading");
   const [error, setError] = useState<string | undefined>();
-  // Late responses from a superseded load must not clobber fresher state.
   const mounted = useRef(true);
   useEffect(() => {
     mounted.current = true;
@@ -86,6 +145,16 @@ export function useAccountAcl(): AccountAcl {
   const signTypedData = adapter.signTypedData;
   const signSolanaMessage = adapter.signSolanaMessage;
   const openAccountUI = adapter.openAccountUI;
+  const accounts = (adapter.accounts ?? []) as AdapterAccount[];
+
+  const unboundWallets = useMemo(
+    () => unboundFromAccounts(accounts, wallets),
+    [accounts, wallets],
+  );
+  const needsParaAgentWallet = useMemo(
+    () => detectNeedsParaAgentWallet(wallets),
+    [wallets],
+  );
 
   const refresh = useCallback(async () => {
     try {
@@ -109,12 +178,6 @@ export function useAccountAcl(): AccountAcl {
     void refresh();
   }, [refresh]);
 
-  /**
-   * Which of *this account's* connected keys can produce a signature for a
-   * permit on `wallet`'s chain. Chain-matched on purpose: an EVM permit is an
-   * EIP-712 hash and an SVM permit is an Ed25519 message — one connected wallet
-   * can't stand in for the other.
-   */
   const signerFor = useCallback(
     (wallet: WalletPolicy) =>
       wallet.chain === "evm"
@@ -136,9 +199,6 @@ export function useAccountAcl(): AccountAcl {
       if (!signer.canSign) {
         return `Connect a ${chainLabel} wallet to sign this authorization.`;
       }
-      // Loosening authority must be signed by the wallet whose authority grows
-      // — except for provider-managed keys, where the user holds no key
-      // material and the backend accepts any linked sibling key instead.
       const needsSelf = isLoosening(wallet.desiredMode, mode) && !wallet.providerManaged;
       if (
         needsSelf &&
@@ -170,8 +230,6 @@ export function useAccountAcl(): AccountAcl {
         }
         const { signature } = await readable(() =>
           signTypedData({
-            // The backend assembles wagmi-ready EIP-712; the wire type is
-            // `unknown` because only the wallet interprets it.
             typed_data: challenge.typed_data as WalletEip712Payload["typed_data"],
             description: permitDescription(wallet, mode),
           }),
@@ -190,7 +248,6 @@ export function useAccountAcl(): AccountAcl {
             description: permitDescription(wallet, mode),
           }),
         );
-        // Ed25519 has no recovery, so the signer is named rather than derived.
         await readable(() =>
           authorizationCommit(post, {
             permit: challenge.permit,
@@ -204,6 +261,29 @@ export function useAccountAcl(): AccountAcl {
     },
     [blockedReason, refresh, signSolanaMessage, signTypedData, svmAddress, svmCluster],
   );
+
+  const bindWallet = useCallback(
+    async (wallet: UnboundWallet) => {
+      const result = await readable(() =>
+        bindWalletVia(post, {
+          chain: wallet.chain,
+          address: wallet.address,
+          signTypedData,
+          signSolanaMessage,
+          svmCluster,
+          signerAddress: wallet.chain === "svm" ? svmAddress : evmAddress,
+        }),
+      );
+      await refresh();
+      return result;
+    },
+    [evmAddress, refresh, signSolanaMessage, signTypedData, svmAddress, svmCluster],
+  );
+
+  const provisionParaAgentWallet = useCallback(async () => {
+    await readable(() => provisionAgentWallet("para"));
+    await refresh();
+  }, [refresh]);
 
   const revokeGrant = useCallback(
     async (grant: DelegationGrant) => {
@@ -220,8 +300,6 @@ export function useAccountAcl(): AccountAcl {
         .filter((grant) => grant.status === "active")
         .map((grant) => grant.providerKey ?? grant.provider.toLowerCase()),
     );
-    // Sequential: each revoke clears that identity's vault secrets, and a
-    // partial failure should stop rather than race the rest.
     for (const provider of providers) {
       await readable(() => revokeProviderGrant(provider));
     }
@@ -235,9 +313,6 @@ export function useAccountAcl(): AccountAcl {
           "Reconnect this provider from the wallet menu to mint a new grant.",
         );
       }
-      // Grants are born only from the provider's verified connect flow — there
-      // is no server-side "re-grant". Sending the user back through the
-      // provider is the real path; the reload picks up whatever it minted.
       await openAccountUI({ family: wallet.chain });
       await refresh();
     },
@@ -250,23 +325,31 @@ export function useAccountAcl(): AccountAcl {
       error,
       wallets,
       grants,
+      unboundWallets,
+      needsParaAgentWallet,
       refresh,
       commitMode,
+      bindWallet,
+      provisionParaAgentWallet,
       revokeGrant,
       stopAllAuto,
       regrant,
       blockedReason,
     }),
     [
+      bindWallet,
       blockedReason,
       commitMode,
       error,
       grants,
+      needsParaAgentWallet,
+      provisionParaAgentWallet,
       refresh,
       regrant,
       revokeGrant,
       status,
       stopAllAuto,
+      unboundWallets,
       wallets,
     ],
   );

--- a/apps/portal/src/features/account/wallet-bind.test.ts
+++ b/apps/portal/src/features/account/wallet-bind.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { bindWalletVia } from "./wallet-bind";
+
+describe("bindWalletVia", () => {
+  it("runs challenge → sign → commit for EVM bind", async () => {
+    const post = vi.fn(async (path: string, body: unknown) => {
+      if (path.endsWith("/challenge")) {
+        return {
+          permit: { wallet: "0xabc", mode: "bind" },
+          typed_data: { primaryType: "AuthorizationPermit" },
+        };
+      }
+      return { address: "0xabc", chain_type: "evm", signing_mode: "manual" };
+    });
+    const signTypedData = vi.fn(async () => ({ signature: "0xsig" }));
+
+    await expect(
+      bindWalletVia(post, {
+        chain: "evm",
+        address: "0xabc",
+        signTypedData,
+      }),
+    ).resolves.toBe("bound");
+
+    expect(post).toHaveBeenCalledWith("/api/account/authorization/challenge", {
+      chain_type: "evm",
+      wallet: "0xabc",
+      mode: "bind",
+    });
+    expect(signTypedData).toHaveBeenCalledOnce();
+  });
+
+  it("returns already_bound when the wallet is linked", async () => {
+    const post = vi.fn(async () => {
+      throw new Error('{"error":"already_bound"}');
+    });
+
+    await expect(
+      bindWalletVia(post, {
+        chain: "evm",
+        address: "0xabc",
+        signTypedData: vi.fn(),
+      }),
+    ).resolves.toBe("already_bound");
+  });
+});

--- a/apps/portal/src/features/account/wallet-bind.ts
+++ b/apps/portal/src/features/account/wallet-bind.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import {
+  authorizationChallenge,
+  authorizationCommit,
+  type AuthorizationPoster,
+  type WalletEip712Payload,
+} from "@aomi-labs/client";
+import { explainAccountError } from "./account-api";
+
+export type BindWalletSigner = {
+  chain: "evm" | "svm";
+  address: string;
+  signTypedData?: (args: {
+    typed_data: unknown;
+    description: string;
+  }) => Promise<{ signature: string }>;
+  signSolanaMessage?: (args: {
+    message: string;
+    cluster?: string;
+    description: string;
+  }) => Promise<{ signature: string }>;
+  svmCluster?: string;
+  signerAddress?: string;
+};
+
+const BIND_DESCRIPTION =
+  "Link this wallet to your Aomi account so it can sign transactions.";
+
+/** Run the bind permit ceremony for an EVM or SVM wallet. */
+export async function bindWalletVia(
+  post: AuthorizationPoster,
+  signer: BindWalletSigner,
+): Promise<"bound" | "already_bound"> {
+  let challenge;
+  try {
+    challenge = await authorizationChallenge(post, {
+      chain_type: signer.chain,
+      wallet: signer.address,
+      mode: "bind",
+    });
+  } catch (cause) {
+    if (isAlreadyBound(cause)) return "already_bound";
+    throw new Error(explainAccountError(cause));
+  }
+
+  if (signer.chain === "evm") {
+    if (!challenge.typed_data || !signer.signTypedData) {
+      throw new Error("Connect an Ethereum wallet that can sign EIP-712 messages.");
+    }
+    const { signature } = await signer.signTypedData({
+      typed_data: challenge.typed_data as WalletEip712Payload["typed_data"],
+      description: BIND_DESCRIPTION,
+    });
+    try {
+      await authorizationCommit(post, { permit: challenge.permit, signature });
+      return "bound";
+    } catch (cause) {
+      if (isAlreadyBound(cause)) return "already_bound";
+      throw new Error(explainAccountError(cause));
+    }
+  }
+
+  if (!challenge.message_base64 || !signer.signSolanaMessage) {
+    throw new Error("Connect a Solana wallet that can sign messages.");
+  }
+  const { signature } = await signer.signSolanaMessage({
+    message: challenge.message_base64,
+    cluster: signer.svmCluster,
+    description: BIND_DESCRIPTION,
+  });
+  try {
+    await authorizationCommit(post, {
+      permit: challenge.permit,
+      signature,
+      ...(signer.signerAddress ? { signer: signer.signerAddress } : {}),
+    });
+    return "bound";
+  } catch (cause) {
+    if (isAlreadyBound(cause)) return "already_bound";
+    throw new Error(explainAccountError(cause));
+  }
+}
+
+function isAlreadyBound(cause: unknown): boolean {
+  const raw = cause instanceof Error ? cause.message : String(cause);
+  return raw.includes("already_bound");
+}


### PR DESCRIPTION
## Summary
Production-focused Account tab polish — not UI-only mock sync. All mutations hit live `/api/account` routes and refetch ACL state after commit (nothing optimistic).

### Wired to endpoints
- **Link connected wallets** — compares wallet-kit `accounts` vs `GET /api/account/wallets`; unbound wallets get **Link to account** → `POST /authorization/challenge` (`mode: bind`) → sign → `POST /authorization/commit`
- **Para agent wallet** — when a Para login wallet exists but no `provider_managed` agent wallet, shows **Provision agent wallet** → `POST /api/account/providers/para/agent-wallet`
- **Drift re-grant** — clearer copy ("Reconnect provider"); still uses provider connect flow (`openAccountUI`) since grants are minted only at connect time (backend limitation)
- **Grant kind labels** — human-readable map (`session_delegation` → "Session delegation")

### Already working (unchanged)
- Mode changes: challenge → signTypedData/signSolanaMessage → commit
- Grant revoke: `DELETE /api/account/providers/:provider/grant`
- Stop all auto-signing: sequential provider revokes

### Still blocked (honest gaps)
- **Wallet brand tags (MetaMask/Phantom)** — needs `rdns` persisted at connect time; wire has no field yet
- **Dedicated re-grant route** — would need backend; today reconnect-via-provider is the real path

## Test plan
- [ ] Vercel chat-portal preview: Settings → Account
- [ ] Connect a wallet not yet in ACL → **Link connected wallets** section appears → sign bind message → wallet appears in policy list
- [ ] Para account without agent wallet → **Provision agent wallet** → new provider-managed row after refetch
- [ ] Drifted auto wallet → **Reconnect provider** opens wallet UI; after reconnect, grant + drift clears on refetch
- [ ] Mode change still runs permit ceremony; revoke grant still hits DELETE route

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787987914&installation_model_id=12362&pr_number=430&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F430&signature=19f4ef8c15fa8502811fcdd569b2be61b6ac065b0583d5f5b9da28338e8ff1d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->