### PR TITLE
Keep Build project views platform-scoped

### DIFF
--- a/apps/build/src/app/(control-plane)/operate/deployments/page.tsx
+++ b/apps/build/src/app/(control-plane)/operate/deployments/page.tsx
@@ -1,12 +1,18 @@
 import { Suspense } from "react";
 import { ErrorBoundary } from "@build/components/shell/error-boundary";
 import { OperateDeployments } from "@build/features/launch/components/deployments/operate-deployments";
+import { platformParam } from "@build/features/launch/platform";
 
-export default function OperateDeploymentsPage() {
+export default async function OperateDeploymentsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ platform?: string | string[] }>;
+}) {
+  const { platform } = await searchParams;
   return (
     <ErrorBoundary>
       <Suspense fallback={null}>
-        <OperateDeployments />
+        <OperateDeployments platform={platformParam(platform)} />
       </Suspense>
     </ErrorBoundary>
   );

--- a/apps/build/src/app/(control-plane)/overview/page.tsx
+++ b/apps/build/src/app/(control-plane)/overview/page.tsx
@@ -1,5 +1,11 @@
 import { OverviewDashboard } from "@build/features/overview/overview-dashboard";
+import { platformParam } from "@build/features/launch/platform";
 
-export default function OverviewPage() {
-  return <OverviewDashboard />;
+export default async function OverviewPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ platform?: string | string[] }>;
+}) {
+  const { platform } = await searchParams;
+  return <OverviewDashboard platform={platformParam(platform)} />;
 }

