### PR TITLE
Harden Telegram Para wallet flow

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -1,5 +1,21 @@
 # Auth BFF BetterAuth Cleanup Goal
 
+## Telegram Para Mini App
+
+Current session goal: **IMPLEMENTED AND LOCALLY VERIFIED 2026-08-06** — use one
+Para Mini App page for verified Telegram login and canonical wallet requests,
+with Portal issuing the account bearer only after Telegram session ownership
+and Para identity verification agree. The Mini App no longer owns a Telegram
+relay or legacy operation pages; transaction and EIP-712 acknowledgements flow
+through the canonical Session contract.
+
+- Added the shared Telegram Ed25519 launch verifier to `@aomi-labs/account` and
+  a Portal exchange route that safely claims an unowned/same-owner thread,
+  links Para to that canonical user, and issues an origin-bound widget session.
+- Kept the public BotFather contract aligned to `/start`, `/thread`,
+  `/wallet`, `/permission`, `/tx`, `/app`, `/model`, `/network`, and
+  `/disconnect`.
+
 ## BFF Sentry Observability
 
 Current session goal: **LOCAL IMPLEMENTATION AND REVIEW FIXES COMPLETE;

--- a/apps/build/src/features/integrations/how-it-works.tsx
+++ b/apps/build/src/features/integrations/how-it-works.tsx
@@ -12,23 +12,22 @@ import { ThreadModeControl } from "./thread-mode-control";
 export type BotThreadMode = "single" | "multi";
 
 /** The /setcommands list we tell builders to paste into BotFather. The
- *  `sessions` line follows the bot's thread mode: single-thread bots render a
+ *  `thread` line follows the bot's thread mode: single-thread bots render a
  *  read-only conversation view (the panel blocks switching with a toast), so
  *  only multi-thread bots may advertise switching. */
 export function botfatherCommands(threadMode: BotThreadMode): string {
   return [
     "start - Start the bot",
     threadMode === "multi"
-      ? "sessions - View and switch threads"
-      : "sessions - View your conversation",
+      ? "thread - View and switch threads"
+      : "thread - View your conversation",
     "wallet - Connect or manage wallet",
     "permission - View or change what the agent may sign",
     "tx - Review pending transactions",
-    "sign - Sign selected transactions",
     "app - View or change app",
     "model - View or change model",
-    "network - View or switch network",
-    "settings - Open bot settings",
+    "network - View or select network",
+    "disconnect - Disconnect this thread",
   ].join("\n");
 }
 
