### PR TITLE
fix(auth): restore Privy provider exchange

### DIFF
--- a/apps/shadcn-registry/src/lib/wallet-kit/providers/privy/PrivyPluginProvider.tsx
+++ b/apps/shadcn-registry/src/lib/wallet-kit/providers/privy/PrivyPluginProvider.tsx
@@ -170,22 +170,22 @@ export function AomiPrivyPluginProvider({
       },
       logout: privy.logout,
       getCredential:
-        (privy.getIdentityToken ?? privy.getAccessToken)
+        (privy.getAccessToken ?? privy.getIdentityToken)
           ? async (): Promise<AomiAccountCredential | null> => {
-              const identityToken = (await privy.getIdentityToken?.())?.trim();
-              if (identityToken) {
+              const accessToken = (await privy.getAccessToken?.())?.trim();
+              if (accessToken) {
                 return {
                   provider: "privy",
-                  tokenKind: "identity_token",
-                  providerToken: identityToken,
+                  tokenKind: "access_token",
+                  providerToken: accessToken,
                 };
               }
-              const accessToken = (await privy.getAccessToken?.())?.trim();
-              return accessToken
+              const identityToken = (await privy.getIdentityToken?.())?.trim();
+              return identityToken
                 ? {
                     provider: "privy",
-                    tokenKind: "access_token",
-                    providerToken: accessToken,
+                    tokenKind: "identity_token",
+                    providerToken: identityToken,
                   }
                 : null;
             }


### PR DESCRIPTION
## Summary
- prefer Privy access tokens for the Aomi provider exchange
- keep identity tokens as a fallback when access-token retrieval is unavailable
- preserve server-side Privy wallet attestation via the existing app-secret API path

## Why
Production identity-token exchange is failing signature verification. Privy documents access and identity tokens as distinct verification flows; the current server already has a supported access-token verifier and independently fetches wallet ownership.

## Validation
- Prettier check for the changed file
- `pnpm --filter @aomi-labs/widget-lib build:package`
- production sign-in will be retested after deployment

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788630928&installation_model_id=12362&pr_number=458&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F458&signature=bf6d3ce9782999dbf70b1e3ae2d78703bd6c010f45c8d177cf31c7e402d26f23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->