### PR TITLE
Surface /permission in the Telegram setup guide

### DIFF
--- a/apps/build/src/features/integrations/how-it-works.tsx
+++ b/apps/build/src/features/integrations/how-it-works.tsx
@@ -22,6 +22,7 @@ export function botfatherCommands(threadMode: BotThreadMode): string {
       ? "sessions - View and switch threads"
       : "sessions - View your conversation",
     "wallet - Connect or manage wallet",
+    "signing - View or change signing mode",
     "tx - Review pending transactions",
     "sign - Sign selected transactions",
     "app - View or change app",
@@ -121,8 +122,12 @@ export function TelegramHowItWorks() {
       body: "Anyone who messages your bot uses their own Aomi identity, wallets, and threads. The primary app answers new conversations; /app switches between attached apps.",
     },
     {
+      title: "Users choose how their agent signs",
+      body: "Agent wallets start unable to sign. In /signing, a user can turn on autonomous signing — letting the agent trade without approving each transaction — or turn it back off. Wallets the user holds themselves stay read-only there and change in the web app, since loosening those needs their signature.",
+    },
+    {
       title: "Optional: make slash commands visible",
-      body: "Send /setcommands to BotFather as shown on the right, so commands like /wallet and /tx autocomplete in Telegram.",
+      body: "Send /setcommands to BotFather as shown on the right, so commands like /signing and /tx autocomplete in Telegram.",
     },
   ];
   return (

--- a/apps/build/src/features/integrations/how-it-works.tsx
+++ b/apps/build/src/features/integrations/how-it-works.tsx
@@ -22,7 +22,7 @@ export function botfatherCommands(threadMode: BotThreadMode): string {
       ? "sessions - View and switch threads"
       : "sessions - View your conversation",
     "wallet - Connect or manage wallet",
-    "signing - View or change signing mode",
+    "permission - View or change what the agent may sign",
     "tx - Review pending transactions",
     "sign - Sign selected transactions",
     "app - View or change app",
@@ -123,11 +123,11 @@ export function TelegramHowItWorks() {
     },
     {
       title: "Users choose how their agent signs",
-      body: "Agent wallets start unable to sign. In /signing, a user can turn on autonomous signing — letting the agent trade without approving each transaction — or turn it back off. Wallets the user holds themselves stay read-only there and change in the web app, since loosening those needs their signature.",
+      body: "Agent wallets start unable to sign. In /permission, a user can turn on autonomous signing — letting the agent trade without approving each transaction — or turn it back off. Wallets the user holds themselves stay read-only there and change in the web app, since loosening those needs their signature.",
     },
     {
       title: "Optional: make slash commands visible",
-      body: "Send /setcommands to BotFather as shown on the right, so commands like /signing and /tx autocomplete in Telegram.",
+      body: "Send /setcommands to BotFather as shown on the right, so commands like /permission and /tx autocomplete in Telegram.",
     },
   ];
   return (


### PR DESCRIPTION
Companion to [product-mono#916](https://github.com/aomi-labs/product-mono/pull/916), which adds a `/signing` panel to the Telegram bot.

## Why this page needs it

Agent wallets no longer arm themselves. #916 moved the handover's `auto` escalation from claim time to activation, so autonomy starts at the account owner's on-chain grant instead of at a QR scan. That closes the partner-handover case — but it left a hole for the other population: a user who provisions an agent wallet *outside* a handover had no way to turn autonomy on from Telegram, because the bot had no signing-mode surface at all (`signing_mode` appeared nowhere in the telegram binary).

`/signing` is that switch. This page is where builders learn which commands exist, so it needs both the command line and the concept.

## Changes

- `signing - View or change signing mode` added to the `/setcommands` block builders copy into BotFather.
- New step, **"Users choose how their agent signs"**, describing the split users will actually hit: agent wallets are changeable in chat; wallets the user holds themselves are read-only there and change in the web app, since loosening those requires their own signature.
- Step 5's example commands now name `/signing` rather than `/wallet`.

## Note

The rule that survives this change: a chat message may arm a wallet **Aomi custodies** (the permit is one the key signs for itself — no human is being skipped, because no human is in that key's custody chain), and may never arm a wallet a **human** custodies. The copy states that distinction rather than hiding it, since it's the first thing a security-minded builder will ask about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788295132&installation_model_id=12362&pr_number=442&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F442&signature=6def9fc1540787ff34053b370f32b49b61dc03150012ac23e40c520133a0c4b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->