### PR TITLE
fix(landing): update Discord invite link

### DIFF
--- a/apps/landing/app/contact/page.tsx
+++ b/apps/landing/app/contact/page.tsx
@@ -143,7 +143,7 @@ export default function ContactPage() {
 
               {/* Discord Card */}
               <a
-                href="https://discord.gg/Ngz4KXgn"
+                href="https://discord.gg/uk5ZAMuepJ"
                 target="_blank"
                 rel="noreferrer"
                 className="group flex flex-col items-center gap-4 bg-black/20 p-8 text-center transition-all hover:bg-black/30"

--- a/apps/landing/app/sections/resources.tsx
+++ b/apps/landing/app/sections/resources.tsx
@@ -273,7 +273,7 @@ export function Resources() {
                 </svg>
               </a>
               <a
-                href="https://discord.gg/YK2sqKDBYh"
+                href="https://discord.gg/uk5ZAMuepJ"
                 target="_blank"
                 rel="noreferrer"
                 className="text-neutral-200 transition-colors hover:text-white"


### PR DESCRIPTION
## Summary
Updates the Discord community invite on the landing app to the current server link.

- `apps/landing/app/contact/page.tsx` - Discord card on /contact
- `apps/landing/app/sections/resources.tsx` - homepage resources footer

Old invites (`discord.gg/Ngz4KXgn`, `discord.gg/YK2sqKDBYh`) replaced with `discord.gg/uk5ZAMuepJ`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789044488&installation_model_id=12362&pr_number=478&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F478&signature=cee8d8cd9e4c5b887ef4e4d432f1232fa94eacc7d296c08e154560e0fd3ce74c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->