@@ -158,7 +157,7 @@ export function TelegramHowItWorks() {
               onChange={(next) =>
                 setThreadMode(next === "multi" ? "multi" : "single")
               }
-              tooltip="Match your bot's thread mode — the command list on the right follows it. Single thread keeps the bot to one conversation, so /sessions only views it; multiple threads lets users create and switch threads with /sessions."
+              tooltip="Match your bot's thread mode — the command list on the right follows it. Single thread keeps the bot to one conversation, so /thread only views it; multiple threads lets users create and switch threads with /thread."
             />
           </div>
         </div>

--- a/apps/build/src/features/integrations/thread-mode-control.tsx
+++ b/apps/build/src/features/integrations/thread-mode-control.tsx
@@ -81,7 +81,7 @@ export function ThreadModeControl({
       <ThreadModeToggle value={value} onChange={onChange} disabled={disabled} />
       <HelpBadge label="About thread mode">
         {tooltip ??
-          "Single thread keeps the bot to one conversation. Multiple threads lets users switch threads with /sessions."}
+          "Single thread keeps the bot to one conversation. Multiple threads lets users switch threads with /thread."}
       </HelpBadge>
     </div>
   );

--- a/apps/portal/src/app/api/aomi/telegram/exchange/route.test.ts
+++ b/apps/portal/src/app/api/aomi/telegram/exchange/route.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  claimOwner: vi.fn(),
+  issueSession: vi.fn(),
+  linkIdentity: vi.fn(),
+  verifyCredential: vi.fn(),
+  verifyTelegram: vi.fn(),
+}));
+
+vi.mock("@aomi-labs/account/account", () => ({
+  claimTelegramSessionOwner: mocks.claimOwner,
+  linkVerifiedProviderIdentityForUser: mocks.linkIdentity,
+}));
+
+vi.mock("@aomi-labs/account/telegram", () => ({
+  verifyTelegramInitData: mocks.verifyTelegram,
+}));
+
+vi.mock("@aomi-labs/account/widget-auth", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@aomi-labs/account/widget-auth")>();
+  return {
+    ...actual,
+    issueWidgetSession: mocks.issueSession,
+    requireWidgetOrigin: () => "https://telegram-mini.aomi.dev",
+  };
+});
+
+vi.mock("@portal/lib/widget-auth/exchange", () => ({
+  verifyWidgetProviderCredential: mocks.verifyCredential,
+}));
+
+vi.mock("@portal/lib/widget-auth/rate-limit", () => ({
+  widgetAuthRateLimit: () => null,
+}));
+
+vi.mock("@portal/server/bff/failures", () => ({
+  portalFailures: {
+    handle: (input: { response: { error: string; status: number } }) => ({
+      response: Response.json(
+        { error: input.response.error },
+        { status: input.response.status },
+      ),
+    }),
+  },
+}));
+
+import { POST } from "./route";
+
+function request(body: unknown): Request {
+  return new Request("https://portal.aomi.dev/api/aomi/telegram/exchange", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      origin: "https://telegram-mini.aomi.dev",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const DM_THREAD_ID = "0b9c1f2e-4d3a-4c5b-8e7f-1a2b3c4d5e6f";
+
+describe("Telegram Para exchange", () => {
+  beforeEach(() => {
+    for (const mock of Object.values(mocks)) mock.mockReset();
+    mocks.verifyTelegram.mockReturnValue({
+      ok: true,
+      launch: { botId: "123", telegramUserId: "456" },
+    });
+    mocks.claimOwner.mockResolvedValue("canonical-user");
+    mocks.verifyCredential.mockResolvedValue({
+      descriptor: {
+        id: "para",
+        policy: { subjectIsEnvironmentGlobal: true },
+      },
+      identity: {
+        provider: "para",
+        issuerEnvironment: "beta",
+        tenantId: "para",
+        subject: "para-user",
+        walletAttestations: [],
+      },
+    });
+    mocks.linkIdentity.mockResolvedValue({
+      status: "linked",
+      identity: { id: "provider-identity" },
+      user: { id: "canonical-user" },
+    });
+    mocks.issueSession.mockResolvedValue({
+      token: "widget-token",
+      tokenType: "Bearer",
+      expiresAt: 1_800_000_000,
+      userId: "canonical-user",
+    });
+  });
+
+  it("claims the Telegram session and issues a canonical Para bearer", async () => {
+    const response = await POST(
+      request({
+        bot_id: "123",
+        init_data: "signed-init-data",
+        session_id: DM_THREAD_ID,
+        credential: { provider: "para", provider_token: "credential" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      access_token: "widget-token",
+      user: { id: "canonical-user" },
+    });
+    expect(mocks.claimOwner).toHaveBeenCalledWith({
+      sessionId: DM_THREAD_ID,
+      telegramUserId: "456",
+    });
+    expect(mocks.issueSession).toHaveBeenCalledWith({
+      userId: "canonical-user",
+      origin: "https://telegram-mini.aomi.dev",
+      authMethod: "telegram_para",
+      providerIdentityId: "provider-identity",
+    });
+  });
+
+  it("rejects a session already owned by another account", async () => {
+    mocks.claimOwner.mockResolvedValue(null);
+
+    const response = await POST(
+      request({
+        bot_id: "123",
+        init_data: "signed-init-data",
+        session_id: DM_THREAD_ID,
+        credential: { provider: "para", provider_token: "credential" },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "telegram_session_mismatch",
+    });
+    expect(mocks.issueSession).not.toHaveBeenCalled();
+  });
+
+  it("refuses to claim a thread whose id is not a private conversation", async () => {
+    // `telegram:group:<chat>` is shared by every member and guessable, so a
+    // valid launch must not be able to bind it to the caller's account.
+    const response = await POST(
+      request({
+        bot_id: "123",
+        init_data: "signed-init-data",
+        session_id: "telegram:group:-1001234567890",
+        credential: { provider: "para", provider_token: "credential" },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "unsupported_session",
+    });
+    expect(mocks.claimOwner).not.toHaveBeenCalled();
+    expect(mocks.issueSession).not.toHaveBeenCalled();
+  });
+});

--- a/apps/portal/src/app/api/aomi/telegram/exchange/route.ts
+++ b/apps/portal/src/app/api/aomi/telegram/exchange/route.ts
@@ -1,0 +1,117 @@
+import {
+  claimTelegramSessionOwner,
+  linkVerifiedProviderIdentityForUser,
+} from "@aomi-labs/account/account";
+import { verifyTelegramInitData } from "@aomi-labs/account/telegram";
+import {
+  issueWidgetSession,
+  requireWidgetOrigin,
+  WidgetAuthError,
+} from "@aomi-labs/account/widget-auth";
+import { verifyWidgetProviderCredential } from "@portal/lib/widget-auth/exchange";
+import { widgetAuthRateLimit } from "@portal/lib/widget-auth/rate-limit";
+import {
+  widgetPreflight,
+  widgetRoute,
+  widgetSessionResponse,
+} from "@portal/lib/widget-auth/response";
+
+const TELEGRAM_FAILURE_STATUS = {
+  malformed: 400,
+  missing_signature: 400,
+  missing_user: 400,
+  bad_signature: 401,
+  expired: 401,
+} as const;
+
+type TelegramParaExchange = {
+  bot_id?: unknown;
+  credential?: unknown;
+  init_data?: unknown;
+  session_id?: unknown;
+};
+
+const DM_THREAD_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function requiredString(value: unknown, maxLength: number): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed && trimmed.length <= maxLength ? trimmed : null;
+}
+
+/**
+ * Only a bot's DM threads may be claimed here. Those carry an opaque per-user
+ * UUID, while shared threads use a derived id such as `telegram:group:<chat>`
+ * that every member — and anyone who can guess a chat id — could present.
+ * Since claiming an unowned thread binds it to the caller's account, an
+ * allowlist on the DM shape is what keeps a guessable id from being claimed.
+ */
+function isClaimableThreadId(sessionId: string): boolean {
+  return DM_THREAD_ID.test(sessionId);
+}
+
+export const POST = widgetRoute(async (request: Request) => {
+  const limited = widgetAuthRateLimit(request);
+  if (limited) return limited;
+  const origin = requireWidgetOrigin(request);
+  const body = (await request
+    .json()
+    .catch(() => null)) as TelegramParaExchange | null;
+  const botId = requiredString(body?.bot_id, 32);
+  const initData = requiredString(body?.init_data, 16_384);
+  const sessionId = requiredString(body?.session_id, 512);
+  if (!botId || !initData || !sessionId || !body?.credential) {
+    throw new WidgetAuthError("invalid_request", 400);
+  }
+  if (!isClaimableThreadId(sessionId)) {
+    throw new WidgetAuthError("unsupported_session", 400);
+  }
+
+  const telegram = verifyTelegramInitData(initData, botId);
+  if (!telegram.ok) {
+    throw new WidgetAuthError(
+      telegram.reason,
+      TELEGRAM_FAILURE_STATUS[telegram.reason],
+    );
+  }
+
+  const userId = await claimTelegramSessionOwner({
+    sessionId,
+    telegramUserId: telegram.launch.telegramUserId,
+  });
+  if (!userId) {
+    throw new WidgetAuthError("telegram_session_mismatch", 403);
+  }
+
+  const { descriptor, identity } = await verifyWidgetProviderCredential(
+    body.credential,
+  );
+  if (descriptor.id !== "para" || identity.provider !== "para") {
+    throw new WidgetAuthError("provider_not_enabled", 400);
+  }
+  const resolution = await linkVerifiedProviderIdentityForUser({
+    userId,
+    identity,
+    policy: descriptor.policy,
+  });
+  if (resolution.status === "conflict") {
+    return Response.json(
+      { ...resolution, error: "already_linked_to_another_account" },
+      { status: 409 },
+    );
+  }
+
+  return widgetSessionResponse(
+    await issueWidgetSession({
+      userId,
+      origin,
+      authMethod: "telegram_para",
+      providerIdentityId: resolution.identity.id,
+    }),
+  );
+}, "telegram.para.exchange");
+
+export const OPTIONS = widgetPreflight(["POST", "OPTIONS"]);
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";

--- a/apps/telegram/next.config.ts
+++ b/apps/telegram/next.config.ts
@@ -6,6 +6,9 @@ const appRoot = path.dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = path.resolve(appRoot, "../..");
 const appNodeModules = path.join(appRoot, "node_modules");
 
+// Para consumes React Query through a peer dependency. Pin both sides to the
+// app copy so the provider and Para hooks share the same runtime context.
+
 const nextConfig: NextConfig = {
   agentRules: false,
   reactStrictMode: true,

--- a/apps/telegram/next.config.ts
+++ b/apps/telegram/next.config.ts
@@ -19,6 +19,7 @@ const nextConfig: NextConfig = {
       "@getpara/user-management-client":
         "./node_modules/@getpara/user-management-client",
       "@getpara/web-sdk": "./node_modules/@getpara/web-sdk",
+      "@tanstack/react-query": "./node_modules/@tanstack/react-query",
     },
   },
   webpack: (config) => {
@@ -35,6 +36,10 @@ const nextConfig: NextConfig = {
         "@getpara/user-management-client",
       ),
       "@getpara/web-sdk": path.join(appNodeModules, "@getpara/web-sdk"),
+      "@tanstack/react-query": path.join(
+        appNodeModules,
+        "@tanstack/react-query",
+      ),
     };
     return config;
   },

--- a/apps/telegram/package.json
+++ b/apps/telegram/package.json
@@ -14,12 +14,13 @@
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
-    "test": "node --test test/*.test.mjs",
+    "test": "pnpm --dir ../.. exec vitest run apps/telegram/src && node --test test/*.test.mjs",
     "test:unit": "node --test test/*.test.mjs",
     "check": "pnpm typecheck && pnpm lint && pnpm test && pnpm build",
     "clean": "rm -rf node_modules .next"
   },
   "dependencies": {
+    "@aomi-labs/account": "workspace:*",
     "@aomi-labs/client": "workspace:*",
     "@getpara/core-sdk": "3.12.0",
     "@getpara/react-core": "3.12.0",

--- a/apps/telegram/src/app/api/telegram/launch/route.ts
+++ b/apps/telegram/src/app/api/telegram/launch/route.ts
@@ -1,4 +1,4 @@
-import { verifyTelegramInitData } from "@/lib/telegram-init-data";
+import { verifyTelegramInitData } from "@aomi-labs/account/telegram";
 
 const STATUS_BY_REASON = {
   malformed: 400,

--- a/apps/telegram/src/app/globals.css
+++ b/apps/telegram/src/app/globals.css
@@ -40,6 +40,66 @@ body {
   font-size: 14px;
 }
 
+.wallet-review {
+  width: 100%;
+  max-width: 460px;
+  display: grid;
+  gap: 20px;
+}
+
+.wallet-review h1 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 650;
+}
+
+.wallet-review dl {
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.wallet-review dt {
+  color: var(--tg-theme-hint-color, #a1a1aa);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.wallet-review dd {
+  margin: 4px 0 0;
+  font-size: 15px;
+  overflow-wrap: anywhere;
+}
+
+.wallet-review dd.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px;
+  white-space: pre-wrap;
+  max-height: 220px;
+  overflow: auto;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: var(--tg-theme-secondary-bg-color, #1c1c1f);
+}
+
+.wallet-actions {
+  display: grid;
+  gap: 10px;
+}
+
+.para-button--ghost {
+  background: transparent;
+  color: var(--tg-theme-hint-color, #a1a1aa);
+  border: 1px solid var(--tg-theme-hint-color, #3f3f46);
+  font-weight: 550;
+}
+
+.para-button:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
 .para-button {
   min-width: 180px;
   min-height: 48px;

--- a/apps/telegram/src/app/page.tsx
+++ b/apps/telegram/src/app/page.tsx
@@ -7,6 +7,7 @@ import { useAomiWalletRequest } from "@/hooks/use-aomi-wallet-request";
 import { useCanonicalAccount } from "@/hooks/use-canonical-account";
 import { useTelegramLaunch } from "@/hooks/use-telegram-launch";
 import { useWalletExecutor } from "@/hooks/use-wallet-executor";
+import { describeRequest, requestChain } from "@/lib/wallet-request";
 
 function statusText(input: {
   account: ReturnType<typeof useCanonicalAccount>;
@@ -30,9 +31,7 @@ function statusText(input: {
   ) {
     return "Waiting for the wallet request…";
   }
-  if (input.execution.status === "preparing") return "Preparing Para…";
-  if (input.execution.status === "awaiting_wallet")
-    return "Review and approve in Para";
+  if (input.execution.status === "awaiting_wallet") return "Signing…";
   if (input.execution.status === "done") return "Approved";
   if (input.execution.status === "error")
     return "The wallet request was not approved.";
@@ -44,7 +43,7 @@ export default function Home() {
   const account = useAccount();
   const opened = useRef(false);
   const launch = useTelegramLaunch();
-  const canonicalAccount = useCanonicalAccount();
+  const canonicalAccount = useCanonicalAccount(launch.context);
   const walletRequest = useAomiWalletRequest({
     enabled: launch.status === "ready" && canonicalAccount.status === "ready",
     provider: canonicalAccount.provider,
@@ -61,6 +60,52 @@ export default function Home() {
     opened.current = true;
     openModal();
   }, [launch.status, openModal]);
+
+  const summary = walletRequest.request
+    ? describeRequest(walletRequest.request, requestChain(walletRequest.request))
+    : null;
+
+  // Nothing is signed until the user reads this and taps Approve — the Telegram
+  // button only opens the app.
+  if (
+    summary &&
+    (execution.status === "review" || execution.status === "preparing")
+  ) {
+    return (
+      <main className="wallet-page">
+        <section className="wallet-review" aria-live="polite">
+          <h1>{summary.title}</h1>
+          <dl>
+            {summary.fields.map((field) => (
+              <div key={field.label}>
+                <dt>{field.label}</dt>
+                <dd className={field.mono ? "mono" : undefined}>
+                  {field.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+          <div className="wallet-actions">
+            <button
+              className="para-button"
+              type="button"
+              disabled={execution.status !== "review"}
+              onClick={execution.approve}
+            >
+              {execution.status === "review" ? "Approve" : "Preparing Para…"}
+            </button>
+            <button
+              className="para-button para-button--ghost"
+              type="button"
+              onClick={execution.reject}
+            >
+              Decline
+            </button>
+          </div>
+        </section>
+      </main>
+    );
+  }
 
   const message = statusText({
     account: canonicalAccount,

--- a/apps/telegram/src/hooks/use-canonical-account.ts
+++ b/apps/telegram/src/hooks/use-canonical-account.ts
@@ -5,10 +5,13 @@ import { useAccount, useClient } from "@getpara/react-sdk-lite";
 import {
   createProviderCredentialAdapter,
   createWidgetSessionProvider,
+  type WidgetAuthAdapter,
+  type WidgetAuthSession,
   type WidgetSessionProvider,
 } from "@aomi-labs/client";
 
 import { aomiBffUrl, paraEnvironment } from "@/app/config";
+import type { LaunchContext } from "@/lib/telegram";
 
 type CanonicalAccountState = {
   error: string | null;
@@ -17,7 +20,69 @@ type CanonicalAccountState = {
   userId: string | null;
 };
 
-export function useCanonicalAccount(): CanonicalAccountState {
+type TelegramExchangeResponse = {
+  access_token?: unknown;
+  expires_at?: unknown;
+};
+
+function telegramParaAdapter(input: {
+  getCredential: () => Promise<{
+    keyId?: string;
+    providerToken: string;
+  } | null>;
+  launch: LaunchContext;
+  paraSubject: string | null;
+}): WidgetAuthAdapter {
+  return {
+    getFingerprint: () =>
+      input.paraSubject
+        ? `telegram:${input.launch.proof?.telegramUserId}:para:${input.paraSubject}:session:${input.launch.sessionId}`
+        : null,
+    exchange: async ({ baseUrl, fetch: fetchImpl }) => {
+      const credential = await input.getCredential();
+      if (!credential || !input.launch.proof || !input.launch.sessionId) {
+        throw new Error("telegram_para_credential_unavailable");
+      }
+      const response = await fetchImpl(
+        new URL("/api/aomi/telegram/exchange", baseUrl),
+        {
+          method: "POST",
+          credentials: "omit",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            bot_id: input.launch.proof.botId,
+            init_data: input.launch.proof.initData,
+            session_id: input.launch.sessionId,
+            credential: {
+              provider: "para",
+              environment: paraEnvironment,
+              provider_token: credential.providerToken,
+              key_id: credential.keyId,
+            },
+          }),
+        },
+      );
+      const body = (await response
+        .json()
+        .catch(() => null)) as TelegramExchangeResponse | null;
+      if (
+        !response.ok ||
+        typeof body?.access_token !== "string" ||
+        typeof body.expires_at !== "number"
+      ) {
+        throw new Error(`telegram_para_exchange_failed_${response.status}`);
+      }
+      return {
+        accessToken: body.access_token,
+        expiresAt: body.expires_at,
+      } satisfies WidgetAuthSession;
+    },
+  };
+}
+
+export function useCanonicalAccount(
+  launch: LaunchContext | null,
+): CanonicalAccountState {
   const account = useAccount();
   const paraClient = useClient();
   const paraSubject = account.embedded.userId ?? paraClient?.userId ?? null;
@@ -28,26 +93,32 @@ export function useCanonicalAccount(): CanonicalAccountState {
   });
 
   const provider = useMemo(() => {
-    if (!account.embedded.isConnected || !paraClient) return null;
-    const adapter = createProviderCredentialAdapter({
-      provider: "para",
-      environment: paraEnvironment,
-      getCredential: async () => {
-        const credential = await paraClient.issueJwt({});
-        const providerToken = credential.token.trim();
-        return providerToken
-          ? {
-              provider: "para",
-              tokenKind: "session_jwt",
-              providerToken,
-              keyId: credential.keyId,
-            }
-          : null;
-      },
-      getSubject: () => paraSubject,
-    });
+    if (!account.embedded.isConnected || !paraClient || !launch) return null;
+    const getCredential = async () => {
+      const credential = await paraClient.issueJwt({});
+      const providerToken = credential.token.trim();
+      return providerToken ? { providerToken, keyId: credential.keyId } : null;
+    };
+    const adapter =
+      launch.inTelegram && launch.proof && launch.sessionId
+        ? telegramParaAdapter({ getCredential, launch, paraSubject })
+        : createProviderCredentialAdapter({
+            provider: "para",
+            environment: paraEnvironment,
+            getCredential: async () => {
+              const credential = await getCredential();
+              return credential
+                ? {
+                    provider: "para",
+                    tokenKind: "session_jwt",
+                    ...credential,
+                  }
+                : null;
+            },
+            getSubject: () => paraSubject,
+          });
     return createWidgetSessionProvider({ baseUrl: aomiBffUrl, adapter });
-  }, [account.embedded.isConnected, paraClient, paraSubject]);
+  }, [account.embedded.isConnected, launch, paraClient, paraSubject]);
 
   useEffect(() => {
     if (!provider) return;

--- a/apps/telegram/src/hooks/use-wallet-executor.ts
+++ b/apps/telegram/src/hooks/use-wallet-executor.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { createParaViemClientHook } from "@getpara/react-core/evm/viem";
 import {
   toAAWalletCalls,
@@ -10,18 +10,30 @@ import {
   type WalletRequest,
   type WalletRequestResult,
 } from "@aomi-labs/client";
-import { http, type Hex } from "viem";
+import { createPublicClient, http, type Hex } from "viem";
 
 import {
   errorMessage,
   requestChain,
   requestedAaMode,
 } from "@/lib/wallet-request";
-import { failTelegramRequest, finishTelegramRequest } from "@/lib/telegram";
 
 type ExecutionState = {
   error: string | null;
-  status: "idle" | "preparing" | "awaiting_wallet" | "done" | "error";
+  status:
+    | "idle"
+    | "preparing"
+    | "review"
+    | "awaiting_wallet"
+    | "done"
+    | "error";
+};
+
+export type WalletExecution = ExecutionState & {
+  /** Sign the request. Only meaningful while `status` is `review`. */
+  approve: () => void;
+  /** Decline the request and tell the bot it was not approved. */
+  reject: () => void;
 };
 
 type EvmWalletRequest = Extract<
@@ -41,12 +53,12 @@ function isEvmRequest(request: WalletRequest): request is EvmWalletRequest {
 export function useWalletExecutor(input: {
   request: WalletRequest | null;
   session: Session | null;
-}): ExecutionState {
+}): WalletExecution {
   const [state, setState] = useState<ExecutionState>({
     error: null,
     status: "idle",
   });
-  const processed = useRef(new Set<string>());
+  const settled = useRef(new Set<string>());
   const chain = requestChain(input.request);
   const { viemClient } = useEmbeddedParaViemClient({
     walletClientConfig: {
@@ -55,37 +67,42 @@ export function useWalletExecutor(input: {
     },
   });
 
+  // A fresh request opens the review screen; nothing signs until the user acts.
+  useEffect(() => {
+    const request = input.request;
+    if (!request || !input.session || !isEvmRequest(request)) return;
+    if (settled.current.has(request.id)) return;
+    setState({ error: null, status: "review" });
+  }, [input.request, input.session]);
+
+  // A request this app cannot present for review is declined outright — that is
+  // not a decision to put in front of the user.
   useEffect(() => {
     const request = input.request;
     const session = input.session;
-    if (!request || !session || processed.current.has(request.id)) return;
+    if (!request || !session) return;
+    if (isEvmRequest(request) || settled.current.has(request.id)) return;
 
-    if (!isEvmRequest(request)) {
-      processed.current.add(request.id);
-      void session
-        .reject(
-          request.id,
-          "Telegram Mini App currently supports EVM requests only.",
-        )
-        .finally(() => {
-          setState({ error: "unsupported_wallet_request", status: "error" });
-          failTelegramRequest({
-            request_id: request.id,
-            status: "failed",
-            error: "unsupported_wallet_request",
-          });
-        });
-      return;
-    }
+    settled.current.add(request.id);
+    void session
+      .reject(
+        request.id,
+        "Telegram Mini App currently supports EVM requests only.",
+      )
+      .finally(() => {
+        setState({ error: "unsupported_wallet_request", status: "error" });
+      });
+  }, [input.request, input.session]);
+
+  const approve = useCallback(() => {
+    const request = input.request;
+    const session = input.session;
+    if (!request || !session || !isEvmRequest(request)) return;
+    if (!viemClient?.account || settled.current.has(request.id)) return;
+
+    settled.current.add(request.id);
+    setState({ error: null, status: "awaiting_wallet" });
     const evmRequest = request;
-
-    if (!viemClient?.account) return;
-
-    processed.current.add(request.id);
-    let active = true;
-    queueMicrotask(() => {
-      if (active) setState({ error: null, status: "awaiting_wallet" });
-    });
 
     const execute = async (): Promise<EvmWalletResult> => {
       if (evmRequest.kind === "eip712_sign") {
@@ -128,6 +145,13 @@ export function useWalletExecutor(input: {
         to: call.to,
         value: call.value,
       });
+      const receipt = await createPublicClient({
+        chain,
+        transport: http(chain.rpcUrls.default.http[0]),
+      }).waitForTransactionReceipt({ hash: txHash });
+      if (receipt.status !== "success") {
+        throw new Error("transaction_reverted");
+      }
       return {
         kind: "transaction",
         txHash,
@@ -145,38 +169,36 @@ export function useWalletExecutor(input: {
     void execute()
       .then(async (result) => {
         await session.resolve(request.id, result);
-        if (!active) return;
         setState({ error: null, status: "done" });
-        finishTelegramRequest({
-          request_id: request.id,
-          status: "signed",
-          kind: result.kind,
-          ...(result.kind === "transaction"
-            ? { tx_hash: result.txHash }
-            : { signature: result.signature }),
-        });
       })
       .catch(async (error: unknown) => {
         const message = errorMessage(error);
         await session.reject(request.id, message).catch(() => undefined);
-        if (!active) return;
         setState({ error: message, status: "error" });
-        failTelegramRequest({
-          request_id: request.id,
-          status: "failed",
-          error: message,
-        });
       });
-
-    return () => {
-      active = false;
-    };
   }, [chain, input.request, input.session, viemClient]);
 
-  const preparing =
-    input.request &&
-    input.session &&
-    isEvmRequest(input.request) &&
-    !viemClient?.account;
-  return preparing ? { error: null, status: "preparing" } : state;
+  const reject = useCallback(() => {
+    const request = input.request;
+    const session = input.session;
+    if (!request || !session || settled.current.has(request.id)) return;
+
+    settled.current.add(request.id);
+    setState({ error: null, status: "error" });
+    void session
+      .reject(request.id, "Declined in the Telegram Mini App.")
+      .catch(() => undefined);
+  }, [input.request, input.session]);
+
+  // `settled` is only ever read from effects and callbacks — the rendered view
+  // comes from state, so approving or declining re-renders.
+  return {
+    ...state,
+    status:
+      state.status === "review" && !viemClient?.account
+        ? "preparing"
+        : state.status,
+    approve,
+    reject,
+  };
 }

--- a/apps/telegram/src/lib/telegram.ts
+++ b/apps/telegram/src/lib/telegram.ts
@@ -8,6 +8,11 @@ export type TelegramLaunch = {
 
 export type LaunchContext = {
   inTelegram: boolean;
+  proof: {
+    botId: string;
+    initData: string;
+    telegramUserId: string;
+  } | null;
   sessionId: string | null;
   requestId: string | null;
   verified: boolean;
@@ -36,6 +41,7 @@ export async function establishTelegramLaunch(): Promise<LaunchContext> {
     if (!isLocalPreview()) throw new Error("open_from_telegram");
     return {
       inTelegram: false,
+      proof: null,
       sessionId: querySessionId,
       requestId,
       verified: false,
@@ -61,24 +67,13 @@ export async function establishTelegramLaunch(): Promise<LaunchContext> {
 
   return {
     inTelegram: true,
+    proof: {
+      botId,
+      initData: webApp.initData,
+      telegramUserId: launch.telegramUserId,
+    },
     sessionId: querySessionId ?? launch.startParam ?? null,
     requestId,
     verified: true,
   };
-}
-
-export function finishTelegramRequest(payload: Record<string, unknown>): void {
-  const webApp = window.Telegram?.WebApp;
-  webApp?.HapticFeedback?.notificationOccurred("success");
-  if (!webApp?.sendData) return;
-  webApp.sendData(JSON.stringify(payload));
-  window.setTimeout(() => webApp.close(), 150);
-}
-
-export function failTelegramRequest(payload: Record<string, unknown>): void {
-  const webApp = window.Telegram?.WebApp;
-  webApp?.HapticFeedback?.notificationOccurred("error");
-  if (!webApp?.sendData) return;
-  webApp.sendData(JSON.stringify(payload));
-  window.setTimeout(() => webApp.close(), 150);
 }

--- a/apps/telegram/src/lib/wallet-request.test.ts
+++ b/apps/telegram/src/lib/wallet-request.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { mainnet } from "viem/chains";
+
+import type { WalletRequest } from "@aomi-labs/client";
+
+import { describeRequest, requestedAaMode } from "./wallet-request";
+
+describe("Telegram wallet request policy", () => {
+  it("keeps auto and omitted AA preferences on the canonical 7702 path", () => {
+    expect(requestedAaMode({ aaPreference: "auto" })).toBe("7702");
+    expect(requestedAaMode({})).toBe("7702");
+    expect(requestedAaMode({ aaPreference: "eip4337" })).toBe("4337");
+    expect(requestedAaMode({ aaPreference: "none" })).toBe("none");
+  });
+
+  it("shows every signed EIP-712 section, including the verifying contract", () => {
+    const request = {
+      id: "eip712-1",
+      kind: "eip712_sign",
+      timestamp: 1,
+      payload: {
+        typed_data: {
+          domain: {
+            chainId: 1,
+            name: "Permit",
+            verifyingContract: "0x0000000000000000000000000000000000000001",
+            version: "1",
+          },
+          types: {
+            Permit: [
+              { name: "spender", type: "address" },
+              { name: "value", type: "uint256" },
+            ],
+          },
+          primaryType: "Permit",
+          message: {
+            spender: "0x0000000000000000000000000000000000000002",
+            value: "10",
+          },
+        },
+      },
+    } as unknown as WalletRequest;
+    const summary = describeRequest(request, mainnet);
+
+    expect(summary?.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Domain",
+          value: expect.stringContaining(
+            "0x0000000000000000000000000000000000000001",
+          ),
+        }),
+        expect.objectContaining({
+          label: "Types",
+          value: expect.stringContaining("spender"),
+        }),
+        expect.objectContaining({
+          label: "Message",
+          value: expect.stringContaining("value"),
+        }),
+      ]),
+    );
+  });
+
+  it("shows complete transaction calldata instead of only its selector", () => {
+    const calldata = `0x12345678${"ab".repeat(32)}`;
+    const summary = describeRequest(
+      {
+        id: "tx-1",
+        kind: "transaction",
+        timestamp: 1,
+        payload: {
+          calls: [
+            {
+              txId: 1,
+              to: "0x0000000000000000000000000000000000000001",
+              data: calldata,
+              value: "0",
+              chainId: 1,
+            },
+          ],
+        },
+      },
+      mainnet,
+    );
+
+    expect(summary?.fields).toContainEqual({
+      label: "Calldata",
+      value: calldata,
+      mono: true,
+    });
+  });
+});

--- a/apps/telegram/src/lib/wallet-request.ts
+++ b/apps/telegram/src/lib/wallet-request.ts
@@ -4,6 +4,7 @@ import {
   type WalletRequest,
   type WalletTxPayload,
 } from "@aomi-labs/client";
+import { formatEther } from "viem";
 import { mainnet, type Chain } from "viem/chains";
 
 export function requestChain(request: WalletRequest | null): Chain {
@@ -32,9 +33,99 @@ export function pendingTransactionIds(payload: WalletTxPayload): number[] {
 export function requestedAaMode(
   payload: WalletTxPayload,
 ): "4337" | "7702" | "none" {
+  if (payload.aaPreference === "none") return "none";
   if (payload.aaPreference === "eip4337") return "4337";
-  if (payload.aaPreference === "eip7702") return "7702";
-  return "none";
+  // Keep this aligned with the canonical Session policy: `auto` (and an
+  // omitted preference before normalization) requests 7702. Treating it as
+  // `none` would let an `aaStrict` request silently execute through an EOA.
+  return "7702";
+}
+
+export type RequestField = {
+  label: string;
+  value: string;
+  /** Render in a monospace, wrappable block — addresses, calldata, JSON. */
+  mono?: boolean;
+};
+
+export type RequestSummary = {
+  title: string;
+  fields: RequestField[];
+};
+
+function formatCalldata(data: string | undefined): string {
+  if (!data || data === "0x") return "None";
+  return data;
+}
+
+/**
+ * What the user is asked to approve, in the plainest terms we can state without
+ * decoding. Nothing here is inferred — every field comes straight off the
+ * request — because this is the only place a Telegram user sees what they are
+ * signing.
+ */
+export function describeRequest(
+  request: WalletRequest,
+  chain: Chain,
+): RequestSummary | null {
+  if (request.kind === "transaction") {
+    const call = request.payload.calls?.[0];
+    const to = call?.to ?? request.payload.to;
+    const rawValue = call?.value ?? request.payload.value ?? "0";
+    const data = call?.data ?? request.payload.data;
+
+    let amount = `${rawValue} wei`;
+    try {
+      amount = `${formatEther(BigInt(rawValue))} ${chain.nativeCurrency.symbol}`;
+    } catch {
+      // Leave the raw value visible rather than hiding an unparseable amount.
+    }
+
+    const fields: RequestField[] = [
+      { label: "Network", value: chain.name },
+      { label: "To", value: to ?? "unknown", mono: true },
+      { label: "Amount", value: amount },
+      { label: "Calldata", value: formatCalldata(data), mono: true },
+    ];
+    if (call?.description) {
+      fields.unshift({ label: "Action", value: call.description });
+    }
+    return { title: "Approve transaction", fields };
+  }
+
+  if (request.kind !== "eip712_sign") return null;
+
+  const { typed_data: typedData, non_typed_data: message } = request.payload;
+  const fields: RequestField[] = [];
+  if (request.payload.description) {
+    fields.push({ label: "Action", value: request.payload.description });
+  }
+
+  if (typedData) {
+    fields.push({ label: "Network", value: chain.name });
+    if (typedData.primaryType) {
+      fields.push({ label: "Type", value: typedData.primaryType });
+    }
+    fields.push({
+      label: "Domain",
+      value: JSON.stringify(typedData.domain ?? {}, null, 2),
+      mono: true,
+    });
+    fields.push({
+      label: "Types",
+      value: JSON.stringify(typedData.types ?? {}, null, 2),
+      mono: true,
+    });
+    fields.push({
+      label: "Message",
+      value: JSON.stringify(typedData.message ?? {}, null, 2),
+      mono: true,
+    });
+    return { title: "Approve signature", fields };
+  }
+
+  fields.push({ label: "Message", value: message ?? "", mono: true });
+  return { title: "Approve signature", fields };
 }
 
 export function errorMessage(error: unknown): string {

--- a/apps/telegram/test/integration-contract.test.mjs
+++ b/apps/telegram/test/integration-contract.test.mjs
@@ -3,6 +3,8 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+const readWorkspace = (path) =>
+  readFile(new URL(`../../../${path}`, import.meta.url), "utf8");
 
 test("Para login resolves the canonical Aomi account", async () => {
   const [providers, canonicalAccount] = await Promise.all([
@@ -14,6 +16,7 @@ test("Para login resolves the canonical Aomi account", async () => {
   assert.match(canonicalAccount, /createProviderCredentialAdapter/);
   assert.match(canonicalAccount, /paraClient\.issueJwt/);
   assert.match(canonicalAccount, /createWidgetSessionProvider/);
+  assert.match(canonicalAccount, /\/api\/aomi\/telegram\/exchange/);
   assert.match(canonicalAccount, /\/api\/aomi\/account/);
 });
 
@@ -21,7 +24,7 @@ test("Telegram launches are verified before a production wallet flow", async () 
   const [client, route, verifier] = await Promise.all([
     read("src/lib/telegram.ts"),
     read("src/app/api/telegram/launch/route.ts"),
-    read("src/lib/telegram-init-data.ts"),
+    readWorkspace("packages/account/src/telegram.ts"),
   ]);
 
   assert.match(client, /webApp\.initData/);
@@ -48,6 +51,14 @@ test("the Mini App uses canonical wallet requests and acknowledgements", async (
   assert.match(executor, /session\.resolve/);
   assert.match(executor, /session\.reject/);
   assert.match(executor, /strict_account_abstraction_is_backend_only/);
+  assert.match(executor, /waitForTransactionReceipt/);
+});
+
+test("Para and the app share one React Query context", async () => {
+  const nextConfig = await read("next.config.ts");
+
+  assert.match(nextConfig, /"@tanstack\/react-query"/);
+  assert.match(nextConfig, /appNodeModules/);
 });
 
 test("the legacy relay and multi-page wallet are absent", async () => {
@@ -58,4 +69,30 @@ test("the legacy relay and multi-page wallet are absent", async () => {
 
   assert.doesNotMatch(packageJson, /walletconnect|wagmi|privy/i);
   assert.doesNotMatch(page, /\/api\/operation|Swap assets|Review & sign/i);
+});
+
+test("signing is gated behind an explicit approval of a rendered request", async () => {
+  const [executor, page, describe] = await Promise.all([
+    read("src/hooks/use-wallet-executor.ts"),
+    read("src/app/page.tsx"),
+    read("src/lib/wallet-request.ts"),
+  ]);
+
+  // The Telegram button only opens the app; the user must read the request and
+  // approve it here. Para signs headlessly, so this screen is the only place a
+  // Telegram user ever sees what they are signing.
+  assert.match(executor, /approve: \(\) => void/);
+  assert.match(executor, /reject: \(\) => void/);
+  assert.match(page, /onClick=\{execution\.approve\}/);
+  assert.match(page, /onClick=\{execution\.reject\}/);
+  assert.match(page, /describeRequest/);
+  assert.match(describe, /export function describeRequest/);
+
+  // sendTransaction must be reachable only from the approve callback.
+  const approveIndex = executor.indexOf("const approve = useCallback");
+  assert.ok(approveIndex > 0, "approve callback is present");
+  assert.ok(
+    executor.indexOf("sendTransaction") > approveIndex,
+    "sendTransaction is only called after the user approves",
+  );
 });

--- a/apps/telegram/tsconfig.json
+++ b/apps/telegram/tsconfig.json
@@ -18,6 +18,7 @@
       }
     ],
     "paths": {
+      "@aomi-labs/account/*": ["../../packages/account/src/*"],
       "@aomi-labs/client": ["../../packages/client/src/index.ts"],
       "@aomi-labs/client/*": ["../../packages/client/src/*"],
       "@/*": ["./src/*"]

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/account",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Server-only account graph: resolve-or-create the canonical user and mint AccountBearers. Node-only; never bundle into a browser.",
   "type": "module",
   "main": "./src/index.ts",
@@ -14,6 +14,7 @@
     "./better-auth/env": "./src/better-auth/env.ts",
     "./better-auth/siwe": "./src/better-auth/siwe.ts",
     "./providers": "./src/providers/index.ts",
+    "./telegram": "./src/telegram.ts",
     "./observability": "./src/observability.ts",
     "./widget-auth": "./src/widget-auth/index.ts"
   },

--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -6,6 +6,7 @@ export {
   ensureAccountSchema,
   deactivateAomiAccount,
   fetchAttestedProviderWallets,
+  claimTelegramSessionOwner,
   getAccountResponseForBetterAuthSession,
   getAccountResponseForWidgetSession,
   getOrCreateAomiUserForSiwe,

--- a/packages/account/src/db/queries.ts
+++ b/packages/account/src/db/queries.ts
@@ -60,6 +60,41 @@ export async function findAomiUserById(
   return result.rows[0] ? mapUser(result.rows[0]) : null;
 }
 
+/** Resolve the verified Telegram identity and claim an unowned runtime session
+ * for that same canonical user. A session already owned by anyone else is
+ * rejected, preventing a valid Telegram launch from crossing accounts. */
+export async function claimTelegramSessionOwner(input: {
+  sessionId: string;
+  telegramUserId: string;
+  db?: Db;
+}): Promise<AomiUserId | null> {
+  const db = input.db ?? getPool();
+  const result = await db.query(
+    `with telegram_owner as (
+       select ap.user_id
+         from auth_providers ap
+         join users u on u.id = ap.user_id
+        where ap.provider = 'telegram'
+          and ap.issuer_environment = 'aomi'
+          and ap.tenant_id = 'global'
+          and ap.subject = $2
+          and coalesce(u.status, '') <> 'deactivated'
+        limit 1
+     ), claimed as (
+       update threads t
+          set user_id = owner.user_id
+         from telegram_owner owner
+        where t.id = $1
+          and (t.user_id is null or t.user_id = owner.user_id)
+       returning t.user_id
+     )
+     select user_id from claimed`,
+    [input.sessionId, input.telegramUserId],
+  );
+  const userId = result.rows[0]?.user_id;
+  return typeof userId === "string" ? userId : null;
+}
+
 export async function createAomiUser(input: {
   userId?: AomiUserId;
   email?: string | null;

--- a/packages/account/src/service/account-service.ts
+++ b/packages/account/src/service/account-service.ts
@@ -10,6 +10,7 @@ import {
   deleteBetterAuthSiwsWallet,
   findAuthIdentityById,
   findAomiUserById,
+  claimTelegramSessionOwner as claimTelegramSessionOwnerQuery,
   findSignalOwner,
   findWalletById,
   listBetterAuthSiweWallets,
@@ -77,6 +78,14 @@ export async function ensureAccountSchema(): Promise<void> {
     });
   }
   await accountSchemaReady;
+}
+
+export async function claimTelegramSessionOwner(input: {
+  sessionId: string;
+  telegramUserId: string;
+}): Promise<AomiUserId | null> {
+  await ensureAccountSchema();
+  return claimTelegramSessionOwnerQuery(input);
 }
 
 export async function getOrCreateAomiUserForBetterAuthSession(input: {

--- a/packages/account/src/service/provider-exchange.ts
+++ b/packages/account/src/service/provider-exchange.ts
@@ -58,7 +58,11 @@ export type ProviderExchangeResult =
   | (SignalResolution & { status: "conflict" | "noop" });
 
 type ProviderLinkResult =
-  | { status: "linked"; user: DbAomiUser | null }
+  | {
+      status: "linked";
+      user: DbAomiUser | null;
+      identity: DbAomiAuthIdentity;
+    }
   | (SignalResolution & { status: "conflict" });
 
 type ProviderSignInResult =
@@ -116,7 +120,11 @@ export async function signInWithVerifiedProviderCredential(input: {
   });
   return resolution.status === "conflict"
     ? resolution
-    : { status: "linked", user: resolution.user };
+    : {
+        status: "linked",
+        user: resolution.user,
+        identity: resolution.identity,
+      };
 }
 
 export async function signInWithVerifiedProviderIdentity(input: {
@@ -174,7 +182,7 @@ export async function linkVerifiedProviderIdentityForUser(input: {
   await ensureAccountSchema();
   const wallets = [...(input.wallets ?? input.identity.walletAttestations)];
   try {
-    await attachVerifiedProviderIdentityToUser({
+    const identity = await attachVerifiedProviderIdentityToUser({
       userId: input.userId,
       identity: input.identity,
       policy: input.policy,
@@ -198,6 +206,7 @@ export async function linkVerifiedProviderIdentityForUser(input: {
     return {
       status: "linked",
       user: await findAomiUserById(input.userId),
+      identity,
     };
   } catch (error) {
     return providerConflict(error);

--- a/packages/account/src/telegram.ts
+++ b/packages/account/src/telegram.ts
@@ -58,8 +58,13 @@ function telegramUserId(fields: URLSearchParams): string | null {
 export function verifyTelegramInitData(
   initData: string,
   botId: string,
-  now = Date.now(),
+  options: {
+    now?: number;
+    /** Test-only override. Production always verifies against Telegram's key. */
+    publicKeyHex?: string;
+  } = {},
 ): TelegramLaunchVerification {
+  const now = options.now ?? Date.now();
   if (!initData || !/^\d+$/.test(botId)) {
     return { ok: false, reason: "malformed" };
   }
@@ -87,7 +92,7 @@ export function verifyTelegramInitData(
   const publicKey = createPublicKey({
     key: Buffer.concat([
       SPKI_ED25519_PREFIX,
-      Buffer.from(TELEGRAM_PUBLIC_KEY, "hex"),
+      Buffer.from(options.publicKeyHex ?? TELEGRAM_PUBLIC_KEY, "hex"),
     ]),
     format: "der",
     type: "spki",

--- a/packages/account/test/canonical-queries.test.ts
+++ b/packages/account/test/canonical-queries.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   countLoginFactors,
+  claimTelegramSessionOwner,
   revokeAuthIdentity,
   updateWalletLabel,
   upsertWallet,
@@ -30,6 +31,25 @@ function fakeDb(
 }
 
 describe("canonical account queries", () => {
+  it("resolves a Telegram session only through the same canonical owner", async () => {
+    const { db, calls } = fakeDb(() => ({
+      rows: [{ user_id: "canonical-user" }],
+    }));
+
+    await expect(
+      claimTelegramSessionOwner({
+        sessionId: "thread-1",
+        telegramUserId: "12345",
+        db: db as never,
+      }),
+    ).resolves.toBe("canonical-user");
+    expect(calls[0]?.params).toEqual(["thread-1", "12345"]);
+    expect(calls[0]?.sql).toContain("from auth_providers");
+    expect(calls[0]?.sql).toContain("ap.provider = 'telegram'");
+    expect(calls[0]?.sql).toContain("update threads");
+    expect(calls[0]?.sql).toContain("t.user_id is null");
+  });
+
   it("counts independent auth providers instead of provider-owned child wallets", async () => {
     const { db, calls } = fakeDb(() => ({
       rows: [{ count: 1 }],

--- a/packages/account/test/telegram.test.ts
+++ b/packages/account/test/telegram.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment node
+import { generateKeyPairSync, sign as signEd25519 } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { verifyTelegramInitData } from "../src/telegram";
+
+// A throwaway Ed25519 pair stands in for Telegram's, so these tests exercise
+// the real signature path rather than only its rejection branches.
+const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+const publicKeyHex = publicKey
+  .export({ format: "der", type: "spki" })
+  .subarray(-32)
+  .toString("hex");
+
+const BOT_ID = "8761674214";
+const NOW = 1_800_000_000_000;
+const AUTH_DATE = 1_800_000_000;
+
+/** Builds a launch payload signed the way Telegram signs one: the data-check
+ *  string is prefixed with the bot id, so a signature is only ever valid for
+ *  the bot it was minted for. */
+function signedInitData(
+  input: {
+    authDate?: number;
+    botId?: string;
+    extraFields?: Record<string, string>;
+    signWith?: typeof privateKey;
+    user?: unknown;
+  } = {},
+): string {
+  const fields: Record<string, string> = {
+    auth_date: String(input.authDate ?? AUTH_DATE),
+    query_id: "AAExampleQueryId",
+    user: JSON.stringify(input.user ?? { id: 456, username: "ada" }),
+    ...input.extraFields,
+  };
+
+  const checkString = `${input.botId ?? BOT_ID}:WebAppData\n${Object.keys(fields)
+    .sort()
+    .map((key) => `${key}=${fields[key]}`)
+    .join("\n")}`;
+
+  const params = new URLSearchParams(fields);
+  params.set("hash", "unused-by-third-party-validation");
+  params.set(
+    "signature",
+    signEd25519(
+      null,
+      Buffer.from(checkString),
+      input.signWith ?? privateKey,
+    ).toString("base64url"),
+  );
+  return params.toString();
+}
+
+function verify(initData: string, botId = BOT_ID) {
+  return verifyTelegramInitData(initData, botId, { now: NOW, publicKeyHex });
+}
+
+describe("Telegram Mini App launch verification", () => {
+  it("accepts a launch signed for the claimed bot", () => {
+    expect(verify(signedInitData())).toEqual({
+      ok: true,
+      launch: { botId: BOT_ID, telegramUserId: "456", startParam: undefined },
+    });
+  });
+
+  it("carries start_param through as the session hint", () => {
+    const result = verify(
+      signedInitData({ extraFields: { start_param: "thread-1" } }),
+    );
+
+    expect(result.ok && result.launch.startParam).toBe("thread-1");
+  });
+
+  it("rejects a launch replayed under a different bot id", () => {
+    // The bot id is part of the signed check string, so one builder cannot take
+    // another builder's launch payload and present it as their own.
+    expect(verify(signedInitData(), "9999999999")).toEqual({
+      ok: false,
+      reason: "bad_signature",
+    });
+  });
+
+  it("rejects a signature minted by anyone but Telegram", () => {
+    const { privateKey: attackerKey } = generateKeyPairSync("ed25519");
+
+    expect(verify(signedInitData({ signWith: attackerKey }))).toEqual({
+      ok: false,
+      reason: "bad_signature",
+    });
+  });
+
+  it("rejects tampered user data", () => {
+    const params = new URLSearchParams(signedInitData());
+    params.set("user", JSON.stringify({ id: 1, username: "mallory" }));
+
+    expect(verify(params.toString())).toEqual({
+      ok: false,
+      reason: "bad_signature",
+    });
+  });
+
+  it("rejects a non-numeric bot id", () => {
+    expect(verify(signedInitData(), "bot-123")).toEqual({
+      ok: false,
+      reason: "malformed",
+    });
+  });
+
+  it("requires Telegram's third-party signature", () => {
+    const params = new URLSearchParams(signedInitData());
+    params.delete("signature");
+
+    expect(verify(params.toString())).toEqual({
+      ok: false,
+      reason: "missing_signature",
+    });
+  });
+
+  it("rejects stale signed launch data before account exchange", () => {
+    expect(verify(signedInitData({ authDate: 1_700_000_000 }))).toEqual({
+      ok: false,
+      reason: "expired",
+    });
+  });
+
+  it("rejects launch data dated beyond the allowed clock skew", () => {
+    expect(verify(signedInitData({ authDate: AUTH_DATE + 3600 }))).toEqual({
+      ok: false,
+      reason: "expired",
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -845,6 +845,9 @@ importers:
 
   apps/telegram:
     dependencies:
+      '@aomi-labs/account':
+        specifier: workspace:*
+        version: link:../../packages/account
       '@aomi-labs/client':
         specifier: workspace:*
         version: link:../../packages/client

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,9 +34,10 @@ export default defineConfig({
     include: [
       "packages/**/*.{test,spec}.{ts,tsx,mjs,cjs,js,jsx}",
       "apps/build/src/**/*.{test,spec}.{ts,tsx}",
+      "apps/telegram/src/**/*.{test,spec}.{ts,tsx}",
       "apps/portal/src/{app,server}/mcp/**/*.{test,spec}.{ts,tsx}",
       "apps/portal/src/lib/widget-auth/**/*.{test,spec}.{ts,tsx}",
-      "apps/portal/src/app/api/*/route.{test,spec}.{ts,tsx}",
+      "apps/portal/src/app/api/**/route.{test,spec}.{ts,tsx}",
     ],
     exclude: [".claude/**", "**/.claude/**", "**/node_modules/**", "dist/**"],
     restoreMocks: true,


### PR DESCRIPTION
## Summary
- serve the clean Para Telegram Mini App and canonical Portal exchange
- verify Telegram launch ownership before binding the Para identity
- render complete transaction/EIP-712 approval details and wait for mined receipts
- keep BotFather commands on the agreed `/thread`, `/wallet`, `/permission`, `/tx`, `/app`, `/model`, `/network`, and `/disconnect` contract

## Verification
- `pnpm --filter telegram check`
- account: 98 tests passed
- portal: 366 tests passed
- browser: Para modal opened on the production build at `127.0.0.1:3100`
- BFF runtime: OPTIONS 204 and malformed POST 400 at `127.0.0.1:3101`
- regression: Para and the app resolve one React Query context

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788645702&installation_model_id=12362&pr_number=461&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F461&signature=09a7135b3712d0c8455206bbc4a5e9ece7f7d35eec4c48563b1cc705f667e090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->