### PR TITLE
Refresh source revision when retrying deploy

### DIFF
--- a/apps/build/src/features/launch/components/deploy-step.test.tsx
+++ b/apps/build/src/features/launch/components/deploy-step.test.tsx
@@ -180,6 +180,42 @@ describe("DeployStep", () => {
     ).toBeInTheDocument();
   });
 
+  it("clears the pinned source revision before retrying", async () => {
+    const onProgress = vi.fn();
+    vi.mocked(launchPreflight).mockRejectedValueOnce(new Error("stale source"));
+    render(
+      <DeployStep
+        {...defaultProps}
+        progress={{
+          ...baseProgress(),
+          projectId: 42,
+          sourceRef: "old-commit",
+          deployment: {
+            id: "preview",
+            status: "preflight",
+            source: { ref: "old-commit" },
+            platform: { apps: [] },
+          } as LaunchDeployPayload,
+        }}
+        onProgress={onProgress}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Preflight" }));
+    await screen.findByText("stale source");
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(onProgress).toHaveBeenLastCalledWith({
+      deployment: undefined,
+      deploymentId: undefined,
+      sourceRef: undefined,
+      releaseTags: undefined,
+      apps: undefined,
+      live: false,
+    });
+    expect(screen.getByText(/Run a preflight/)).toBeInTheDocument();
+  });
+
   it("shows the required-secrets banner and keeps Activate disabled when the target app is missing one", () => {
     const detail = {
       hasMissingSecrets: (app: string) => app === "binance",

--- a/apps/build/src/features/launch/components/deploy-step.tsx
+++ b/apps/build/src/features/launch/components/deploy-step.tsx
@@ -627,11 +627,19 @@ export function DeployStep({
     lastCompletedRef.current = 0;
     setProgressModel(null);
     setVerifyAttempt(0);
+    setDeployment(undefined);
     setDeploymentId(undefined);
-    onProgress({ deploymentId: undefined, live: false });
-    setPhase(deployment ? "preflight_ready" : "idle");
+    onProgress({
+      deployment: undefined,
+      deploymentId: undefined,
+      sourceRef: undefined,
+      releaseTags: undefined,
+      apps: undefined,
+      live: false,
+    });
+    setPhase("idle");
     onReset?.();
-  }, [deployment, onProgress, onReset]);
+  }, [onProgress, onReset]);
 
   if (phase === "error") {
     return (


### PR DESCRIPTION
## Summary
- clear the pinned immutable source revision and stale preflight snapshot when a failed deployment is retried
- force the next preflight to resolve the repository's current default-branch head
- cover the regression where a generated repository is repaired after its first preflight failed

## Verification
- `pnpm --filter aomi-build exec vitest run src/features/launch/components/deploy-step.test.tsx` (12 passed)
- `pnpm --filter aomi-build type-check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788667180&installation_model_id=12362&pr_number=463&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F463&signature=ca6c2e00184828708701b65a99330bbf1e4ac4f7da9bf848ed58183ed3a35fce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->