### PR TITLE
fix(client): register `deploy` as a root subcommand

### DIFF
--- a/packages/client/src/cli/main.ts
+++ b/packages/client/src/cli/main.ts
@@ -1,22 +1,9 @@
 import { runCommand, runMain } from "citty";
-import { root } from "./root";
+import { root, SUBCOMMAND_NAMES } from "./root";
 import { CliExit, DeployCliError } from "./errors";
 import packageJson from "../../package.json";
 
-const ROOT_SUBCOMMANDS = new Set([
-  "chat",
-  "tx",
-  "session",
-  "model",
-  "app",
-  "chain",
-  "wallet",
-  "account",
-  "logout",
-  "config",
-  "secret",
-  "deploy",
-]);
+const ROOT_SUBCOMMANDS = SUBCOMMAND_NAMES;
 
 function isPnpmExecWrapper(): boolean {
   const npmCommand = process.env.npm_command ?? "";
@@ -112,7 +99,7 @@ function printRootHelp(): void {
   console.log("  config                       CLI configuration");
   console.log("  secret                       Secret management");
   console.log(
-    "  deploy                       Deploy your app (requires --activation-token)",
+    "  deploy                       Deploy your app (also: deploy status, deploy activate)",
   );
   console.log("");
   console.log("Use aomi <command> --help for command-specific details.");

--- a/packages/client/src/cli/root.ts
+++ b/packages/client/src/cli/root.ts
@@ -9,10 +9,16 @@ import { walletDef } from "./commands/defs/wallet";
 import { accountDef } from "./commands/defs/account";
 import { configDef } from "./commands/defs/config";
 import { secretDef } from "./commands/defs/secret";
+import { deployDef } from "./commands/defs/deploy";
 import { buildCliConfig, globalArgs } from "./commands/defs/shared";
 import packageJson from "../../package.json";
 
-const SUBCOMMAND_NAMES = new Set([
+/**
+ * Every token that resolves to a root subcommand. Kept in one place because
+ * `main.ts` needs the same set for help routing — when the two lists drifted,
+ * `deploy` was advertised in `--help` while being unreachable at runtime.
+ */
+export const SUBCOMMAND_NAMES = new Set([
   "chat",
   "tx",
   "session",
@@ -24,6 +30,7 @@ const SUBCOMMAND_NAMES = new Set([
   "logout",
   "config",
   "secret",
+  "deploy",
 ]);
 
 export function hasRootSubcommand(rawArgs: string[]): boolean {
@@ -88,5 +95,6 @@ export const root = defineCommand({
     logout: logoutDef,
     config: configDef,
     secret: secretDef,
+    deploy: deployDef,
   },
 });

--- a/packages/client/test/cli/cli-root.unit.test.ts
+++ b/packages/client/test/cli/cli-root.unit.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, it } from "vitest";
 
-import { hasRootSubcommand } from "../../src/cli/root";
+import { hasRootSubcommand, root, SUBCOMMAND_NAMES } from "../../src/cli/root";
+
+describe("CLI root subcommand registration", () => {
+  // Regression: `deploy` was listed in the hand-written root help and in
+  // main.ts's routing set, but was never added to `root.subCommands`. The
+  // command was therefore unreachable — `aomi deploy` failed with "Unknown
+  // command deploy" while `aomi --help` advertised it. Keep the name set and
+  // the registered subcommands in lockstep so help can never promise a
+  // command the dispatcher cannot run.
+  it("registers every name in SUBCOMMAND_NAMES as a real subcommand", () => {
+    const registered = Object.keys(root.subCommands ?? {});
+    expect([...SUBCOMMAND_NAMES].sort()).toEqual(registered.sort());
+  });
+
+  it("exposes deploy as a runnable subcommand", () => {
+    expect(Object.keys(root.subCommands ?? {})).toContain("deploy");
+    expect(hasRootSubcommand(["deploy", "--project-id", "1"])).toBe(true);
+  });
+});
 
 describe("CLI root dispatch", () => {
   it("recognizes a subcommand after global options and their values", () => {


### PR DESCRIPTION
## The bug

`deployDef` is defined in [`commands/defs/deploy.ts`](packages/client/src/cli/commands/defs/deploy.ts) with a complete implementation behind it — `commands/deploy.ts` (333 lines), plus `status` and `activate` subcommands. **Nothing ever imported it.**

It was missing from both `root.subCommands` and `SUBCOMMAND_NAMES` in `root.ts`, while `main.ts`'s `ROOT_SUBCOMMANDS` set and the hand-written root help both listed it. So the help advertised a command the dispatcher could not run:

```
$ aomi --help
  ...
  deploy                       Deploy your app (requires --activation-token)

$ aomi deploy
❌ Unknown command deploy

$ aomi deploy --help
# prints the generic root help, not deploy usage
```

`git log -S deployDef -- src/cli/root.ts` returns nothing — this was never a deliberate removal, it was never wired in the first place. The whole deploy surface has been dead code.

## The fix

- Import `deployDef` and register it in `root.subCommands`.
- Add `"deploy"` to `SUBCOMMAND_NAMES`.
- Export that set from `root.ts` and have `main.ts` import it instead of maintaining a second hand-written copy. **The two lists drifting is the root cause** — one governed help routing, the other governed dispatch, and nothing kept them honest.
- Correct the root help line: `--activation-token` is not required (it falls back to the device auth flow); `--project-id` is the required input.

## Verification

Built locally and exercised the real binary:

| Command | Result |
|---|---|
| `aomi deploy --help` | deploy usage + `status` / `activate` subcommands |
| `aomi deploy status --help` | renders |
| `aomi deploy activate --help` | renders |
| `aomi deploy` (token set, no project-id) | `❌ [VALIDATION_ERROR] --project-id is required.` |

All 11 other command groups still resolve (`chat`, `tx`, `session`, `model`, `app`, `chain`, `wallet`, `account`, `config`, `secret`, `logout`), and the REPL path is unchanged — bare `aomi` on a non-TTY still gives the expected TTY error rather than falling through.

- `pnpm run typecheck` — clean
- `pnpm exec vitest run packages/client` — 317 passed, 28 skipped, 42 files

## Regression test

Added to `test/cli/cli-root.unit.test.ts`: asserts `SUBCOMMAND_NAMES` and `Object.keys(root.subCommands)` are identical, so help can never again promise a command that isn't registered. I confirmed it actually catches the defect by removing the registration and watching both new assertions fail.

## Note on `dist/`

`packages/client/dist/` is checked in but stale relative to `src/` — a rebuild produced ~700 lines of diff, most of it unrelated to this change (other people's unbuilt source). I deliberately left `dist/` out of this commit rather than sweeping that in. `prepublishOnly` rebuilds on publish, so the shipped artifact is unaffected.

## Context

Found while syncing the Aomi skill docs against the published CLI (aomi-labs/skills#32). The skill currently documents `aomi deploy` as unavailable; once this lands that note can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788739053&installation_model_id=12362&pr_number=467&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F467&signature=64923547cb2fd9f45d6c7010f1587233ff5f84d710e84d7009d4ae212e789cd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->