--- a/apps/build/src/components/control-plane/command-palette.test.tsx
+++ b/apps/build/src/components/control-plane/command-palette.test.tsx
@@ -69,7 +69,7 @@ describe("CommandPalette", () => {
     await screen.findByRole("dialog", { name: /command palette/i });
 
     fireEvent.click(screen.getByRole("button", { name: /^last project\b/i }));
-    expect(push).toHaveBeenCalledWith("/projects/42");
+    expect(push).toHaveBeenCalledWith("/projects/42?platform=community");
 
     push.mockClear();
     openCommandPalette();
@@ -77,7 +77,9 @@ describe("CommandPalette", () => {
     fireEvent.click(
       screen.getByRole("button", { name: /^environment \/ secrets\b/i }),
     );
-    expect(push).toHaveBeenCalledWith("/projects/42?tab=environment");
+    expect(push).toHaveBeenCalledWith(
+      "/projects/42?tab=environment&platform=community",
+    );
 
     push.mockClear();
     openCommandPalette();

--- a/apps/build/src/components/control-plane/prefetch-control-plane-route.ts
+++ b/apps/build/src/components/control-plane/prefetch-control-plane-route.ts
@@ -11,6 +11,7 @@ import {
   buildQueryKeys,
   buildQueryStaleTime,
 } from "@build/features/launch/query-keys";
+import { platformParam } from "@build/features/launch/platform";
 import {
   modelKeysFetch,
   operateAppDetailFetch,
@@ -90,9 +91,10 @@ export function prefetchControlPlaneRoute(
   }
 
   if (path === "/projects") {
+    const platform = platformParam(searchParams.get("platform") ?? undefined);
     void queryClient.prefetchQuery({
-      queryKey: buildQueryKeys.projects(accountKey),
-      queryFn: () => deploymentProjects(),
+      queryKey: buildQueryKeys.projects(accountKey, platform),
+      queryFn: () => deploymentProjects(platform),
       staleTime: buildQueryStaleTime.projects,
       retry: false,
     });
@@ -106,16 +108,17 @@ export function prefetchControlPlaneRoute(
   }
 
   if (path === "/overview" || path === "/operate/deployments") {
+    const platform = platformParam(searchParams.get("platform") ?? undefined);
     void queryClient.prefetchQuery({
-      queryKey: buildQueryKeys.projects(accountKey),
-      queryFn: () => deploymentProjects(),
+      queryKey: buildQueryKeys.projects(accountKey, platform),
+      queryFn: () => deploymentProjects(platform),
       staleTime: buildQueryStaleTime.projects,
       retry: false,
     });
     void queryClient.prefetchInfiniteQuery({
-      queryKey: buildQueryKeys.deployments(accountKey),
+      queryKey: buildQueryKeys.deployments(accountKey, platform),
       queryFn: ({ pageParam }) =>
-        deploymentFeed({ limit: 50, cursor: pageParam }),
+        deploymentFeed({ platform, limit: 50, cursor: pageParam }),
       initialPageParam: null,
       staleTime: buildQueryStaleTime.deployments,
       retry: false,

--- a/apps/build/src/features/launch/client.ts
+++ b/apps/build/src/features/launch/client.ts
@@ -118,6 +118,7 @@ export function deploymentHistory(input: {
 }
 
 export function deploymentFeed(input: {
+  platform?: string;
   limit?: number;
   cursor?: DeploymentFeedResult["nextCursor"];
 }): Promise<DeploymentFeedResult> {

--- a/apps/build/src/features/launch/components/deployments/global-deployments-list.test.tsx
+++ b/apps/build/src/features/launch/components/deployments/global-deployments-list.test.tsx
@@ -9,7 +9,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("./use-global-deployment-records", () => ({
-  useGlobalDeploymentRecords: () => ({
+  useGlobalDeploymentRecords: vi.fn(() => ({
     projectsState: {
       status: "ready",
       projects: [
@@ -41,14 +41,14 @@ vi.mock("./use-global-deployment-records", () => ({
     loadMore: vi.fn(),
     hasMore: false,
     loadingMore: false,
-  }),
+  })),
 }));
 
 import { GlobalDeploymentsList } from "./global-deployments-list";
 
 describe("GlobalDeploymentsList", () => {
   it("renders all deployment records read-only", () => {
-    render(<GlobalDeploymentsList />);
+    render(<GlobalDeploymentsList platform="world-market-apps" />);
 
     expect(screen.getByText("dep_1_alice-bot_abc123")).toBeInTheDocument();
     expect(screen.getAllByText("alice/bot").length).toBeGreaterThan(0);
@@ -59,7 +59,7 @@ describe("GlobalDeploymentsList", () => {
       screen.getByRole("link", { name: /view deployment/i }),
     ).toHaveAttribute(
       "href",
-      "/operate/deployments?project=42&deployment=dep_1_alice-bot_abc123",
+      "/operate/deployments?platform=world-market-apps&project=42&deployment=dep_1_alice-bot_abc123",
     );
   });
 });

--- a/apps/build/src/features/launch/components/deployments/global-deployments-list.tsx
+++ b/apps/build/src/features/launch/components/deployments/global-deployments-list.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Filter, RefreshCw, Rocket } from "lucide-react";
 import { EmptyState } from "@build/components/control-plane/empty-state";
+import { platformHref } from "@build/features/launch/platform";
 import { useGlobalDeploymentRecords } from "./use-global-deployment-records";
 import { ErrorPanel, GitHubSignInPanel, LoadingPanel } from "./ui/state-panels";
 
@@ -12,7 +13,23 @@ function formatDate(seconds: number) {
   return new Date(seconds * 1000).toLocaleString();
 }
 
-function DeploymentsPageHeader({ onReload }: { onReload: () => void }) {
+function deploymentsHref(
+  platform: string,
+  values: { project?: string; deployment?: string } = {},
+) {
+  const params = new URLSearchParams({ platform });
+  if (values.project) params.set("project", values.project);
+  if (values.deployment) params.set("deployment", values.deployment);
+  return `/operate/deployments?${params}`;
+}
+
+function DeploymentsPageHeader({
+  platform,
+  onReload,
+}: {
+  platform: string;
+  onReload: () => void;
+}) {
   return (
     <header className="flex flex-wrap items-start justify-between gap-4">
       <div className="min-w-0">
@@ -23,7 +40,7 @@ function DeploymentsPageHeader({ onReload }: { onReload: () => void }) {
           </h1>
         </div>
         <p className="text-dim mt-1.5 max-w-3xl text-sm leading-5">
-          Deployment history across all projects.
+          Deployment history for projects on {platform}.
         </p>
       </div>
       <div className="flex shrink-0 items-center gap-2">
@@ -36,7 +53,7 @@ function DeploymentsPageHeader({ onReload }: { onReload: () => void }) {
           Refresh
         </button>
         <Link
-          href="/operate/deployments/new"
+          href={platformHref("/operate/deployments/new", platform)}
           prefetch={false}
           className="bg-primary text-primary-foreground inline-flex h-8 items-center justify-center rounded-md px-3 text-sm font-medium hover:opacity-90"
         >
@@ -47,7 +64,7 @@ function DeploymentsPageHeader({ onReload }: { onReload: () => void }) {
   );
 }
 
-export function GlobalDeploymentsList() {
+export function GlobalDeploymentsList({ platform }: { platform: string }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const {
@@ -58,7 +75,7 @@ export function GlobalDeploymentsList() {
     loadMore,
     hasMore,
     loadingMore,
-  } = useGlobalDeploymentRecords();
+  } = useGlobalDeploymentRecords(platform);
   const [query, setQuery] = useState("");
   const [status, setStatus] = useState<"all" | "current" | "previous">("all");
   const projectParam = searchParams.get("project");
@@ -117,7 +134,7 @@ export function GlobalDeploymentsList() {
   if (projectsState.status !== "ready") {
     return (
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
-        <DeploymentsPageHeader onReload={reload} />
+        <DeploymentsPageHeader platform={platform} onReload={reload} />
         {projectsState.status === "loading" ? (
           <LoadingPanel label="Loading projects…" />
         ) : projectsState.status === "signed_out" ? (
@@ -132,7 +149,7 @@ export function GlobalDeploymentsList() {
   return (
     <main className="bg-background text-foreground min-h-screen">
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
-        <DeploymentsPageHeader onReload={reload} />
+        <DeploymentsPageHeader platform={platform} onReload={reload} />
 
         <div className="border-border bg-surface-1 rounded-lg border">
           <div className="border-border flex flex-wrap items-center gap-2 border-b px-4 py-3">
@@ -143,9 +160,9 @@ export function GlobalDeploymentsList() {
                 const value = event.target.value;
                 setSourceFilter(value);
                 if (value !== "all") {
-                  router.push(`/operate/deployments?project=${value}`);
+                  router.push(deploymentsHref(platform, { project: value }));
                 } else {
-                  router.push("/operate/deployments");
+                  router.push(deploymentsHref(platform));
                 }
               }}
               className="border-border bg-surface-1 h-8 rounded-md border px-2 text-sm"
@@ -201,7 +218,10 @@ export function GlobalDeploymentsList() {
                 </div>
                 <div className="flex shrink-0 items-center gap-2">
                   <Link
-                    href={`/projects/${selectedDeployment.projectId}`}
+                    href={platformHref(
+                      `/projects/${selectedDeployment.projectId}`,
+                      platform,
+                    )}
                     prefetch={false}
                     className="border-border bg-surface-1 hover:bg-accent-hover inline-flex h-8 items-center rounded-md border px-3 text-xs font-medium"
                   >
@@ -210,8 +230,8 @@ export function GlobalDeploymentsList() {
                   <Link
                     href={
                       projectParam
-                        ? `/operate/deployments?project=${projectParam}`
-                        : "/operate/deployments"
+                        ? deploymentsHref(platform, { project: projectParam })
+                        : deploymentsHref(platform)
                     }
                     prefetch={false}
                     className="border-border bg-surface-1 hover:bg-accent-hover inline-flex h-8 items-center rounded-md border px-3 text-xs font-medium"
@@ -233,7 +253,7 @@ export function GlobalDeploymentsList() {
               <EmptyState
                 title="No deployments yet"
                 description="Deploy an app from a connected project to see history here."
-                actionHref="/operate/deployments/new"
+                actionHref={platformHref("/operate/deployments/new", platform)}
                 actionLabel="New app"
               />
             ) : (
@@ -247,7 +267,10 @@ export function GlobalDeploymentsList() {
               {filtered.map((deployment) => (
                 <Link
                   key={`${deployment.projectId}-${deployment.deploymentId}`}
-                  href={`/operate/deployments?project=${deployment.projectId}&deployment=${encodeURIComponent(deployment.deploymentId)}`}
+                  href={deploymentsHref(platform, {
+                    project: String(deployment.projectId),
+                    deployment: deployment.deploymentId,
+                  })}
                   prefetch={false}
                   className="hover:bg-accent-hover grid min-h-[76px] grid-cols-[minmax(0,1fr)_auto] items-center gap-4 px-4 py-3"
                 >

--- a/apps/build/src/features/launch/components/deployments/operate-deployments.tsx
+++ b/apps/build/src/features/launch/components/deployments/operate-deployments.tsx
@@ -2,6 +2,6 @@
 
 import { GlobalDeploymentsList } from "./global-deployments-list";
 
-export function OperateDeployments() {
-  return <GlobalDeploymentsList />;
+export function OperateDeployments({ platform }: { platform: string }) {
+  return <GlobalDeploymentsList platform={platform} />;
 }

--- a/apps/build/src/features/launch/components/deployments/project-index.test.tsx
+++ b/apps/build/src/features/launch/components/deployments/project-index.test.tsx
@@ -41,7 +41,7 @@ describe("ProjectIndex", () => {
     await waitFor(() =>
       expect(screen.getByRole("link", { name: /alice\/bot/ })).toHaveAttribute(
         "href",
-        "/projects/3",
+        "/projects/3?platform=somm.finance",
       ),
     );
     expect(useProjects).toHaveBeenCalledWith("somm.finance");

--- a/apps/build/src/features/launch/components/deployments/project-index.tsx
+++ b/apps/build/src/features/launch/components/deployments/project-index.tsx
@@ -82,6 +82,7 @@ export function ProjectIndex({
             <div className="text-sm font-medium">Projects</div>
             <div className="text-dim text-xs">
               {state.status === "ready" ? state.projects.length : 0}
+              {platform ? ` on ${platform}` : ""}
             </div>
           </div>
           {state.status === "loading" && (
@@ -105,7 +106,7 @@ export function ProjectIndex({
                 key={source.id}
                 source={source}
                 requiredSdk={requiredSdk}
-                href={`/projects/${source.id}`}
+                href={platformHref(`/projects/${source.id}`, platform)}
               />
             ))}
         </div>

--- a/apps/build/src/features/launch/components/deployments/project-page.test.tsx
+++ b/apps/build/src/features/launch/components/deployments/project-page.test.tsx
@@ -43,6 +43,7 @@ vi.mock("@build/features/launch/hooks/use-project-detail", () => ({
       source: {
         id: 1,
         repositoryLink: "a/b",
+        platformName: "somm.finance",
         apps: [],
         latestDeployment: null,
         installationId: 5,
@@ -120,6 +121,8 @@ describe("ProjectPage", () => {
 
     expect(useProjectDetail).toHaveBeenCalledWith(1);
     fireEvent.click(screen.getByRole("tab", { name: /^deployments$/i }));
-    expect(push).toHaveBeenCalledWith("/projects/1?tab=deployments");
+    expect(push).toHaveBeenCalledWith(
+      "/projects/1?tab=deployments&platform=somm.finance",
+    );
   });
 });

--- a/apps/build/src/features/launch/components/deployments/project-page.tsx
+++ b/apps/build/src/features/launch/components/deployments/project-page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams, useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { prefetchProjectDetail } from "@build/components/control-plane/prefetch-control-plane-route";
 import { useProjectDetail } from "@build/features/launch/hooks/use-project-detail";
+import { platformHref } from "@build/features/launch/platform";
 import { setLastProjectId } from "@build/lib/last-project";
 import { ProjectHeader } from "./project-header";
 import { ChatTab } from "./tabs/chat-tab";
@@ -50,7 +51,10 @@ export function ProjectPage({
     const params = new URLSearchParams();
     if (!tabBaseHref) params.set("project", String(projectId));
     params.set("tab", tab);
-    return `${tabBaseHref ?? "/operate/deployments"}?${params}`;
+    return platformHref(
+      `${tabBaseHref ?? "/operate/deployments"}?${params}`,
+      detail.source?.platformName,
+    );
   };
   const openEnvironment = () => router.push(projectTabHref("environment"));
   const queryClient = useQueryClient();
@@ -80,7 +84,7 @@ export function ProjectPage({
         source={detail.source}
         latest={detail.source?.latestDeployment ?? null}
         onRefresh={detail.reload}
-        backHref={backHref}
+        backHref={platformHref(backHref, detail.source?.platformName)}
         backLabel={backLabel}
       />
       <div className="mx-auto w-full max-w-5xl px-4 py-6 sm:px-6">

--- a/apps/build/src/features/launch/components/deployments/tabs/environment-card.test.ts
+++ b/apps/build/src/features/launch/components/deployments/tabs/environment-card.test.ts
@@ -30,7 +30,10 @@ describe("environmentCard", () => {
   it("does not warn for a source with no apps at all", () => {
     const card = environmentCard(base);
 
-    expect(card).toMatchObject({ value: "No keys required", tone: "good" });
+    expect(card).toMatchObject({ value: "No apps yet", tone: "neutral" });
+    expect(card.hint).toBe(
+      "Deploy an app before configuring its environment keys.",
+    );
     expect(card.blocked).toBe(false);
   });
 
@@ -146,7 +149,14 @@ describe("environmentCard", () => {
   });
 
   it("waits for the configured keys too", () => {
-    const card = environmentCard({ ...base, secretsByApp: null });
+    const card = environmentCard({
+      ...base,
+      apps: ["somm-agent"],
+      requiredSecrets: {
+        "somm-agent": { applicationId: 11, slots: [], missing: [] },
+      },
+      secretsByApp: null,
+    });
 
     expect(card).toMatchObject({ value: "Loading…", tone: "neutral" });
   });

--- a/apps/build/src/features/launch/components/deployments/tabs/environment-card.ts
+++ b/apps/build/src/features/launch/components/deployments/tabs/environment-card.ts
@@ -38,6 +38,15 @@ export function environmentCard({
 }): EnvironmentCard {
   const glossary = BUILD_GLOSSARY.environment.meaning;
 
+  if (apps.length === 0) {
+    return {
+      value: "No apps yet",
+      hint: "Deploy an app before configuring its environment keys.",
+      tone: "neutral",
+      blocked: false,
+    };
+  }
+
   // An error is worth reporting on its own terms — saying "keys missing"
   // because a read failed would send the user looking for a key that is fine.
   const error = requiredSecretsError ?? secretsError;

--- a/apps/build/src/features/launch/components/deployments/tabs/home-tab.test.tsx
+++ b/apps/build/src/features/launch/components/deployments/tabs/home-tab.test.tsx
@@ -78,8 +78,7 @@ describe("HomeTab", () => {
     expect(loadRequiredSecrets).toHaveBeenCalled();
     expect(screen.getByText("Project home")).toBeInTheDocument();
     expect(screen.getByText("Not live")).toBeInTheDocument();
-    // Nothing declares a required key here, so this is not a fault.
-    expect(screen.getByText("No keys required")).toBeInTheDocument();
+    expect(screen.getByText("No apps yet")).toBeInTheDocument();
     expect(screen.queryByText("Keys missing")).not.toBeInTheDocument();
     expect(
       await screen.findByRole("link", {

--- a/apps/build/src/features/launch/components/deployments/use-global-deployment-records.test.tsx
+++ b/apps/build/src/features/launch/components/deployments/use-global-deployment-records.test.tsx
@@ -50,7 +50,10 @@ vi.mock("@build/features/launch/dashboard", () => ({
 }));
 
 import { GitHubSessionProvider } from "@build/components/control-plane/github-session-context";
-import { deploymentFeed } from "@build/features/launch/client";
+import {
+  deploymentFeed,
+  deploymentProjects,
+} from "@build/features/launch/client";
 import { useGlobalDeploymentRecords } from "./use-global-deployment-records";
 
 function wrapper(client = new QueryClient()) {
@@ -66,16 +69,23 @@ function wrapper(client = new QueryClient()) {
 describe("useGlobalDeploymentRecords", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("loads one global feed regardless of source or app count", async () => {
-    const { result } = renderHook(() => useGlobalDeploymentRecords(), {
-      wrapper: wrapper(),
-    });
+  it("loads one platform feed regardless of project or app count", async () => {
+    const { result } = renderHook(
+      () => useGlobalDeploymentRecords("community"),
+      {
+        wrapper: wrapper(),
+      },
+    );
 
     await waitFor(() =>
       expect(result.current.recordsState.status).toBe("ready"),
     );
     expect(deploymentFeed).toHaveBeenCalledTimes(1);
-    expect(deploymentFeed).toHaveBeenCalledWith({ limit: 50, cursor: null });
+    expect(deploymentFeed).toHaveBeenCalledWith({
+      platform: "community",
+      limit: 50,
+      cursor: null,
+    });
     expect(
       result.current.recordsState.status === "ready"
         ? result.current.recordsState.deployments
@@ -96,7 +106,7 @@ describe("useGlobalDeploymentRecords", () => {
   it("reuses cached records after the page hook remounts", async () => {
     const client = new QueryClient();
     const sharedWrapper = wrapper(client);
-    const first = renderHook(() => useGlobalDeploymentRecords(), {
+    const first = renderHook(() => useGlobalDeploymentRecords("community"), {
       wrapper: sharedWrapper,
     });
     await waitFor(() =>
@@ -104,12 +114,42 @@ describe("useGlobalDeploymentRecords", () => {
     );
     first.unmount();
 
-    const second = renderHook(() => useGlobalDeploymentRecords(), {
+    const second = renderHook(() => useGlobalDeploymentRecords("community"), {
       wrapper: sharedWrapper,
     });
     await waitFor(() =>
       expect(second.result.current.recordsState.status).toBe("ready"),
     );
     expect(deploymentFeed).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the selected platform for both project and deployment totals", async () => {
+    vi.mocked(deploymentProjects).mockResolvedValueOnce({
+      projects: [],
+    } as never);
+    vi.mocked(deploymentFeed).mockResolvedValueOnce({
+      deployments: [],
+      nextCursor: null,
+    });
+    const { result } = renderHook(
+      () => useGlobalDeploymentRecords("world-market-apps"),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() =>
+      expect(result.current.recordsState.status).toBe("ready"),
+    );
+    expect(deploymentProjects).toHaveBeenCalledWith("world-market-apps");
+    expect(deploymentFeed).toHaveBeenCalledWith({
+      platform: "world-market-apps",
+      limit: 50,
+      cursor: null,
+    });
+    expect(result.current.projects).toEqual([]);
+    expect(
+      result.current.recordsState.status === "ready"
+        ? result.current.recordsState.deployments
+        : [],
+    ).toEqual([]);
   });
 });

--- a/apps/build/src/features/launch/components/deployments/use-global-deployment-records.ts
+++ b/apps/build/src/features/launch/components/deployments/use-global-deployment-records.ts
@@ -43,14 +43,15 @@ function globalDeployment(deployment: UserDeployment): GlobalDeployment | null {
   };
 }
 
-export function useGlobalDeploymentRecords() {
-  const { state: projectsState, reload: reloadProjects } = useProjects();
+export function useGlobalDeploymentRecords(platform: string) {
+  const { state: projectsState, reload: reloadProjects } =
+    useProjects(platform);
   const { account } = useGitHubSession();
   const accountKey = githubAccountKey(account.githubLogin);
   const feed = useInfiniteQuery({
-    queryKey: buildQueryKeys.deployments(accountKey ?? "unavailable"),
+    queryKey: buildQueryKeys.deployments(accountKey ?? "unavailable", platform),
     queryFn: ({ pageParam }) =>
-      deploymentFeed({ limit: 50, cursor: pageParam }),
+      deploymentFeed({ platform, limit: 50, cursor: pageParam }),
     initialPageParam: null as UserDeploymentsCursor | null,
     getNextPageParam: (page) => page.nextCursor ?? undefined,
     enabled: account.signedIn && accountKey !== null,

--- a/apps/build/src/features/launch/platform.test.ts
+++ b/apps/build/src/features/launch/platform.test.ts
@@ -21,21 +21,31 @@ describe("platformParam", () => {
 });
 
 describe("platformHref", () => {
-  it("re-attaches the platform only before a Project exists", () => {
+  it("re-attaches the platform to project and deployment navigation", () => {
     expect(platformHref("/projects", "somm.finance")).toBe(
       "/projects?platform=somm.finance",
     );
     expect(platformHref("/operate/deployments/new", "somm.finance")).toBe(
       "/operate/deployments/new?platform=somm.finance",
     );
+    expect(platformHref("/overview", "somm.finance")).toBe(
+      "/overview?platform=somm.finance",
+    );
+    expect(platformHref("/operate/deployments", "somm.finance")).toBe(
+      "/operate/deployments?platform=somm.finance",
+    );
+    expect(platformHref("/projects/3", "somm.finance")).toBe(
+      "/projects/3?platform=somm.finance",
+    );
+    expect(platformHref("/projects/3?tab=environment", "somm.finance")).toBe(
+      "/projects/3?tab=environment&platform=somm.finance",
+    );
   });
 
   it("leaves routes that are not platform-scoped alone", () => {
     for (const href of [
-      "/overview",
       "/settings/general",
       "/build",
-      "/projects/3",
       "/integrations",
       "/operate/bots",
     ]) {
@@ -43,9 +53,9 @@ describe("platformHref", () => {
     }
   });
 
-  it("does not double-append or invent a platform", () => {
+  it("replaces an existing scope and never invents one", () => {
     expect(platformHref("/projects?platform=a", "b")).toBe(
-      "/projects?platform=a",
+      "/projects?platform=b",
     );
     expect(platformHref("/projects", null)).toBe("/projects");
     expect(platformHref("/projects", undefined)).toBe("/projects");

--- a/apps/build/src/features/launch/platform.ts
+++ b/apps/build/src/features/launch/platform.ts
@@ -46,11 +46,18 @@ export function platformParam(value: string | string[] | undefined): string {
 }
 
 /**
- * Routes where the user chooses a platform before a Project exists. Project
- * detail and account-wide operate routes resolve it from the canonical Project.
+ * Routes whose navigation stays inside one platform. Project detail still
+ * derives authority from the canonical Project; carrying the query here keeps
+ * surrounding links and the return path in the same visible scope.
  */
 function isPlatformScoped(href: string): boolean {
-  return href === "/projects" || href === "/operate/deployments/new";
+  return (
+    href === "/overview" ||
+    href === "/projects" ||
+    href.startsWith("/projects/") ||
+    href === "/operate/deployments" ||
+    href === "/operate/deployments/new"
+  );
 }
 
 /** Re-attach the active platform to a platform-scoped href. */
@@ -58,6 +65,10 @@ export function platformHref(
   href: string,
   platform: string | null | undefined,
 ): string {
-  if (!platform || href.includes("?") || !isPlatformScoped(href)) return href;
-  return `${href}?platform=${encodeURIComponent(platform)}`;
+  if (!platform) return href;
+  const [pathname, query = ""] = href.split("?", 2);
+  if (!isPlatformScoped(pathname)) return href;
+  const params = new URLSearchParams(query);
+  params.set("platform", platform);
+  return `${pathname}?${params}`;
 }

--- a/apps/build/src/features/launch/query-keys.ts
+++ b/apps/build/src/features/launch/query-keys.ts
@@ -12,8 +12,14 @@ export const buildQueryKeys = {
   // A Project ID is canonical and already owns its platform binding.
   projectSource: (account: string, projectId: number) =>
     [...buildQueryKeys.all, "account", account, "project", projectId] as const,
-  deployments: (account: string) =>
-    [...buildQueryKeys.all, "account", account, "deployments"] as const,
+  deployments: (account: string, platform?: string | null) =>
+    [
+      ...buildQueryKeys.all,
+      "account",
+      account,
+      "deployments",
+      platform?.trim() || "all",
+    ] as const,
   operate: (account: string, kind: string, projectId: number | null = null) =>
     [
       ...buildQueryKeys.all,

--- a/apps/build/src/features/overview/overview-dashboard.tsx
+++ b/apps/build/src/features/overview/overview-dashboard.tsx
@@ -22,6 +22,7 @@ import { operateFetch } from "@build/features/operate/client";
 import { BUILD_GLOSSARY } from "@build/lib/glossary";
 import { lastUsageHref, projectHref } from "@build/lib/deep-links";
 import { getLastProjectId } from "@build/lib/last-project";
+import { platformHref } from "@build/features/launch/platform";
 
 type UsagePayload = {
   daily?: Array<Record<string, any>>;
@@ -57,10 +58,10 @@ function StatCard({
   );
 }
 
-export function OverviewDashboard() {
+export function OverviewDashboard({ platform }: { platform: string }) {
   const { account } = useGitHubSession();
   const { projectsState, recordsState, projects, reload } =
-    useGlobalDeploymentRecords();
+    useGlobalDeploymentRecords(platform);
   const accountKey = githubAccountKey(account.githubLogin);
   const usageQuery = useQuery({
     queryKey: buildQueryKeys.operate(accountKey ?? "unavailable", "usage"),
@@ -147,7 +148,7 @@ export function OverviewDashboard() {
         <StatCard
           label="Projects"
           value={projectsLoading ? "—" : String(projects.length)}
-          helper="App projects on GitHub"
+          helper={platform ? `Projects on ${platform}` : "Projects on GitHub"}
         />
         <StatCard
           label="Live deployments"
@@ -178,7 +179,7 @@ export function OverviewDashboard() {
               <div className="text-dim text-xs">Latest project activity</div>
             </div>
             <ControlPlaneLink
-              href="/operate/deployments"
+              href={platformHref("/operate/deployments", platform)}
               className="text-dim hover:text-foreground text-sm"
             >
               View all
@@ -195,7 +196,7 @@ export function OverviewDashboard() {
             <EmptyState
               title="No deployments yet"
               description={BUILD_GLOSSARY.deployment.meaning}
-              actionHref="/operate/deployments/new"
+              actionHref={platformHref("/operate/deployments/new", platform)}
               actionLabel="New app"
             />
           ) : !recordsPending ? (
@@ -203,7 +204,10 @@ export function OverviewDashboard() {
               {deployments.slice(0, 5).map((deployment) => (
                 <ControlPlaneLink
                   key={`${deployment.projectId}-${deployment.deploymentId}`}
-                  href={projectHref(deployment.projectId, "deployments")}
+                  href={platformHref(
+                    projectHref(deployment.projectId, "deployments"),
+                    platform,
+                  )}
                   className="hover:bg-accent-hover flex items-center justify-between gap-3 px-4 py-3 text-sm"
                 >
                   <div className="min-w-0">
@@ -226,7 +230,7 @@ export function OverviewDashboard() {
 
         <div className="flex flex-col gap-3">
           <ControlPlaneLink
-            href="/operate/deployments/new"
+            href={platformHref("/operate/deployments/new", platform)}
             className="border-border bg-surface-1 hover:bg-accent-hover rounded-md border p-4"
           >
             <Rocket className="text-dim size-4" aria-hidden />

--- a/apps/build/src/server/bff/launch/routes.test.ts
+++ b/apps/build/src/server/bff/launch/routes.test.ts
@@ -1843,7 +1843,7 @@ describe("deploymentFeedRoute", () => {
 
     const res = await deploymentFeedRoute(
       new Request(
-        "http://localhost:3000/api/bff/deployments/feed?limit=50&cursorCreatedAt=200&cursorId=10",
+        "http://localhost:3000/api/bff/deployments/feed?platform=world-market-apps&limit=50&cursorCreatedAt=200&cursorId=10",
       ),
     );
     const body = await res.json();
@@ -1855,7 +1855,7 @@ describe("deploymentFeedRoute", () => {
       "/api/integrations/github-app/user/deployments?",
     );
     expect(String(url)).toContain("github_user_id=42");
-    expect(String(url)).not.toContain("platform=");
+    expect(String(url)).toContain("platform=world-market-apps");
     expect(String(url)).toContain("cursor_created_at=200");
     expect(body).toMatchObject({
       deployments: [{ deploymentId: "dep_1", projectId: 7 }],

--- a/apps/build/src/server/bff/launch/routes.ts
+++ b/apps/build/src/server/bff/launch/routes.ts
@@ -736,6 +736,7 @@ export async function deploymentFeedRoute(req: Request) {
   if ("response" in auth) return auth.response;
   const { session } = auth;
   const params = new URL(req.url).searchParams;
+  const platform = params.get("platform")?.trim() || undefined;
   const limit = Number(params.get("limit") ?? "50");
   const cursorCreatedAt = params.get("cursorCreatedAt");
   const cursorId = params.get("cursorId");
@@ -769,6 +770,7 @@ export async function deploymentFeedRoute(req: Request) {
     const client = await backendClient();
     const page = await client.listUserDeployments({
       githubUserId: session.githubUserId,
+      platform,
       limit,
       cursor,
     });

--- a/packages/deploy/src/__tests__/user-deployments.test.ts
+++ b/packages/deploy/src/__tests__/user-deployments.test.ts
@@ -42,6 +42,7 @@ describe("listUserDeployments", () => {
 
     const result = await client.listUserDeployments({
       githubUserId: "123",
+      platform: "world-market-apps",
       limit: 50,
       cursor: { createdAt: 200, id: 9 },
     });
@@ -50,7 +51,7 @@ describe("listUserDeployments", () => {
     expect(String(url)).toContain(
       "/api/integrations/github-app/user/deployments?",
     );
-    expect(String(url)).not.toContain("platform=");
+    expect(String(url)).toContain("platform=world-market-apps");
     expect(String(url)).toContain("cursor_created_at=200");
     expect(String(url)).toContain("cursor_id=9");
     expect(result).toEqual({

--- a/packages/deploy/src/backend/user.ts
+++ b/packages/deploy/src/backend/user.ts
@@ -211,6 +211,9 @@ export class BackendClient extends BackendPlatformClient {
         nextCursor: camelUserDeploymentsCursor(raw.next_cursor),
       }),
       (params) => {
+        if (input.platform?.trim()) {
+          params.set("platform", input.platform.trim());
+        }
         setLimit(params, input.limit);
         if (input.cursor) {
           params.set("cursor_created_at", String(input.cursor.createdAt));

--- a/packages/deploy/src/launch/browser-client.ts
+++ b/packages/deploy/src/launch/browser-client.ts
@@ -255,14 +255,18 @@ function createBaseClient(options: LaunchClientOptions) {
       );
     },
 
-    /** Cross-source activity feed — not platform-scoped. */
+    /** Activity feed for the selected platform. */
     feed(
       input: {
+        platform?: string;
         limit?: number;
         cursor?: DeploymentFeedResult["nextCursor"];
       } = {},
     ): Promise<DeploymentFeedResult> {
       const params = new URLSearchParams({ limit: String(input.limit ?? 50) });
+      if (input.platform?.trim()) {
+        params.set("platform", input.platform.trim());
+      }
       if (input.cursor) {
         params.set("cursorCreatedAt", String(input.cursor.createdAt));
         params.set("cursorId", String(input.cursor.id));

--- a/packages/deploy/src/types.ts
+++ b/packages/deploy/src/types.ts
@@ -540,6 +540,7 @@ export interface UserDeploymentsCursor {
 
 export interface ListUserDeploymentsInput extends BearerOverride {
   githubUserId: string;
+  platform?: string;
   limit?: number;
   cursor?: UserDeploymentsCursor | null;
 }


### PR DESCRIPTION
## Summary
- send the selected platform through Build, the TypeScript client, and the backend deployment feed before pagination
- key project/deployment caches by platform and scope route prefetches to the same platform
- make Overview, Projects, and Deployments report the same Project set
- preserve platform scope through new-app, Project detail, tab, command-palette, and return navigation
- resolve zero-application environment state as `No apps yet` instead of loading forever

This is strict Project V2 behavior and contains no legacy app-source fallback.

## Dependency
Merge and deploy aomi-labs/product-mono#941 first.

## Validation
- full local suite: 1,397 passed, 29 skipped
- `pnpm --filter aomi-build type-check`
- `pnpm --filter aomi-build build`
- authenticated local browser smoke against staging APIs: Overview and Projects both showed 2 `world-market-apps` Projects; deployment BFF requests included `platform=world-market-apps`; Project Environment settled at `No apps yet`
- GitHub build-and-lint passed
- all five Vercel previews passed
- `git diff --check`