### PR TITLE
Fix BFF Sentry source-map matching

### DIFF
--- a/packages/bff-observability/src/privacy.ts
+++ b/packages/bff-observability/src/privacy.ts
@@ -227,6 +227,7 @@ function scrubStackPath(value: string | undefined): string | undefined {
 
 function isKnownStackPath(value: string): boolean {
   if (value.startsWith("node:")) return true;
+  if (value.startsWith("app:///_next/server/")) return true;
   if (
     value.startsWith("webpack-internal:///") ||
     value.startsWith("webpack:///")

--- a/packages/bff-observability/test/privacy.test.ts
+++ b/packages/bff-observability/test/privacy.test.ts
@@ -233,6 +233,62 @@ describe("scrubSentryEvent", () => {
     });
   });
 
+  it("retains Next server virtual paths used for source-map lookup", () => {
+    const codeFile =
+      "app:///_next/server/chunks/[root-of-the-server]__abcdef12._.js";
+    const debugId = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+    const event = scrubSentryEvent({
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  filename: `${codeFile}?token=secret#private`,
+                  abs_path: `${codeFile}?cookie=secret`,
+                  function: "privateFunction",
+                  module: "privateModule",
+                  lineno: 1,
+                  colno: 1179,
+                  in_app: true,
+                  debug_id: debugId,
+                },
+              ],
+            },
+          },
+        ],
+      },
+      debug_meta: {
+        images: [
+          {
+            type: "sourcemap",
+            code_file: `${codeFile}?token=secret`,
+            debug_id: debugId,
+          },
+        ],
+      },
+    });
+
+    expect(event?.exception?.values?.[0]?.stacktrace?.frames?.[0]).toEqual({
+      filename: codeFile,
+      abs_path: codeFile,
+      lineno: 1,
+      colno: 1179,
+      in_app: true,
+      debug_id: debugId,
+      platform: undefined,
+    });
+    expect(event?.debug_meta).toEqual({
+      images: [
+        {
+          type: "sourcemap",
+          code_file: codeFile,
+          debug_id: debugId,
+        },
+      ],
+    });
+  });
+
   it("drops non-error events and unsafe environment values", () => {
     expect(scrubSentryEvent({ type: "transaction" })).toBeNull();
     expect(scrubSentryEvent({ environment: "preview" })).not.toHaveProperty(


### PR DESCRIPTION
## What changed

- allow the canonical `app:///_next/server/` namespace emitted by `@sentry/nextjs` through the BFF privacy scrubber
- retain the filename and debug metadata required for server source-map matching
- add a regression proving query/fragment data and function/module/source context are still removed

## Root cause

The Next.js Sentry integration rewrites production server bundle paths to `app:///_next/server/...` before `beforeSend`. The BFF privacy boundary did not recognize that canonical path and removed the filenames and matching debug metadata, leaving live Issues with `<unknown>` application frames even though the source maps uploaded successfully.

## Validation

- `pnpm --filter @aomi-labs/bff-observability test` (54 tests)
- `pnpm --filter @aomi-labs/bff-observability type-check`
- focused Portal and Build smoke-route tests
- Portal and Build type-checks
- Portal and Build production builds
- ESLint and Prettier
- local production smoke confirmed the outgoing event retains only the owned `app:///_next/server/chunks/...` filenames

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788042538&installation_model_id=12362&pr_number=435&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F435&signature=3aeb0e0ed9e3848c8b38048a23903258cd49dfc0856a674c763e96210c223404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->