### PR TITLE
fix(build): scope operate pages and Settings secrets to the selected platform

### DIFF
--- a/apps/build/src/app/(control-plane)/settings/settings-secrets-panel.test.tsx
+++ b/apps/build/src/app/(control-plane)/settings/settings-secrets-panel.test.tsx
@@ -4,15 +4,22 @@ import { render, screen } from "@testing-library/react";
 vi.mock("@build/features/launch/hooks/use-projects", () => ({
   useProjects: vi.fn(),
 }));
+vi.mock("@build/features/launch/use-platform", () => ({
+  usePlatform: vi.fn(),
+}));
 
 import { useProjects } from "@build/features/launch/hooks/use-projects";
+import { usePlatform } from "@build/features/launch/use-platform";
 import { SettingsSecretsPanel } from "./settings-secrets-panel";
 
 const useProjectsMock = vi.mocked(useProjects);
+const usePlatformMock = vi.mocked(usePlatform);
 
 describe("SettingsSecretsPanel", () => {
   beforeEach(() => {
     useProjectsMock.mockReset();
+    usePlatformMock.mockReset();
+    usePlatformMock.mockReturnValue("community");
   });
 
   it("shows New app when there are no projects", () => {
@@ -30,7 +37,48 @@ describe("SettingsSecretsPanel", () => {
     expect(screen.getByText(/No projects yet/i)).toBeTruthy();
     expect(screen.getByRole("link", { name: /New app/i })).toHaveAttribute(
       "href",
-      "/operate/deployments/new",
+      "/operate/deployments/new?platform=community",
+    );
+  });
+
+  /** Settings has no `?platform=` of its own, so an unscoped read here listed
+   *  every project the account owns — including ones the selected platform
+   *  cannot open, whose Environment tab then fails to read its secrets. */
+  it("lists only the selected platform's projects", () => {
+    usePlatformMock.mockReturnValue("world-market-apps");
+    useProjectsMock.mockReturnValue({
+      state: {
+        status: "ready",
+        projects: [
+          {
+            id: 3,
+            installationId: 1,
+            repositoryLink: "alice/bot",
+            apps: [],
+            latestDeployment: null,
+          },
+          {
+            id: 4,
+            installationId: 1,
+            repositoryLink: "alice/other",
+            apps: [],
+            latestDeployment: null,
+          },
+        ],
+        sdk: null,
+        github: { signedIn: true, githubLogin: "alice", githubUserId: "1" },
+      },
+      reload: vi.fn(),
+    });
+
+    render(<SettingsSecretsPanel />);
+
+    expect(useProjectsMock).toHaveBeenCalledWith("world-market-apps");
+    // Following a row keeps the platform, so the project page and its back
+    // path do not silently drop the reader onto Community.
+    expect(screen.getByRole("link", { name: /alice\/bot/i })).toHaveAttribute(
+      "href",
+      "/projects/3?tab=environment&platform=world-market-apps",
     );
   });
 
@@ -59,7 +107,7 @@ describe("SettingsSecretsPanel", () => {
     expect(screen.getByText(/alice\/only-bot/i)).toBeTruthy();
     expect(
       screen.getByRole("link", { name: /Open Environment/i }),
-    ).toHaveAttribute("href", "/projects/7?tab=environment");
+    ).toHaveAttribute("href", "/projects/7?tab=environment&platform=community");
   });
 
   it("lists projects that deep-link to Environment", () => {
@@ -91,11 +139,11 @@ describe("SettingsSecretsPanel", () => {
     render(<SettingsSecretsPanel />);
     expect(screen.getByRole("link", { name: /alice\/bot/i })).toHaveAttribute(
       "href",
-      "/projects/3?tab=environment",
+      "/projects/3?tab=environment&platform=community",
     );
     expect(screen.getByRole("link", { name: /alice\/other/i })).toHaveAttribute(
       "href",
-      "/projects/4?tab=environment",
+      "/projects/4?tab=environment&platform=community",
     );
   });
 });

--- a/apps/build/src/app/(control-plane)/settings/settings-secrets-panel.tsx
+++ b/apps/build/src/app/(control-plane)/settings/settings-secrets-panel.tsx
@@ -4,25 +4,29 @@ import Link from "next/link";
 import { ArrowRight } from "lucide-react";
 
 import { useProjects } from "@build/features/launch/hooks/use-projects";
+import { platformHref } from "@build/features/launch/platform";
+import { usePlatform } from "@build/features/launch/use-platform";
 import {
   ErrorPanel,
   GitHubSignInPanel,
   LoadingPanel,
 } from "@build/features/launch/components/deployments/ui/state-panels";
 
-function environmentHref(projectId: number) {
-  return `/projects/${projectId}?tab=environment`;
+function environmentHref(projectId: number, platform: string) {
+  return platformHref(`/projects/${projectId}?tab=environment`, platform);
 }
 
-function projectLabel(source: {
-  id: number;
-  repositoryLink?: string | null;
-}) {
+function projectLabel(source: { id: number; repositoryLink?: string | null }) {
   return source.repositoryLink?.trim() || `Project ${source.id}`;
 }
 
 export function SettingsSecretsPanel() {
-  const { state } = useProjects();
+  // Settings carries no `?platform=`, but its project list is not an exception
+  // to the platform model: an unscoped read here listed every project the
+  // account owns, including ones this platform cannot open — following one of
+  // those rows lands on an Environment tab whose secrets read fails.
+  const platform = usePlatform();
+  const { state } = useProjects(platform);
 
   if (state.status === "loading") {
     return <LoadingPanel label="Loading projects…" />;
@@ -38,16 +42,16 @@ export function SettingsSecretsPanel() {
 
   if (state.projects.length === 0) {
     return (
-      <div className="rounded-lg border border-border bg-surface-1 p-4">
-        <div className="text-sm font-medium text-foreground">
+      <div className="border-border bg-surface-1 rounded-lg border p-4">
+        <div className="text-foreground text-sm font-medium">
           No projects yet
         </div>
-        <p className="mt-2 text-[13px] text-dim">
+        <p className="text-dim mt-2 text-[13px]">
           Create an app first, then set secrets on its Environment tab.
         </p>
         <Link
-          href="/operate/deployments/new"
-          className="mt-4 inline-flex h-8 items-center rounded-md bg-primary px-3 text-[12px] font-medium text-primary-foreground transition hover:bg-brand-hover"
+          href={platformHref("/operate/deployments/new", platform)}
+          className="bg-primary text-primary-foreground hover:bg-brand-hover mt-4 inline-flex h-8 items-center rounded-md px-3 text-[12px] font-medium transition"
         >
           New app
         </Link>
@@ -61,18 +65,18 @@ export function SettingsSecretsPanel() {
 
     return (
       <div className="space-y-3">
-        <div className="rounded-lg border border-border bg-surface-1 p-4">
-          <div className="text-sm font-medium text-foreground">
+        <div className="border-border bg-surface-1 rounded-lg border p-4">
+          <div className="text-foreground text-sm font-medium">
             Per-project secrets
           </div>
-          <p className="mt-2 text-[13px] text-dim">
+          <p className="text-dim mt-2 text-[13px]">
             Edit environment values for{" "}
-            <span className="text-foreground font-medium">{label}</span> on
-            the project Environment tab.
+            <span className="text-foreground font-medium">{label}</span> on the
+            project Environment tab.
           </p>
           <Link
-            href={environmentHref(only.id)}
-            className="mt-4 inline-flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-[12px] font-medium text-primary-foreground transition hover:bg-brand-hover"
+            href={environmentHref(only.id, platform)}
+            className="bg-primary text-primary-foreground hover:bg-brand-hover mt-4 inline-flex h-8 items-center gap-1.5 rounded-md px-3 text-[12px] font-medium transition"
           >
             Open Environment
             <ArrowRight className="size-3.5" aria-hidden />
@@ -84,20 +88,20 @@ export function SettingsSecretsPanel() {
 
   return (
     <div className="space-y-3">
-      <div className="rounded-lg border border-border bg-surface-1 p-4">
-        <div className="text-sm font-medium text-foreground">
+      <div className="border-border bg-surface-1 rounded-lg border p-4">
+        <div className="text-foreground text-sm font-medium">
           Per-project secrets
         </div>
-        <p className="mt-2 text-[13px] text-dim">
+        <p className="text-dim mt-2 text-[13px]">
           Choose a project to open its Environment tab.
         </p>
       </div>
 
-      <ul className="divide-border overflow-hidden rounded-lg border border-border bg-surface-1 divide-y">
+      <ul className="divide-border border-border bg-surface-1 divide-y overflow-hidden rounded-lg border">
         {state.projects.map((source) => (
           <li key={source.id}>
             <Link
-              href={environmentHref(source.id)}
+              href={environmentHref(source.id, platform)}
               className="hover:bg-accent-hover flex items-center justify-between gap-3 px-4 py-3 transition"
             >
               <div className="min-w-0">

--- a/apps/build/src/server/bff/operate/routes.test.ts
+++ b/apps/build/src/server/bff/operate/routes.test.ts
@@ -763,7 +763,9 @@ describe("operateObservabilityRoute live data", () => {
       },
       {
         // A partner-bound source the per-source fan-out could never read
-        // under the default platform — the batch covers it.
+        // under the default platform. The batch still covers it — the read
+        // stays account-wide — but this page is scoped to `community`, so it
+        // must not render here. Its own platform's page shows it.
         project: { id: 1620 },
         platform: "somm.finance",
         scope: "owned_applications",
@@ -804,8 +806,80 @@ describe("operateObservabilityRoute live data", () => {
     expect(body.payments).toBeUndefined();
     expect(
       body.apps.map((app: { application: string }) => app.application),
-    ).toEqual(["real-bot", "somm-agent"]);
+    ).toEqual(["real-bot"]);
     expect(body.monitoring.status).toBe("ok");
+  });
+
+  /** The read is account-wide, the page is not. Observability must show the
+   *  same projects `/projects` lists for the selected platform — a card for a
+   *  project the console cannot even open reads as someone else's account. */
+  it("scopes the account-wide batch to the selected platform's projects", async () => {
+    setSession({ githubUserId: "gh-1" });
+    client.listUserProjects.mockImplementation(async ({ platform }) =>
+      platform === "somm.finance"
+        ? [
+            {
+              id: 1620,
+              repositoryLink: "o/somm",
+              platformName: "somm.finance",
+              apps: [],
+            },
+          ]
+        : [
+            {
+              id: 900,
+              repositoryLink: "o/r",
+              platformName: "community",
+              apps: [],
+            },
+          ],
+    );
+    const snapshot = (id: number, platform: string, application: string) => ({
+      project: { id },
+      platform,
+      scope: "owned_applications",
+      monitoring: {
+        provider: "grafana_prometheus",
+        status: "ok",
+        windowSeconds: 900,
+      },
+      apps: [
+        {
+          applicationId: id,
+          application,
+          active: true,
+          loaded: true,
+          status: "healthy",
+          metrics: null,
+        },
+      ],
+      payments: emptyPayments(),
+      dashboardLinks: [],
+      platformMetrics: [],
+    });
+    client.getUserObservability.mockResolvedValue([
+      snapshot(900, "community", "real-bot"),
+      snapshot(1620, "somm.finance", "somm-agent"),
+    ]);
+
+    const res = await operateObservabilityRoute(
+      new Request(
+        "http://localhost:3000/api/bff/operate/observability?platform=somm.finance",
+      ),
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    // Still one account-wide read — only the response is narrowed.
+    expect(client.getUserObservability).toHaveBeenCalledWith(
+      expect.objectContaining({ githubUserId: "gh-1" }),
+    );
+    expect(
+      body.apps.map((app: { application: string }) => app.application),
+    ).toEqual(["somm-agent"]);
+    expect(body.projects.map((project: { id: number }) => project.id)).toEqual([
+      1620,
+    ]);
   });
 
   it("does not restore the per-source fan-out when the batch route is missing", async () => {
@@ -979,6 +1053,57 @@ describe("account-wide batch reads", () => {
     });
   });
 
+  /** The merged page spans every platform the account owns; the page it feeds
+   *  is scoped to one. Rows for a project this platform does not list are
+   *  dropped, and the global cursor still carries the reader forward. */
+  it("scopes the merged transactions page to the selected platform", async () => {
+    client.listUserProjects.mockResolvedValue([
+      { id: 900, repositoryLink: "o/one", platformName: "community", apps: [] },
+    ]);
+    client.listUserTransactions.mockResolvedValue({
+      projects: [
+        {
+          project: { id: 900, repositoryLink: "o/one" },
+          platform: "community",
+        },
+        {
+          project: { id: 1620, repositoryLink: "partner/app" },
+          platform: "somm.finance",
+        },
+      ],
+      transactions: [
+        {
+          id: "tx:b",
+          createdAt: 1_700_000_100,
+          projectId: 1620,
+          platform: "somm.finance",
+        },
+        {
+          id: "tx:a",
+          createdAt: 1_700_000_000,
+          projectId: 900,
+          platform: "community",
+        },
+      ],
+      nextCursor: { createdAt: 1_700_000_000, id: "tx:a" },
+    });
+    client.getUserStatements.mockResolvedValue([]);
+
+    const body = await (
+      await operateTransactionsRoute(transactionsReq())
+    ).json();
+
+    expect(body.transactions.map((tx: { id: string }) => tx.id)).toEqual([
+      "tx:a",
+    ]);
+    expect(body.projects.map((project: { id: number }) => project.id)).toEqual([
+      900,
+    ]);
+    expect(body.nextCursor).toEqual({
+      batch: { createdAt: 1_700_000_000, id: "tx:a" },
+    });
+  });
+
   it("passes the batch cursor through and skips statements past page one", async () => {
     client.listUserTransactions.mockResolvedValue({
       projects: [],
@@ -1094,6 +1219,62 @@ describe("account-wide batch reads", () => {
         id: "settle:shared",
       },
     });
+  });
+
+  /** The merged stream spans every platform the account owns. Rows for a
+   *  project this platform does not list are dropped; account-level rows
+   *  (a shared partner settlement has no project) belong to every view. */
+  it("scopes the merged log stream to the selected platform", async () => {
+    client.listUserProjects.mockResolvedValue([
+      { id: 900, repositoryLink: "o/one", platformName: "community", apps: [] },
+    ]);
+    client.listUserLogs.mockResolvedValue({
+      projects: [
+        {
+          project: { id: 900, repositoryLink: "o/one" },
+          platform: "community",
+        },
+        {
+          project: { id: 1620, repositoryLink: "o/somm" },
+          platform: "somm.finance",
+        },
+      ],
+      logs: [
+        {
+          id: "log:mine",
+          eventType: "transaction",
+          occurredAt: 1_700_000_002,
+          details: {},
+          projectId: 900,
+          platform: "community",
+        },
+        {
+          id: "log:other-platform",
+          eventType: "transaction",
+          occurredAt: 1_700_000_001,
+          details: {},
+          projectId: 1620,
+          platform: "somm.finance",
+        },
+        {
+          id: "settle:shared",
+          eventType: "usage",
+          occurredAt: 1_700_000_000,
+          details: { source: "partner_settlement" },
+          projectId: null,
+          platform: null,
+        },
+      ],
+      nextCursor: null,
+      invocationsAvailable: true,
+    });
+
+    const body = await (await operateLogsRoute(logsReq())).json();
+
+    expect(body.logs.map((log: { id: string }) => log.id)).toEqual([
+      "log:mine",
+      "settle:shared",
+    ]);
   });
 
   it("keeps a single-source view on the per-source read", async () => {
@@ -1241,20 +1422,57 @@ describe("account-wide reads do not waterfall behind listUserProjects", () => {
     await expect(res.json()).resolves.toMatchObject({ projects: [{ id: 42 }] });
   });
 
-  /** The payments response is derived entirely from the ledger read, so an
-   *  unfiltered request must not read the source list at all — not even in
-   *  parallel. A regression here is a wasted manager round trip per poll. */
-  it("never reads the source list for an unfiltered payments request", async () => {
+  /** The ledger read is account-wide, so the source list is what scopes it to
+   *  the selected platform. It must never be a waterfall in front of the
+   *  ledger read — a regression there is a serial manager hop per poll. */
+  it("reads the source list alongside, not ahead of, an unfiltered payments request", async () => {
     setSession({ githubUserId: "gh-1" });
-    client.getUserPayments.mockResolvedValue([]);
+    const { release } = pendingSources();
+    let ledgerStarted = false;
+    client.getUserPayments.mockImplementation(async () => {
+      ledgerStarted = true;
+      return [];
+    });
+
+    const pending = operatePaymentsRoute(
+      new Request("http://localhost:3000/api/bff/operate/payments"),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(ledgerStarted).toBe(true);
+
+    release([{ id: 42, repositoryLink: "o/r", apps: [] }]);
+    const res = await pending;
+
+    expect(res.status).toBe(200);
+    expect(client.getUserPayments).toHaveBeenCalledOnce();
+  });
+
+  /** A ledger row for a project on another platform must not surface here —
+   *  the payment card sits on a page scoped to one platform. */
+  it("scopes unfiltered payments to the selected platform's projects", async () => {
+    setSession({ githubUserId: "gh-1" });
+    oneSource();
+    const withResource = (application: string) => ({
+      ...emptyPayments(),
+      resources: [{ application, priced: true }],
+    });
+    client.getUserPayments.mockResolvedValue([
+      { project: { id: 900 }, payments: withResource("real-bot") },
+      { project: { id: 1620 }, payments: withResource("somm-agent") },
+    ]);
 
     const res = await operatePaymentsRoute(
       new Request("http://localhost:3000/api/bff/operate/payments"),
     );
+    const body = await res.json();
 
     expect(res.status).toBe(200);
     expect(client.getUserPayments).toHaveBeenCalledOnce();
-    expect(client.listUserProjects).not.toHaveBeenCalled();
+    expect(
+      body.payments.resources.map(
+        (r: { application: string }) => r.application,
+      ),
+    ).toEqual(["real-bot"]);
   });
 
   /** …but a source-scoped request still must, because that is where

--- a/apps/build/src/server/bff/operate/routes.ts
+++ b/apps/build/src/server/bff/operate/routes.ts
@@ -389,9 +389,33 @@ type OperateSession = {
   githubUserId: string;
   platform: string;
   client: BackendClientInstance;
-  /** The signed-in user's account-wide projects, resolved lazily. */
+  /** The signed-in user's account-wide projects, resolved lazily. Ownership
+   *  checks read this one: a partner-bound project must still be provable as
+   *  this user's even while another platform is selected. */
   projects: () => Promise<UserProject[]>;
+  /** The projects the selected platform actually shows, resolved lazily —
+   *  the exact list behind `/projects`. Every page under one platform must
+   *  agree on this set, so account-wide reads narrow their results to it. */
+  platformProjects: () => Promise<UserProject[]>;
 };
+
+/** Ids of the projects visible on the selected platform. Account-wide manager
+ *  batches answer for every platform the account owns (deliberately — the
+ *  per-project read rejects partner-bound projects as not launch-relevant on
+ *  the default platform), so the platform scope is applied to the response. */
+function platformProjectIds(projects: UserProject[]): Set<number> {
+  return new Set(projects.map((project) => project.id));
+}
+
+/** Keep only the rows whose project is on the selected platform. Rows with no
+ *  project (account-level partner settlements) belong to every platform view
+ *  and are kept. */
+function onPlatform<T extends { project?: { id: number } | null }>(
+  rows: T[],
+  ids: Set<number>,
+): T[] {
+  return rows.filter((row) => !row.project || ids.has(row.project.id));
+}
 
 async function operateSession(
   req: Request,
@@ -422,6 +446,13 @@ async function operateSession(
           client.listUserProjects({
             githubUserId: session.githubUserId,
             platform: undefined,
+          }),
+        ),
+      platformProjects: () =>
+        readCache.projects.get([session.githubUserId, platform], () =>
+          client.listUserProjects({
+            githubUserId: session.githubUserId,
+            platform,
           }),
         ),
     };
@@ -512,15 +543,19 @@ async function batchScope(req: Request): Promise<
       /** Set only for a single-source view; already validated as owned. */
       projectId: number | undefined;
       projects: () => Promise<UserProject[]>;
+      platformProjects: () => Promise<UserProject[]>;
     }
 > {
   if (new URL(req.url).searchParams.has("projectId")) {
     const owned = await ownedSources(req);
     if ("response" in owned) return owned;
+    // The named project IS the scope — it was resolved by id and carries its
+    // own platform binding, so there is nothing left to narrow.
     return {
       ...owned,
       projectId: owned.projects[0]?.id,
       projects: () => Promise.resolve(owned.projects),
+      platformProjects: () => Promise.resolve(owned.projects),
     };
   }
   const session = await operateSession(req);
@@ -531,6 +566,7 @@ async function batchScope(req: Request): Promise<
     client: session.client,
     projectId: undefined,
     projects: session.projects,
+    platformProjects: session.platformProjects,
   };
 }
 
@@ -837,7 +873,7 @@ export async function operateTransactionsRoute(req: Request) {
     const scope = await batchScope(req);
     if ("response" in scope) return scope.response;
     // Started before the reads below so it overlaps them.
-    const sourcesPending = scope.projects();
+    const sourcesPending = scope.platformProjects();
     const params = new URL(req.url).searchParams;
     const limit = pageLimit(params, 50, 100);
     const cursor = parseCompositeCursor(params.get("cursor"));
@@ -898,16 +934,23 @@ export async function operateTransactionsRoute(req: Request) {
       const sourceById = new Map(
         batch.page.projects.map((ref) => [ref.project.id, ref.project]),
       );
-      appTransactions = batch.page.transactions.map(
-        ({ projectId, platform, ...transaction }) => ({
-          ...transaction,
-          kind: "app_transaction",
-          project:
-            (projectId != null ? sourceById.get(projectId) : undefined) ?? null,
-          platform: platform ?? owned.platform,
-        }),
+      // The manager batch answers for every platform the account owns; narrow
+      // it to the platform this page is scoped to before anything is rendered.
+      const platformIds = platformProjectIds(owned.projects);
+      appTransactions = onPlatform(
+        batch.page.transactions.map(
+          ({ projectId, platform, ...transaction }) => ({
+            ...transaction,
+            kind: "app_transaction",
+            project:
+              (projectId != null ? sourceById.get(projectId) : undefined) ??
+              null,
+            platform: platform ?? owned.platform,
+          }),
+        ),
+        platformIds,
       );
-      statements = batch.statements;
+      statements = onPlatform(batch.statements, platformIds);
       nextCursor = batch.page.nextCursor
         ? { batch: batch.page.nextCursor }
         : null;
@@ -1077,7 +1120,7 @@ export async function operateUsageRoute(req: Request) {
     const scope = await batchScope(req);
     if ("response" in scope) return scope.response;
     // Started before the reads below so it overlaps them.
-    const sourcesPending = scope.projects();
+    const sourcesPending = scope.platformProjects();
     const params = new URL(req.url).searchParams;
     const dates = {
       fromDate: params.get("fromDate") ?? undefined,
@@ -1129,8 +1172,11 @@ export async function operateUsageRoute(req: Request) {
     let results: OperateUsageResult[];
     let allStatements: OperateStatementResult[];
     if (batch) {
-      results = batch.usage;
-      allStatements = batch.statements;
+      // The manager batch answers for every platform the account owns; narrow
+      // it to the platform this page is scoped to.
+      const platformIds = platformProjectIds(owned.projects);
+      results = onPlatform(batch.usage, platformIds);
+      allStatements = onPlatform(batch.statements, platformIds);
     } else {
       const [usageReads, statementReads] = await Promise.all([
         settleBySource<OperateUsageResult>(
@@ -1260,7 +1306,7 @@ export async function operateLogsRoute(req: Request) {
     if (!params.has("projectId")) {
       const scope = await batchScope(req);
       if ("response" in scope) return scope.response;
-      const sourcesPending = scope.projects();
+      const sourcesPending = scope.platformProjects();
       const [batch, projects] = await Promise.all([
         readCache.logsBatch.get(
           [
@@ -1285,12 +1331,19 @@ export async function operateLogsRoute(req: Request) {
       );
       return NextResponse.json({
         projects,
-        logs: batch.logs.map(({ projectId, platform, ...log }) => ({
-          ...log,
-          project:
-            (projectId != null ? sourceById.get(projectId) : undefined) ?? null,
-          platform: platform ?? scope.platform,
-        })),
+        // The merged stream covers every platform the account owns; narrow it
+        // to the selected one. Account-level rows (a shared partner
+        // settlement carries no projectId) stay.
+        logs: onPlatform(
+          batch.logs.map(({ projectId, platform, ...log }) => ({
+            ...log,
+            project:
+              (projectId != null ? sourceById.get(projectId) : undefined) ??
+              null,
+            platform: platform ?? scope.platform,
+          })),
+          platformProjectIds(projects),
+        ),
         nextCursor: batch.nextCursor ? { batch: batch.nextCursor } : null,
       });
     }
@@ -1388,14 +1441,16 @@ export async function operateObservabilityRoute(req: Request) {
     const scope = await batchScope(req);
     if ("response" in scope) return scope.response;
     const { projectId } = scope;
-    // Kick the dropdown's source list off first so it overlaps the snapshot
+    // Kick the platform's source list off first so it overlaps the snapshot
     // below rather than following it.
-    const sourcesPending = scope.projects();
+    const sourcesPending = scope.platformProjects();
 
     // One manager request for the whole account. Without an explicit
     // `platform` filter the manager resolves each source under its own
     // bound/loaded platform, which also covers partner-bound projects that the
     // per-source read rejects as not launch-relevant on the default platform.
+    // The platform scope is then applied here, so this page shows exactly the
+    // projects `/projects` lists rather than every platform the account owns.
     const [results, projects] = await Promise.all([
       readCache.observabilityBatch.get(
         [scope.githubUserId, requestedPlatform ?? null, projectId ?? null],
@@ -1407,7 +1462,8 @@ export async function operateObservabilityRoute(req: Request) {
       ) as Promise<OperateObservabilitySnapshot[]>,
       sourcesPending,
     ]);
-    const apps = results.flatMap((result) =>
+    const scoped = onPlatform(results, platformProjectIds(projects));
+    const apps = scoped.flatMap((result) =>
       result.apps.map((app) => ({
         ...app,
         project: result.project,
@@ -1415,22 +1471,22 @@ export async function operateObservabilityRoute(req: Request) {
       })),
     );
     return NextResponse.json({
-      // Every source the account owns, not just the ones this read covered:
+      // Every source on this platform, not just the ones this read covered:
       // the filter dropdown is how a user loads one source on its own.
       projects,
       scope: "owned_applications",
       monitoring: {
         provider: "grafana_prometheus",
-        status: results.some((result) => result.monitoring?.status === "ok")
-          ? results.some((result) => result.monitoring?.status !== "ok")
+        status: scoped.some((result) => result.monitoring?.status === "ok")
+          ? scoped.some((result) => result.monitoring?.status !== "ok")
             ? "partial"
             : "ok"
-          : (results[0]?.monitoring?.status ?? "unconfigured"),
-        windowSeconds: results[0]?.monitoring?.windowSeconds ?? 0,
+          : (scoped[0]?.monitoring?.status ?? "unconfigured"),
+        windowSeconds: scoped[0]?.monitoring?.windowSeconds ?? 0,
       },
       apps,
-      dashboardLinks: results.flatMap((result) => result.dashboardLinks),
-      platformMetrics: results[0]?.platformMetrics ?? [],
+      dashboardLinks: scoped.flatMap((result) => result.dashboardLinks),
+      platformMetrics: scoped[0]?.platformMetrics ?? [],
     });
   } catch (err) {
     return buildFailures.handle(
@@ -1440,8 +1496,8 @@ export async function operateObservabilityRoute(req: Request) {
 }
 
 /** Optional ledger card for the observability page; never blocks its snapshot.
- *  The response is derived purely from the ledger read, so the source list is
- *  never awaited here at all. */
+ *  The source list is read only to scope the ledger to the selected platform,
+ *  in parallel with it and off the same cache the snapshot already warmed. */
 export async function operatePaymentsRoute(req: Request) {
   try {
     const scope = await batchScope(req);
@@ -1449,16 +1505,23 @@ export async function operatePaymentsRoute(req: Request) {
     const requestedPlatform =
       new URL(req.url).searchParams.get("platform") ?? undefined;
     const { projectId } = scope;
-    const results = await readCache.paymentsBatch.get(
-      [scope.githubUserId, requestedPlatform ?? null, projectId ?? null],
-      () =>
-        scope.client.getUserPayments({
-          githubUserId: scope.githubUserId,
-          projectId,
-        }),
-    );
+    // The ledger read is account-wide for the same reason the observability
+    // batch is; the platform scope is applied to its rows, not to the request.
+    const [results, projects] = await Promise.all([
+      readCache.paymentsBatch.get(
+        [scope.githubUserId, requestedPlatform ?? null, projectId ?? null],
+        () =>
+          scope.client.getUserPayments({
+            githubUserId: scope.githubUserId,
+            projectId,
+          }),
+      ),
+      scope.platformProjects(),
+    ]);
     return NextResponse.json({
-      payments: mergedPartnerPayments(results),
+      payments: mergedPartnerPayments(
+        onPlatform(results, platformProjectIds(projects)),
+      ),
     });
   } catch (err) {
     return buildFailures.handle(

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,94 @@
 
 ## Last Updated
 
+2026-08-08 — DEPLOY-SURFACE BUGS, BE SIDE (product-mono worktree
+  `~/Code/product-mono-worktrees/deploy-feed-platform-scope`, branch
+  `claude/deploy-feed-platform-scope` off origin/main f5d421933; all changes
+  uncommitted). Root causes established by probing staging directly with a
+  portal-minted service bearer (apps/portal/.env.local).
+  - ENVIRONMENT TAB `list_secrets failed (503)`: the 503 is the Cloudflare
+    Worker's, not the backend's. With APP_AVAILABILITY_ROUTING on, ANY
+    `/api/*?application_id=N` request is availability-probed and hard-503s
+    when no origin has the app's artifact loaded — which is every deactivated
+    app (staging probe: 4 of Cecilia's 5 apps 503'd; only the loaded
+    world-markets passed). `infra/cloudflare/worker/src/index.js` now exempts
+    `/api/_internal/*` (service traffic ABOUT an app, not TO it). Worker tests
+    37/37, new test mutation-checked.
+  - FEED vs PROJECT HISTORY (4 vs 1): on main both reads are projection-only
+    by project_id and CONSISTENT; the data itself is gone — migration
+    `20260806010000_project_model.sql` ran `DELETE FROM deployments;` and the
+    promised import migration never existed. Pre-cutover manifests also fail
+    strict deserialization (no `project_id`) and are silently skipped. Added
+    the explicit recovery door: `SourceRecord.project_id` is `#[serde(default)]`,
+    the projection writer rejects `project_id <= 0`, and new service-only
+    `POST /api/integrations/github-app/user/projects/:id/deployments/import`
+    (`Project::import_deployments`) scans the platform repo's deployment
+    branches + deploy branch, stamps the owning project, and idempotently
+    upserts. Route + route-manifest test + Worker manager-route pattern + test.
+  - REQUIRED-SECRETS 500 ON LEGACY TAGS: staging audit showed
+    `GET /user/projects/:id/required-secrets` 500ing with "invalid platform
+    release tag `latest`" for any project holding a legacy `app_release_tag`
+    DEFAULT-'latest' row — one bad row failed the WHOLE Environment/deploy
+    gate ("Required secrets could not be verified"). `Project::required_secrets`
+    now degrades an unparseable tag to "no release ⇒ no slots" (warn-logged);
+    the "no deployment projection" 500 for parseable tags is kept — that one
+    is real integrity signal and is what the import door repairs.
+  - APP-STATUS 403 (aomi-build CLI): `PlatformHandler::get_app()` authorized
+    `Action::ReadPlatform`, which app-scoped activation tokens are forbidden
+    from. It now resolves the named app row first and authorizes
+    `Action::ReadApps { app_ids: [app.id] }` — the lattice's app-token rules
+    for ReadApps are already unit-tested in activator.rs.
+  - Verified with ALL three fixes (fresh build after the disk-space incident):
+    cargo check -p manager clean; cargo test -p manager 138 passed/19 failed
+    == clean-main baseline (the 19 are the hosted-DB guard refusing an
+    exported hosted DATABASE_URL — pre-existing, environmental); worker tests
+    37/37. PENDING after deploy: re-probe staging (secrets reads should 200),
+    then invoke the import for world-markets (project 1646) to restore its
+    history. NOT a bug: the "0.3.2 vs 3.1.0" report — 3.1.0 is the required
+    aomi-sdk crate version (workspace pins =3.1.0); 0.3.2 is the world-markets
+    app's own DynManifest.version. The stale-descriptor issue behind it is the
+    runtime dlopen hot-reload seam (backend reconcile.rs), owned by another
+    Codex session mid-experiment — deliberately not touched here.
+
+2026-08-08 — OPERATE PAGES IGNORED THE SELECTED PLATFORM (apps/build, working
+
+2026-08-08 — OPERATE PAGES IGNORED THE SELECTED PLATFORM (apps/build, working
+  tree on `claude/deployment-records-mismatch-79b0a0`). Observability listed 5
+  projects across platforms while `/projects` listed the 2 on
+  `world-market-apps`. The account-wide manager batches (observability,
+  transactions, usage, logs, payments) are deliberately unscoped — the
+  per-project read rejects partner-bound projects as not launch-relevant on the
+  default platform — but the BFF read `?platform=` only as a **cache key** and
+  never narrowed the response.
+  - `operateSession` gains `platformProjects()` alongside `projects()`:
+    `listUserProjects({ platform })`, i.e. the exact list `/projects` renders.
+    `projects()` stays account-wide because ownership checks need it.
+  - The five account-wide routes now filter their rows through `onPlatform()`
+    against that id set. The manager call stays account-wide; only the response
+    is scoped, so a partner-bound project is still reachable — on its own
+    platform's page. Rows with no project (shared partner settlements) are kept.
+  - `operatePaymentsRoute` now reads the source list (in `Promise.all`, off the
+    cache the snapshot warmed) where it previously never did.
+  - Settings → Secrets had the same fault one layer up:
+    `settings-secrets-panel.tsx` called `useProjects()` with NO platform (the
+    only such call site left), so it listed all 5 account projects and a row
+    for an off-platform project led to an Environment tab whose secrets read
+    503s. It now takes `usePlatform()` and routes through `platformHref()`, so
+    following a row keeps the platform instead of dropping to Community.
+  - Verified: apps/build vitest 419 passed/1 skipped, tsc/eslint/prettier clean.
+    6 scoping tests mutation-checked (they fail when `onPlatform` is a no-op /
+    when the panel drops its platform argument).
+    The 4 pre-existing failing test FILES (deploy-dashboard, deploy-step,
+    live-panel, oneshot-wizard — collection errors) are unrelated and unchanged.
+  PENDING (backend, product-mono — NOT fixed here): the global deployments feed
+  and a project's Deployments tab are structurally different reads, so they
+  disagree. `user_source_deployments` (github_app.rs:988-1043) is DB projection
+  **plus a GitHub manifest fallback**; `user_deployments` (github_app.rs:1047+)
+  is projection-only and explicitly "never scans GitHub", filtered on
+  `deployments.platform`. Any deployment with no projection row under the
+  queried platform shows on the project page and is invisible in the feed —
+  which is why world-markets showed 4 deployments and the feed showed 1.
+
 2026-08-04 — PROJECT HOME "KEYS MISSING" FALSE ALARM (apps/build, committed
   on `feat/build-new-app-two-starts`). The Environment card warned whenever no
   key was set


### PR DESCRIPTION
## Summary
- The account-wide manager batches (observability, transactions, usage, logs, payments) answer for every platform the account owns — deliberately, since the per-project read rejects partner-bound projects on the default platform — but the BFF used `?platform=` only as a cache key and never narrowed the response. Observability listed 5 projects across platforms while `/projects` listed the 2 on the selected one.
- `operateSession` now resolves `platformProjects()` (the exact list `/projects` renders) alongside the account-wide `projects()` that ownership checks need; the five account-wide routes filter rows through `onPlatform()` against that id set. The manager call stays account-wide — only the response is scoped — so partner-bound projects remain reachable on their own platform's page. Rows with no project (shared partner settlements) are kept in every view.
- Settings → Secrets had the same fault one layer up: the panel called `useProjects()` with **no** platform (the only such call site left), listing every account project; following an off-platform row landed on an Environment tab whose secrets read fails. It now reads `usePlatform()` and routes through `platformHref()`.

## Verification
- apps/build vitest 419 passed / 1 skipped; tsc, eslint, prettier clean
- All six new/updated scoping tests are mutation-checked: they fail when `onPlatform` is a no-op or the panel drops its platform argument
- Root-config vitest on the changed test files: 46 passed / 1 skipped
- Cross-checked against a live staging API audit (service-bearer probes of the manager per-platform project lists vs the account-wide batches)

Companion backend PR (worker availability exemption, deployment-history import door, `get_app` authorization, required-secrets legacy-tag degradation) lands in product-mono.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788813131&installation_model_id=12362&pr_number=468&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F468&signature=f07a7f66e523e40a7853840228a3dec385b0c929bd4e352139bf3bbb09d73ae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->