### PR TITLE
Add frontend release gates and preview smoke

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+.github/workflows/ @h4n0 @phoebe-aomi
+.github/scripts/ @h4n0 @phoebe-aomi
+playwright.config.ts @h4n0 @phoebe-aomi
+tests/e2e/ @h4n0 @phoebe-aomi
+packages/client/test/fixtures/backend-openapi.json @h4n0 @phoebe-aomi

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,0 @@
-.github/workflows/ @h4n0 @phoebe-aomi
-.github/scripts/ @h4n0 @phoebe-aomi
-playwright.config.ts @h4n0 @phoebe-aomi
-tests/e2e/ @h4n0 @phoebe-aomi
-packages/client/test/fixtures/backend-openapi.json @h4n0 @phoebe-aomi
-packages/client/test/fixtures/manager-openapi.json @h4n0 @phoebe-aomi

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 playwright.config.ts @h4n0 @phoebe-aomi
 tests/e2e/ @h4n0 @phoebe-aomi
 packages/client/test/fixtures/backend-openapi.json @h4n0 @phoebe-aomi
+packages/client/test/fixtures/manager-openapi.json @h4n0 @phoebe-aomi

--- a/.github/scripts/check-workflow-policy.py
+++ b/.github/scripts/check-workflow-policy.py
@@ -26,7 +26,18 @@ def event_names(document: dict) -> set[str]:
 
 def permissions(document: dict, job: dict) -> dict[str, str]:
     value = job.get("permissions", document.get("permissions", {}))
-    return value if isinstance(value, dict) else {}
+    if isinstance(value, dict):
+        return value
+    if value == "write-all":
+        return {scope: "write" for scope in FORBIDDEN_WRITE}
+    return {}
+
+
+def environment_name(job: dict) -> str | None:
+    environment = job.get("environment")
+    if isinstance(environment, dict):
+        environment = environment.get("name")
+    return environment if isinstance(environment, str) else None
 
 
 def main() -> int:
@@ -34,11 +45,11 @@ def main() -> int:
     for path in sorted(WORKFLOWS.glob("*.y*ml")):
         text = path.read_text()
         document = yaml.safe_load(text) or {}
-        if "pull_request" in event_names(document):
+        if {"pull_request", "pull_request_target"} & event_names(document):
             for job_name, job in (document.get("jobs") or {}).items():
-                environment = job.get("environment")
-                if isinstance(environment, dict):
-                    environment = environment.get("name")
+                if not isinstance(job, dict):
+                    continue
+                environment = environment_name(job)
                 if environment not in (None, "pr-tests"):
                     failures.append(
                         f"{path.name}:{job_name}: forbidden PR environment {environment!r}"

--- a/.github/scripts/check-workflow-policy.py
+++ b/.github/scripts/check-workflow-policy.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Fail closed on privileged pull-request jobs and mutable Actions refs."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import yaml
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+FORBIDDEN_WRITE = {"packages", "deployments", "id-token"}
+FULL_SHA = re.compile(r"[0-9a-f]{40}")
+
+
+def event_names(document: dict) -> set[str]:
+    trigger = document.get("on", document.get(True, {}))
+    if isinstance(trigger, str):
+        return {trigger}
+    if isinstance(trigger, list):
+        return set(trigger)
+    return set(trigger or {})
+
+
+def permissions(document: dict, job: dict) -> dict[str, str]:
+    value = job.get("permissions", document.get("permissions", {}))
+    return value if isinstance(value, dict) else {}
+
+
+def main() -> int:
+    failures: list[str] = []
+    for path in sorted(WORKFLOWS.glob("*.y*ml")):
+        text = path.read_text()
+        document = yaml.safe_load(text) or {}
+        if "pull_request" in event_names(document):
+            for job_name, job in (document.get("jobs") or {}).items():
+                environment = job.get("environment")
+                if isinstance(environment, dict):
+                    environment = environment.get("name")
+                if environment not in (None, "pr-tests"):
+                    failures.append(
+                        f"{path.name}:{job_name}: forbidden PR environment {environment!r}"
+                    )
+                for scope, level in permissions(document, job).items():
+                    if scope in FORBIDDEN_WRITE and level == "write":
+                        failures.append(
+                            f"{path.name}:{job_name}: PR job grants {scope}: write"
+                        )
+        for line_number, line in enumerate(text.splitlines(), 1):
+            if line.lstrip().startswith("#"):
+                continue
+            match = re.search(r"\buses:\s*([^\s#]+)", line)
+            if not match or match.group(1).startswith("./"):
+                continue
+            ref = match.group(1).rsplit("@", 1)[-1]
+            if not FULL_SHA.fullmatch(ref):
+                failures.append(
+                    f"{path.name}:{line_number}: action is not pinned to a full SHA"
+                )
+    for failure in failures:
+        print(f"ERROR: {failure}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/resolve-preview-urls.sh
+++ b/.github/scripts/resolve-preview-urls.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${PREVIEW_SHA:?PREVIEW_SHA is required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+resolve() {
+  local environment="$1"
+  local output_name="$2"
+  local deployment_id="" url=""
+  for _ in $(seq 1 60); do
+    deployment_id="$(gh api "repos/$GITHUB_REPOSITORY/deployments?sha=$PREVIEW_SHA&per_page=100" \
+      --jq ".[] | select(.environment == \"$environment\") | .id" | head -n 1)"
+    if [[ -n "$deployment_id" ]]; then
+      url="$(gh api "repos/$GITHUB_REPOSITORY/deployments/$deployment_id/statuses?per_page=100" \
+        --jq '[.[] | select(.state == "success" and .environment_url != null)] | first | .environment_url // empty')"
+    fi
+    if [[ "$url" == https://*.vercel.app ]]; then
+      echo "$output_name=$url" >> "$GITHUB_OUTPUT"
+      return 0
+    fi
+    sleep 15
+  done
+  echo "No successful immutable URL for $environment at $PREVIEW_SHA" >&2
+  return 1
+}
+
+resolve "Preview – chat-portal" portal_url
+resolve "Preview – aomi-build" build_url

--- a/.github/scripts/verify-main-ci.sh
+++ b/.github/scripts/verify-main-ci.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${CANDIDATE_SHA:?CANDIDATE_SHA is required}"
+
+[[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "candidate_sha must be a full lowercase commit SHA" >&2
+  exit 1
+}
+git fetch origin main --quiet
+test "$CANDIDATE_SHA" = "$(git rev-parse origin/main)" || {
+  echo "npm publishing only accepts the current main SHA" >&2
+  exit 1
+}
+run_id="$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs?branch=main&status=success&per_page=100" \
+  --jq ".workflow_runs[] | select(.head_sha == \"$CANDIDATE_SHA\") | .id" | head -n 1)"
+test -n "$run_id" || {
+  echo "No successful CI run exists for $CANDIDATE_SHA" >&2
+  exit 1
+}
+echo "Verified successful CI run $run_id for $CANDIDATE_SHA"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,9 +105,10 @@ jobs:
             exit 1
           }
           merge_base="$(git merge-base origin/main origin/prod)"
-          if ! git diff --quiet "$merge_base^{tree}" "origin/prod^{tree}"; then
+          merge_base_tree="$(git rev-parse "${merge_base}^{tree}")"
+          if ! git diff --quiet "$merge_base_tree" "origin/prod^{tree}"; then
             echo "prod contains a tree change that has not been back-merged to main" >&2
-            git diff --stat "$merge_base^{tree}" "origin/prod^{tree}"
+            git diff --stat "$merge_base_tree" "origin/prod^{tree}"
             exit 1
           fi
           git fetch origin "pull/$PR_NUMBER/merge:refs/remotes/origin/promotion-merge" --quiet
@@ -148,9 +149,10 @@ jobs:
           set -euo pipefail
           git fetch origin main prod --quiet
           merge_base="$(git merge-base origin/main origin/prod)"
-          git diff --quiet "$merge_base^{tree}" "origin/prod^{tree}" || {
+          merge_base_tree="$(git rev-parse "${merge_base}^{tree}")"
+          git diff --quiet "$merge_base_tree" "origin/prod^{tree}" || {
             echo "prod has a tree change absent from main; merge the production hotfix first" >&2
-            git diff --stat "$merge_base^{tree}" "origin/prod^{tree}"
+            git diff --stat "$merge_base_tree" "origin/prod^{tree}"
             exit 1
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,22 +89,32 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Require main head and no unreturned production hotfix
+      - name: Require a soaked release candidate and no unreturned production hotfix
         env:
           HEAD_REF: ${{ github.head_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          test "$HEAD_REF" = main || {
-            echo "Production promotion PR head must be main" >&2
+          case "$HEAD_REF" in release/*) ;; *)
+            echo "Production promotion PR head must be release/*" >&2
+            exit 1
+          esac
+          git fetch origin main prod --quiet
+          git merge-base --is-ancestor HEAD origin/main || {
+            echo "Release candidate must be an ancestor of main" >&2
             exit 1
           }
-          git fetch origin main prod --quiet
-          test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
-          if ! git diff --quiet origin/main...origin/prod; then
+          merge_base="$(git merge-base origin/main origin/prod)"
+          if ! git diff --quiet "$merge_base^{tree}" "origin/prod^{tree}"; then
             echo "prod contains a tree change that has not been back-merged to main" >&2
-            git diff --stat origin/main...origin/prod
+            git diff --stat "$merge_base^{tree}" "origin/prod^{tree}"
             exit 1
           fi
+          git fetch origin "pull/$PR_NUMBER/merge:refs/remotes/origin/promotion-merge" --quiet
+          git diff --quiet HEAD^{tree} origin/promotion-merge^{tree} || {
+            echo "The resulting prod merge tree differs from the soaked release candidate" >&2
+            exit 1
+          }
 
       - name: Enable corepack
         run: corepack enable
@@ -122,6 +132,27 @@ jobs:
         env:
           NEXT_PUBLIC_BACKEND_URL: https://api.aomi.dev
         run: pnpm run test:openapi:live
+
+  hotfix-divergence:
+    name: Production Hotfix Divergence
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Require production-only fixes to be back-merged
+        run: |
+          set -euo pipefail
+          git fetch origin main prod --quiet
+          merge_base="$(git merge-base origin/main origin/prod)"
+          git diff --quiet "$merge_base^{tree}" "origin/prod^{tree}" || {
+            echo "prod has a tree change absent from main; merge the production hotfix first" >&2
+            git diff --stat "$merge_base^{tree}" "origin/prod^{tree}"
+            exit 1
+          }
 
   live-production-contract:
     name: Production Backend Contract
@@ -177,7 +208,7 @@ jobs:
   all-checks:
     name: Frontend CI Passed
     if: always()
-    needs: [packages, apps, promotion-policy, workflow-policy]
+    needs: [packages, apps, promotion-policy, hotfix-divergence, workflow-policy]
     runs-on: ubuntu-latest
     steps:
       - name: Aggregate required checks
@@ -186,4 +217,5 @@ jobs:
           test '${{ needs.packages.result }}' = success
           test '${{ needs.apps.result }}' = success
           case '${{ needs.promotion-policy.result }}' in success|skipped) ;; *) exit 1 ;; esac
+          case '${{ needs.hotfix-divergence.result }}' in success|skipped) ;; *) exit 1 ;; esac
           test '${{ needs.workflow-policy.result }}' = success

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,118 +2,188 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
-      - prod
+    branches: [main, prod]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: frontend-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  build-and-lint:
+  packages:
+    name: Packages · lint, types, tests, builds
     runs-on: ubuntu-latest
-    environment: ${{ github.ref == 'refs/heads/prod' && 'Production' || 'Preview' }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Checkout exact source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Enable corepack
         run: corepack enable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Lint (library)
-        run: pnpm run lint
+      - name: Lint and typecheck workspace
+        run: pnpm run lint && pnpm run typecheck
 
-      - name: Build library bundle
-        run: pnpm run build:lib
+      - name: Build every publishable package
+        run: pnpm run build:packages
 
-      - name: Build @aomi-labs/deploy
-        run: pnpm run build:deploy
+      - name: Run workspace tests and committed OpenAPI contract
+        run: pnpm exec vitest run
 
-      # Must precede the test steps: the Aomi Build suites import
-      # `@aomi-labs/widget-lib`, which only resolves once the registry is built.
-      - name: Build registry
-        run: pnpm run build:registry
+  apps:
+    name: Apps · Portal, Build, Base, Landing, Telegram
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - name: Run library tests
-        run: pnpm run test
+      - name: Enable corepack
+        run: corepack enable
 
-      - name: Check live backend OpenAPI contract
-        # Pull requests are checked against the exact combined backend/manager
-        # fixture above. Staging can legitimately lag a coordinated backend PR,
-        # so compare with the deployed API only after a branch is merged.
-        if: github.event_name == 'push' && vars.NEXT_PUBLIC_BACKEND_URL != ''
-        run: pnpm run test:openapi:live
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package prerequisites
+        run: pnpm run build:packages
+
+      - name: Typecheck and test every app
+        run: pnpm run typecheck:apps && pnpm run test:portal && pnpm run test:telegram
+
+      - name: Build every deployed app
         env:
-          NEXT_PUBLIC_BACKEND_URL: ${{ vars.NEXT_PUBLIC_BACKEND_URL }}
-
-      - name: Run registry tests
-        run: pnpm --dir apps/shadcn-registry exec vitest run
-
-      - name: Build landing app
-        run: pnpm --filter landing build
-        env:
+          BETTER_AUTH_SECRET: ci-build-only-secret-at-least-32-bytes-long
+          BETTER_AUTH_URL: http://localhost:3000
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/aomi_ci_build
           NEXT_PUBLIC_PROJECT_ID: 000000000000000000000000000000000000000000
+          NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: 000000000000000000000000000000000000000000
+          NEXT_PUBLIC_PARA_API_KEY: ci-fixture-not-a-secret
+          NEXT_PUBLIC_PARA_ENVIRONMENT: BETA
+          NEXT_PUBLIC_BACKEND_URL: ${{ github.ref == 'refs/heads/prod' && 'https://api.aomi.dev' || 'https://api-staging.aomi.dev' }}
+        run: pnpm run build:apps
 
-  publish-npm:
-    name: Publish to npm
-    needs: build-and-lint
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+  promotion-policy:
+    name: Production Promotion Policy
+    if: github.event_name == 'pull_request' && github.base_ref == 'prod'
     runs-on: ubuntu-latest
-    concurrency:
-      group: npm-publish-${{ github.ref }}
-      cancel-in-progress: false
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Checkout exact PR head
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Require main head and no unreturned production hotfix
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          test "$HEAD_REF" = main || {
+            echo "Production promotion PR head must be main" >&2
+            exit 1
+          }
+          git fetch origin main prod --quiet
+          test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
+          if ! git diff --quiet origin/main...origin/prod; then
+            echo "prod contains a tree change that has not been back-merged to main" >&2
+            git diff --stat origin/main...origin/prod
+            exit 1
+          fi
 
       - name: Enable corepack
         run: corepack enable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
-          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build @aomi-labs/client
-        run: pnpm run build:client
-
-      - name: Build @aomi-labs/react
-        run: pnpm run build:lib
-
-      - name: Build @aomi-labs/widget-lib (shadcn registry)
-        run: pnpm run build:registry
-
-      - name: Build @aomi-labs/deploy
-        run: pnpm run build:deploy
-
-      - name: Publish @aomi-labs/client
-        run: node scripts/publish-package-if-needed.mjs packages/client
+      - name: Gate frontend promotion on the deployed production API
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NEXT_PUBLIC_BACKEND_URL: https://api.aomi.dev
+        run: pnpm run test:openapi:live
 
-      - name: Publish @aomi-labs/deploy
-        run: node scripts/publish-package-if-needed.mjs packages/deploy
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  live-production-contract:
+    name: Production Backend Contract
+    if: github.event_name == 'push' && github.ref == 'refs/heads/prod'
+    needs: [packages, apps]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout production source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - name: Publish @aomi-labs/react
-        run: node scripts/publish-package-if-needed.mjs packages/react
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Enable corepack
+        run: corepack enable
 
-      - name: Publish @aomi-labs/widget-lib
-        run: node scripts/publish-package-if-needed.mjs apps/shadcn-registry
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify committed frontend contract against api.aomi.dev
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NEXT_PUBLIC_BACKEND_URL: https://api.aomi.dev
+        run: pnpm run test:openapi:live
+
+  workflow-policy:
+    name: Workflow Security Policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Install policy tools
+        run: |
+          python3 -m venv /tmp/aomi-workflow-policy
+          /tmp/aomi-workflow-policy/bin/pip install --disable-pip-version-check \
+            'PyYAML==6.0.2' 'zizmor==1.29.0'
+          GOBIN=/tmp/aomi-workflow-policy/bin go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+
+      - name: Enforce workflow policy
+        run: /tmp/aomi-workflow-policy/bin/python .github/scripts/check-workflow-policy.py
+
+      - name: Validate workflow syntax
+        run: /tmp/aomi-workflow-policy/bin/actionlint
+
+      - name: Reject high-severity workflow findings
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: /tmp/aomi-workflow-policy/bin/zizmor --min-severity high .github/workflows
+
+  all-checks:
+    name: Frontend CI Passed
+    if: always()
+    needs: [packages, apps, promotion-policy, workflow-policy]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate required checks
+        run: |
+          set -euo pipefail
+          test '${{ needs.packages.result }}' = success
+          test '${{ needs.apps.result }}' = success
+          case '${{ needs.promotion-policy.result }}' in success|skipped) ;; *) exit 1 ;; esac
+          test '${{ needs.workflow-policy.result }}' = success

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,14 +105,15 @@ jobs:
             exit 1
           }
           merge_base="$(git merge-base origin/main origin/prod)"
-          merge_base_tree="$(git rev-parse "${merge_base}^{tree}")"
-          if ! git diff --quiet "$merge_base_tree" "origin/prod^{tree}"; then
+          merge_base_tree="$(git show -s --format=%T "$merge_base")"
+          prod_tree="$(git show -s --format=%T origin/prod)"
+          if ! git diff --quiet "$merge_base_tree" "$prod_tree"; then
             echo "prod contains a tree change that has not been back-merged to main" >&2
-            git diff --stat "$merge_base_tree" "origin/prod^{tree}"
+            git diff --stat "$merge_base_tree" "$prod_tree"
             exit 1
           fi
           git fetch origin "pull/$PR_NUMBER/merge:refs/remotes/origin/promotion-merge" --quiet
-          git diff --quiet HEAD^{tree} origin/promotion-merge^{tree} || {
+          git diff --quiet "$(git show -s --format=%T HEAD)" "$(git show -s --format=%T origin/promotion-merge)" || {
             echo "The resulting prod merge tree differs from the soaked release candidate" >&2
             exit 1
           }
@@ -149,10 +150,11 @@ jobs:
           set -euo pipefail
           git fetch origin main prod --quiet
           merge_base="$(git merge-base origin/main origin/prod)"
-          merge_base_tree="$(git rev-parse "${merge_base}^{tree}")"
-          git diff --quiet "$merge_base_tree" "origin/prod^{tree}" || {
+          merge_base_tree="$(git show -s --format=%T "$merge_base")"
+          prod_tree="$(git show -s --format=%T origin/prod)"
+          git diff --quiet "$merge_base_tree" "$prod_tree" || {
             echo "prod has a tree change absent from main; merge the production hotfix first" >&2
-            git diff --stat "$merge_base_tree" "origin/prod^{tree}"
+            git diff --stat "$merge_base_tree" "$prod_tree"
             exit 1
           }
 

--- a/.github/workflows/preview-e2e-nightly.yml
+++ b/.github/workflows/preview-e2e-nightly.yml
@@ -1,0 +1,49 @@
+name: Preview E2E Nightly Fallback
+
+on:
+  schedule:
+    - cron: "23 2 * * 1-5"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  playwright:
+    if: vars.PLAYWRIGHT_PREVIEW_MODE == 'nightly' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies and browser
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm exec playwright install --with-deps chromium
+
+      - name: Run canonical staging smoke
+        env:
+          PORTAL_PREVIEW_URL: https://chat-staging.aomi.dev
+          BUILD_PREVIEW_URL: https://build-staging.aomi.dev
+        run: pnpm exec playwright test
+
+      - name: Upload Playwright diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: preview-e2e-nightly-${{ github.run_id }}
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/preview-e2e.yml
+++ b/.github/workflows/preview-e2e.yml
@@ -1,0 +1,75 @@
+name: Preview E2E
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  deployments: read
+
+concurrency:
+  group: preview-e2e-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  playwright:
+    name: Playwright Preview (non-blocking observation)
+    if: vars.PLAYWRIGHT_PREVIEW_MODE != 'nightly'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout exact PR source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Resolve same-SHA immutable Vercel URLs
+        id: previews
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREVIEW_SHA: ${{ github.event.pull_request.head.sha }}
+        run: .github/scripts/resolve-preview-urls.sh
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies and browser
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm exec playwright install --with-deps chromium
+
+      - name: Run anonymous Chat and Build smoke
+        env:
+          PORTAL_PREVIEW_URL: ${{ steps.previews.outputs.portal_url }}
+          BUILD_PREVIEW_URL: ${{ steps.previews.outputs.build_url }}
+        run: pnpm exec playwright test
+
+      - name: Upload Playwright diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: preview-e2e-${{ github.event.pull_request.head.sha }}
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Publish observation summary
+        if: always()
+        run: |
+          {
+            echo "## Preview E2E observation"
+            echo "- Mode: non-blocking"
+            echo "- Owner: CI/release DRI"
+            echo "- PR SHA: \`${{ github.event.pull_request.head.sha }}\`"
+            echo "- Diagnostics: \`preview-e2e-${{ github.event.pull_request.head.sha }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -1,0 +1,61 @@
+name: Production Frontend Smoke
+
+on:
+  push:
+    branches: [prod]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-frontend-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout deployed production source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event_name == 'push' && github.sha || 'prod' }}
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies and browser
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm exec playwright install --with-deps chromium
+
+      - name: Wait for canonical production and run smoke
+        env:
+          PORTAL_PREVIEW_URL: https://chat.aomi.dev
+          BUILD_PREVIEW_URL: https://build.aomi.dev
+        run: |
+          for _ in $(seq 1 20); do
+            if curl -fsS https://chat.aomi.dev/health >/dev/null 2>&1 || curl -fsS https://chat.aomi.dev/ >/dev/null; then
+              break
+            fi
+            sleep 15
+          done
+          pnpm exec playwright test
+
+      - name: Upload production diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: production-frontend-smoke-${{ github.run_id }}
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/publish-npm-oidc-canary.yml
+++ b/.github/workflows/publish-npm-oidc-canary.yml
@@ -1,0 +1,75 @@
+name: Publish npm OIDC Canary
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: Full current main SHA with a reviewed unpublished prerelease version
+        required: true
+        type: string
+      package_directory:
+        description: Reviewed package directory to publish
+        required: true
+        type: choice
+        options:
+          - packages/client
+          - packages/deploy
+          - packages/react
+          - apps/shadcn-registry
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout exact candidate
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ inputs.candidate_sha }}
+          fetch-depth: 0
+
+      - name: Verify current main and successful same-SHA CI
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+        run: .github/scripts/verify-main-ci.sh
+
+      - name: Require a prerelease version
+        env:
+          PACKAGE_DIRECTORY: ${{ inputs.package_directory }}
+        run: |
+          node -e 'const p=require("./"+process.env.PACKAGE_DIRECTORY+"/package.json"); if (!p.version.includes("-")) throw new Error("OIDC canary requires a reviewed prerelease version")'
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22.14.0
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install supported npm and build packages
+        run: |
+          npm install --global npm@11.5.1
+          test "$(npm --version)" = 11.5.1
+          pnpm install --frozen-lockfile
+          pnpm run build:packages
+
+      - name: Prove trusted publishing with no token fallback
+        env:
+          NPM_CONFIG_PROVENANCE: "true"
+          NPM_DIST_TAG: oidc-canary
+        run: node scripts/publish-package-if-needed.mjs '${{ inputs.package_directory }}'

--- a/.github/workflows/publish-npm-token.yml
+++ b/.github/workflows/publish-npm-token.yml
@@ -1,0 +1,57 @@
+name: Publish npm (token)
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: Full current main SHA
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact candidate
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ inputs.candidate_sha }}
+          fetch-depth: 0
+
+      - name: Verify current main and successful same-SHA CI
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+        run: .github/scripts/verify-main-ci.sh
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22.14.0
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install and build publishable packages
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm run build:packages
+
+      - name: Publish versions not already present
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          node scripts/publish-package-if-needed.mjs packages/client
+          node scripts/publish-package-if-needed.mjs packages/deploy
+          node scripts/publish-package-if-needed.mjs packages/react
+          node scripts/publish-package-if-needed.mjs apps/shadcn-registry

--- a/.github/workflows/rollback-frontend.yml
+++ b/.github/workflows/rollback-frontend.yml
@@ -59,11 +59,31 @@ jobs:
         run: |
           set -euo pipefail
           test -n "$VERCEL_TOKEN" || { echo "production VERCEL_TOKEN is required" >&2; exit 1; }
-          for deployment in "$PORTAL" "$BUILD" "$BASE" "$LANDING" "$TELEGRAM"; do
-            vercel rollback "$deployment" --yes --token="$VERCEL_TOKEN"
-          done
+          failures=()
+          declare -A deployments=(
+            [portal]="$PORTAL"
+            [build]="$BUILD"
+            [base]="$BASE"
+            [landing]="$LANDING"
+            [telegram]="$TELEGRAM"
+          )
           {
             echo "## Frontend production rollback"
-            echo "- Restored Portal, Build, Base, Landing, and Telegram from ledgered deployments."
-            echo "- Run production smoke and record the resulting compatibility tuple."
+            echo
+            echo "| Surface | Deployment | Result |"
+            echo "|---|---|---|"
           } >> "$GITHUB_STEP_SUMMARY"
+          for surface in portal build base landing telegram; do
+            deployment="${deployments[$surface]}"
+            if vercel rollback "$deployment" --yes --token="$VERCEL_TOKEN"; then
+              echo "| $surface | \`$deployment\` | restored |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              failures+=("$surface")
+              echo "| $surface | \`$deployment\` | **failed** |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+          if [ "${#failures[@]}" -gt 0 ]; then
+            echo "Rollback is incomplete; failed surfaces: ${failures[*]}" >&2
+            exit 1
+          fi
+          echo "- All surfaces restored; run production smoke and record the resulting compatibility tuple." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/rollback-frontend.yml
+++ b/.github/workflows/rollback-frontend.yml
@@ -1,0 +1,69 @@
+name: Rollback Frontend Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      portal_deployment:
+        description: Ledgered Portal deployment URL or ID
+        required: true
+        type: string
+      build_deployment:
+        description: Ledgered Build deployment URL or ID
+        required: true
+        type: string
+      base_deployment:
+        description: Ledgered Base deployment URL or ID
+        required: true
+        type: string
+      landing_deployment:
+        description: Ledgered Landing deployment URL or ID
+        required: true
+        type: string
+      telegram_deployment:
+        description: Ledgered Telegram deployment URL or ID
+        required: true
+        type: string
+      confirm:
+        description: Type ROLLBACK
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frontend-production-rollback
+  cancel-in-progress: false
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Validate rollback authorization
+        env:
+          CONFIRM: ${{ inputs.confirm }}
+        run: test "$CONFIRM" = ROLLBACK
+
+      - name: Install pinned Vercel CLI
+        run: npm install --global vercel@58.11.0
+
+      - name: Restore each ledgered production deployment
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          PORTAL: ${{ inputs.portal_deployment }}
+          BUILD: ${{ inputs.build_deployment }}
+          BASE: ${{ inputs.base_deployment }}
+          LANDING: ${{ inputs.landing_deployment }}
+          TELEGRAM: ${{ inputs.telegram_deployment }}
+        run: |
+          set -euo pipefail
+          test -n "$VERCEL_TOKEN" || { echo "production VERCEL_TOKEN is required" >&2; exit 1; }
+          for deployment in "$PORTAL" "$BUILD" "$BASE" "$LANDING" "$TELEGRAM"; do
+            vercel rollback "$deployment" --yes --token="$VERCEL_TOKEN"
+          done
+          {
+            echo "## Frontend production rollback"
+            echo "- Restored Portal, Build, Base, Landing, and Telegram from ledgered deployments."
+            echo "- Run production smoke and record the resulting compatibility tuple."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/apps/build/src/features/build/build-view.tsx
+++ b/apps/build/src/features/build/build-view.tsx
@@ -369,7 +369,10 @@ export function BuildView() {
     (displayStageId === "plan" || displayStageId === "generate");
 
   return (
-    <div className="flex h-[calc(100dvh-2.75rem)] min-h-0 w-full">
+    <div
+      data-testid="build-shell"
+      className="flex h-[calc(100dvh-2.75rem)] min-h-0 w-full"
+    >
       {recentOpen ? (
         <aside className="border-border flex w-[220px] shrink-0 flex-col gap-3 overflow-y-auto border-r p-3">
           <SessionHistory

--- a/apps/build/src/features/build/components/intent-composer.tsx
+++ b/apps/build/src/features/build/components/intent-composer.tsx
@@ -120,6 +120,7 @@ export const IntentComposer = forwardRef<
         )}
       >
         <textarea
+          data-testid="build-intent-composer"
           ref={textareaRef}
           value={value}
           onChange={(e) => onChange(e.target.value)}

--- a/apps/portal/src/components/shell/portal-aomi-frame.tsx
+++ b/apps/portal/src/components/shell/portal-aomi-frame.tsx
@@ -154,7 +154,10 @@ export function PortalAomiFrame() {
   }
 
   return (
-    <main className="bg-background relative h-full w-full overflow-hidden">
+    <main
+      data-testid="portal-shell"
+      className="bg-background relative h-full w-full overflow-hidden"
+    >
       <AomiFrame.Root
         key={accountFrameScope.revision}
         width="100%"

--- a/apps/shadcn-registry/src/lib/wallet-kit/providers/para/para-evm-runtime-provider.tsx
+++ b/apps/shadcn-registry/src/lib/wallet-kit/providers/para/para-evm-runtime-provider.tsx
@@ -11,6 +11,11 @@ import {
 import { AomiEvmRuntimeProvider } from "../../runtime/evm/provider";
 import { useSafeParaClient } from "./para-auth";
 
+type AomiConnector = NonNullable<
+  ResolvedEvmWalletsConfig["connectors"]
+>[number];
+type ConnectorPara = Parameters<typeof paraConnector>[0]["para"];
+
 export function createAomiParaEvmConfig(
   config: ResolvedEvmWalletsConfig,
   para: ParaWeb | null,
@@ -21,14 +26,18 @@ export function createAomiParaEvmConfig(
       ...(config.connectors ?? []),
       ...(para
         ? [
+            // Consumers can use a newer compatible Para SDK than widget-lib.
+            // Para's private fields make those otherwise-compatible SDK
+            // instances nominal, so normalize both Para and Wagmi types at
+            // this package boundary.
             paraConnector({
-              para,
+              para: para as unknown as ConnectorPara,
               chains: [...config.chains],
               disableModal: true,
               appName: config.appName ?? "Aomi",
               options: { shimDisconnect: true },
               transports: config.transports,
-            }),
+            }) as unknown as AomiConnector,
           ]
         : []),
     ],

--- a/packages/client/test/backend-openapi.contract.test.ts
+++ b/packages/client/test/backend-openapi.contract.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import backendOpenApiFixture from "./fixtures/backend-openapi.json";
+import managerOpenApiFixture from "./fixtures/manager-openapi.json";
 import { AOMI_BACKEND_ENDPOINTS } from "./routes";
 import type { AomiAuthClass, AomiHttpMethod } from "./routes";
 
@@ -20,6 +21,20 @@ const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
 describe("backend OpenAPI route contract", () => {
   it("keeps the client route manifest aligned with the checked-in backend OpenAPI fixture", () => {
     expectRouteContract(backendOpenApiFixture as OpenApiDocument);
+  });
+
+  it("retains every separately generated manager operation in the merged contract", () => {
+    const managerRoutes = routeContractFromOpenApi(
+      managerOpenApiFixture as OpenApiDocument,
+    );
+    const mergedRoutes = new Set(
+      routeContractFromOpenApi(backendOpenApiFixture as OpenApiDocument),
+    );
+
+    // This is deliberately an explicit review point: silently dropping the
+    // manager exporter from the generator must not shrink rollback safety.
+    expect(managerRoutes).toHaveLength(61);
+    expect(managerRoutes.every((route) => mergedRoutes.has(route))).toBe(true);
   });
 
   it.runIf(process.env.AOMI_BACKEND_OPENAPI_URL)(

--- a/packages/client/test/client.unit.test.ts
+++ b/packages/client/test/client.unit.test.ts
@@ -11,7 +11,7 @@ describe("AomiClient route manifest", () => {
         `${endpoint.method} ${endpoint.path} [${endpoint.auth.join(", ")}]`,
     );
 
-    expect(routeKeys).toHaveLength(139);
+    expect(routeKeys).toHaveLength(146);
     expect(new Set(routeKeys).size).toBe(routeKeys.length);
     expect(routeKeys).toContain("GET /api/account/statement [account]");
     // Public placement probe. Kept distinct from GET /health, which stays a

--- a/packages/client/test/fixtures/backend-openapi.json
+++ b/packages/client/test/fixtures/backend-openapi.json
@@ -50,7 +50,9 @@
             "serviceBearer": []
           }
         ],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/exec/simulate": {
@@ -65,7 +67,9 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["thread"]
+        "x-aomi-auth": [
+          "thread"
+        ]
       }
     },
     "/api/exec/tool-call": {
@@ -81,7 +85,10 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["account", "thread"]
+        "x-aomi-auth": [
+          "account",
+          "thread"
+        ]
       }
     },
     "/api/exec/run": {
@@ -97,7 +104,10 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["account", "thread"]
+        "x-aomi-auth": [
+          "account",
+          "thread"
+        ]
       }
     },
     "/api/aa/v1/{chain_slug}": {
@@ -112,7 +122,9 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["thread"]
+        "x-aomi-auth": [
+          "thread"
+        ]
       }
     },
     "/api/_internal/secrets": {
@@ -127,7 +139,9 @@
             "serviceBearer": []
           }
         ],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       },
       "get": {
         "responses": {
@@ -140,7 +154,9 @@
             "serviceBearer": []
           }
         ],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       },
       "delete": {
         "responses": {
@@ -153,7 +169,9 @@
             "serviceBearer": []
           }
         ],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/auth/privy/begin": {
@@ -168,7 +186,9 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["thread"]
+        "x-aomi-auth": [
+          "thread"
+        ]
       }
     },
     "/api/auth/privy/callback": {
@@ -194,7 +214,9 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["thread"]
+        "x-aomi-auth": [
+          "thread"
+        ]
       }
     },
     "/api/auth/para/callback": {
@@ -221,7 +243,10 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["account", "thread"]
+        "x-aomi-auth": [
+          "account",
+          "thread"
+        ]
       },
       "post": {
         "responses": {
@@ -234,7 +259,9 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["thread"]
+        "x-aomi-auth": [
+          "thread"
+        ]
       }
     },
     "/api/threads/{thread_id}": {
@@ -250,7 +277,10 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["account", "thread"]
+        "x-aomi-auth": [
+          "account",
+          "thread"
+        ]
       },
       "get": {
         "responses": {
@@ -264,7 +294,10 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["account", "thread"]
+        "x-aomi-auth": [
+          "account",
+          "thread"
+        ]
       },
       "patch": {
         "responses": {
@@ -278,7 +311,10 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["account", "thread"]
+        "x-aomi-auth": [
+          "account",
+          "thread"
+        ]
       }
     },
     "/api/threads/{thread_id}/archive": {
@@ -294,7 +330,10 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["account", "thread"]
+        "x-aomi-auth": [
+          "account",
+          "thread"
+        ]
       }
     },
     "/api/threads/{thread_id}/unarchive": {
@@ -310,7 +349,10 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["account", "thread"]
+        "x-aomi-auth": [
+          "account",
+          "thread"
+        ]
       }
     },
     "/api/account": {
@@ -325,7 +367,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/apps": {
@@ -340,7 +384,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       },
       "put": {
         "responses": {
@@ -353,7 +399,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/usage": {
@@ -368,7 +416,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/statement": {
@@ -383,7 +433,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/status": {
@@ -398,7 +450,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/wallets": {
@@ -413,7 +467,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/grants": {
@@ -428,7 +484,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/authorization/challenge": {
@@ -443,7 +501,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/authorization/commit": {
@@ -458,7 +518,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/providers/{provider}/agent-wallet": {
@@ -473,7 +535,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/providers/{provider}/grant": {
@@ -488,7 +552,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/scheduled-intents": {
@@ -503,7 +569,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/scheduled-intents/{id}": {
@@ -518,7 +586,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       },
       "delete": {
         "responses": {
@@ -531,7 +601,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/app-keys": {
@@ -546,7 +618,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       },
       "post": {
         "responses": {
@@ -559,7 +633,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/app-keys/{key_hash}": {
@@ -574,7 +650,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/bots": {
@@ -589,7 +667,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       },
       "post": {
         "responses": {
@@ -602,7 +682,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/bots/{id}": {
@@ -617,7 +699,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/payment": {
@@ -632,7 +716,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/payment/byok": {
@@ -647,7 +733,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/payment/byok/{provider}": {
@@ -662,7 +750,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/account/payment/tempo": {
@@ -677,7 +767,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       },
       "post": {
         "responses": {
@@ -690,7 +782,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/resource/apps": {
@@ -705,7 +799,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/resource/apps/{app}": {
@@ -720,7 +816,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/resource/tools": {
@@ -735,7 +833,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/resource/tools/{tool_id}": {
@@ -750,7 +850,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/resource/skills": {
@@ -765,7 +867,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/resource/skills/{skill_id}": {
@@ -780,7 +884,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/resource/search/apps": {
@@ -795,7 +901,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/resource/search/tools": {
@@ -810,7 +918,9 @@
             "accountBearer": []
           }
         ],
-        "x-aomi-auth": ["account"]
+        "x-aomi-auth": [
+          "account"
+        ]
       }
     },
     "/api/thread/chat": {
@@ -826,7 +936,10 @@
             "appKey": []
           }
         ],
-        "x-aomi-auth": ["thread", "app_gate"]
+        "x-aomi-auth": [
+          "thread",
+          "app_gate"
+        ]
       }
     },
     "/api/thread/state": {
@@ -841,7 +954,9 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["thread"]
+        "x-aomi-auth": [
+          "thread"
+        ]
       }
     },
     "/api/thread/interrupt": {
@@ -856,7 +971,9 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["thread"]
+        "x-aomi-auth": [
+          "thread"
+        ]
       }
     },
     "/api/thread/updates": {
@@ -871,7 +988,9 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["thread"]
+        "x-aomi-auth": [
+          "thread"
+        ]
       }
     },
     "/api/thread/events": {
@@ -886,7 +1005,9 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["thread"]
+        "x-aomi-auth": [
+          "thread"
+        ]
       }
     },
     "/api/thread/apps": {
@@ -901,7 +1022,9 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["thread"]
+        "x-aomi-auth": [
+          "thread"
+        ]
       }
     },
     "/api/thread/runtime/models": {
@@ -916,7 +1039,9 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["thread"]
+        "x-aomi-auth": [
+          "thread"
+        ]
       }
     },
     "/api/thread/runtime/model": {
@@ -931,7 +1056,9 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["thread"]
+        "x-aomi-auth": [
+          "thread"
+        ]
       }
     },
     "/api/thread/models": {
@@ -946,7 +1073,9 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["thread"]
+        "x-aomi-auth": [
+          "thread"
+        ]
       }
     },
     "/api/thread/model": {
@@ -961,7 +1090,9 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["thread"]
+        "x-aomi-auth": [
+          "thread"
+        ]
       }
     },
     "/api/platforms/{name}/apps": {
@@ -976,7 +1107,9 @@
             "platformBearer": []
           }
         ],
-        "x-aomi-auth": ["activation"]
+        "x-aomi-auth": [
+          "activation"
+        ]
       }
     },
     "/api/platforms/{name}/apps/{app}": {
@@ -991,7 +1124,9 @@
             "platformBearer": []
           }
         ],
-        "x-aomi-auth": ["activation"]
+        "x-aomi-auth": [
+          "activation"
+        ]
       }
     },
     "/api/platforms/{name}/telegram/handover": {
@@ -1006,7 +1141,9 @@
             "platformBearer": []
           }
         ],
-        "x-aomi-auth": ["activation"]
+        "x-aomi-auth": [
+          "activation"
+        ]
       }
     },
     "/api/platforms/{name}/telegram/handover/{bot}/{id}": {
@@ -1021,7 +1158,9 @@
             "platformBearer": []
           }
         ],
-        "x-aomi-auth": ["activation"]
+        "x-aomi-auth": [
+          "activation"
+        ]
       }
     },
     "/api/platforms/{name}/telegram/handover/{bot}/{id}/activate": {
@@ -1036,7 +1175,9 @@
             "platformBearer": []
           }
         ],
-        "x-aomi-auth": ["activation"]
+        "x-aomi-auth": [
+          "activation"
+        ]
       }
     },
     "/api/platforms/{name}/telegram/handover/{bot}/{id}/revoke": {
@@ -1051,7 +1192,9 @@
             "platformBearer": []
           }
         ],
-        "x-aomi-auth": ["activation"]
+        "x-aomi-auth": [
+          "activation"
+        ]
       }
     },
     "/api/bots/telegram/{webhook_secret}": {
@@ -1077,7 +1220,43 @@
             "adminBearer": []
           }
         ],
-        "x-aomi-auth": ["admin"]
+        "x-aomi-auth": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/release": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "adminBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/release/sentry-smoke": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "adminBearer": []
+          }
+        ],
+        "x-aomi-auth": [
+          "admin"
+        ]
       }
     },
     "/api/admin/apps/{app}/reload": {
@@ -1092,7 +1271,9 @@
             "adminBearer": []
           }
         ],
-        "x-aomi-auth": ["admin"]
+        "x-aomi-auth": [
+          "admin"
+        ]
       }
     },
     "/api/admin/apps/public": {
@@ -1107,7 +1288,9 @@
             "adminBearer": []
           }
         ],
-        "x-aomi-auth": ["admin"]
+        "x-aomi-auth": [
+          "admin"
+        ]
       },
       "put": {
         "responses": {
@@ -1120,7 +1303,9 @@
             "adminBearer": []
           }
         ],
-        "x-aomi-auth": ["admin"]
+        "x-aomi-auth": [
+          "admin"
+        ]
       }
     },
     "/api/admin/skills": {
@@ -1135,7 +1320,9 @@
             "adminBearer": []
           }
         ],
-        "x-aomi-auth": ["admin"]
+        "x-aomi-auth": [
+          "admin"
+        ]
       }
     },
     "/api/admin/skills/batch": {
@@ -1150,7 +1337,9 @@
             "adminBearer": []
           }
         ],
-        "x-aomi-auth": ["admin"]
+        "x-aomi-auth": [
+          "admin"
+        ]
       }
     },
     "/api/admin/skills/rollback": {
@@ -1165,7 +1354,9 @@
             "adminBearer": []
           }
         ],
-        "x-aomi-auth": ["admin"]
+        "x-aomi-auth": [
+          "admin"
+        ]
       }
     },
     "/api/admin/skills/{id}": {
@@ -1180,7 +1371,9 @@
             "adminBearer": []
           }
         ],
-        "x-aomi-auth": ["admin"]
+        "x-aomi-auth": [
+          "admin"
+        ]
       },
       "put": {
         "responses": {
@@ -1193,7 +1386,9 @@
             "adminBearer": []
           }
         ],
-        "x-aomi-auth": ["admin"]
+        "x-aomi-auth": [
+          "admin"
+        ]
       }
     },
     "/api/skills": {
@@ -1220,7 +1415,10 @@
             "threadId": []
           }
         ],
-        "x-aomi-auth": ["account", "thread"]
+        "x-aomi-auth": [
+          "account",
+          "thread"
+        ]
       }
     },
     "/api/integrations/github-app/oauth/start": {
@@ -1297,7 +1495,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/projects": {
@@ -1308,7 +1508,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/projects/{id}": {
@@ -1319,7 +1521,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/builder/applications/{application_id}": {
@@ -1330,7 +1534,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/deployments": {
@@ -1341,7 +1547,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/projects/{id}/latest-deployment": {
@@ -1352,7 +1560,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/projects/{id}/required-secrets": {
@@ -1363,7 +1573,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/projects/{id}/sdk-upgrade": {
@@ -1374,7 +1586,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/projects/{id}/sdk-upgrade-status": {
@@ -1385,7 +1599,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/projects/{id}/deployments": {
@@ -1396,7 +1612,74 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/deployments/{deployment}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/deployments/{deployment}/promote": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/deployments/{deployment}/refresh": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/releases/activate": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/deployments/import": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/projects/{id}/apps": {
@@ -1407,7 +1690,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/projects/{id}/transactions": {
@@ -1418,7 +1703,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/projects/{id}/usage": {
@@ -1429,7 +1716,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/projects/{id}/logs": {
@@ -1440,7 +1729,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/projects/{id}/observability": {
@@ -1451,7 +1742,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/observability": {
@@ -1462,7 +1755,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/payments": {
@@ -1473,7 +1768,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/transactions": {
@@ -1484,7 +1781,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/statement": {
@@ -1495,7 +1794,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/usage": {
@@ -1506,7 +1807,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/logs": {
@@ -1517,7 +1820,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/projects/{id}/statement": {
@@ -1528,7 +1833,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/builder/applications/{application_id}/detail": {
@@ -1539,7 +1846,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/builder/applications/{application_id}/tools/{tool}/trace": {
@@ -1550,7 +1859,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/projects/{id}/bots": {
@@ -1561,7 +1872,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       },
       "post": {
         "responses": {
@@ -1570,7 +1883,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/projects/{id}/bots/{bot_id}": {
@@ -1581,7 +1896,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/bots": {
@@ -1592,7 +1909,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       },
       "post": {
         "responses": {
@@ -1601,7 +1920,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/bots/{bot_id}": {
@@ -1612,7 +1933,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       },
       "delete": {
         "responses": {
@@ -1621,7 +1944,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/model-keys": {
@@ -1632,7 +1957,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       },
       "post": {
         "responses": {
@@ -1641,7 +1968,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/model-keys/{key_id}": {
@@ -1652,7 +1981,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       },
       "delete": {
         "responses": {
@@ -1661,7 +1992,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/user/model-keys/{key_id}/grants": {
@@ -1672,7 +2005,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["service"]
+        "x-aomi-auth": [
+          "service"
+        ]
       }
     },
     "/api/integrations/github-app/platforms/{name}/projects/create-from-template": {
@@ -1683,7 +2018,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["activation"]
+        "x-aomi-auth": [
+          "activation"
+        ]
       }
     },
     "/api/platforms/{name}/activate": {
@@ -1694,7 +2031,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["activation"]
+        "x-aomi-auth": [
+          "activation"
+        ]
       }
     },
     "/api/platforms/{name}/deactivate": {
@@ -1705,7 +2044,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["activation"]
+        "x-aomi-auth": [
+          "activation"
+        ]
       }
     },
     "/api/projects/{project_id}/deploy": {
@@ -1716,7 +2057,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["activation"]
+        "x-aomi-auth": [
+          "activation"
+        ]
       }
     },
     "/api/platforms/{name}/apps/activate": {
@@ -1727,7 +2070,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["activation"]
+        "x-aomi-auth": [
+          "activation"
+        ]
       }
     },
     "/api/platforms/{name}/applications/{application_id}/deactivate": {
@@ -1738,7 +2083,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["activation"]
+        "x-aomi-auth": [
+          "activation"
+        ]
       }
     },
     "/api/platforms/{name}/deployments/{deployment}/status": {
@@ -1749,7 +2096,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["activation"]
+        "x-aomi-auth": [
+          "activation"
+        ]
       }
     },
     "/api/platforms/{name}/deployments/{deployment}/rerun": {
@@ -1760,7 +2109,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["activation"]
+        "x-aomi-auth": [
+          "activation"
+        ]
       }
     },
     "/api/platforms/{name}/apps/{app}/records": {
@@ -1771,7 +2122,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["activation"]
+        "x-aomi-auth": [
+          "activation"
+        ]
       }
     },
     "/api/platforms/{name}/projects": {
@@ -1782,7 +2135,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["activation"]
+        "x-aomi-auth": [
+          "activation"
+        ]
       }
     },
     "/api/platforms/{name}/tokens": {
@@ -1793,7 +2148,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["activation"]
+        "x-aomi-auth": [
+          "activation"
+        ]
       },
       "get": {
         "responses": {
@@ -1802,7 +2159,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["activation"]
+        "x-aomi-auth": [
+          "activation"
+        ]
       }
     },
     "/api/platforms/{name}/tokens/{id}": {
@@ -1813,7 +2172,9 @@
           }
         },
         "security": [],
-        "x-aomi-auth": ["activation"]
+        "x-aomi-auth": [
+          "activation"
+        ]
       }
     }
   },

--- a/packages/client/test/fixtures/manager-openapi.json
+++ b/packages/client/test/fixtures/manager-openapi.json
@@ -1,0 +1,779 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Aomi Manager",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": []
+      }
+    },
+    "/api/integrations/github-app/oauth/start": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": []
+      }
+    },
+    "/api/integrations/github-app/oauth/callback": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": []
+      }
+    },
+    "/api/integrations/github-app/oauth/result": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": []
+      }
+    },
+    "/api/platforms": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": []
+      }
+    },
+    "/api/platforms/server-tags": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": []
+      }
+    },
+    "/api/integrations/github-app/webhook": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": []
+      }
+    },
+    "/api/integrations/github-app/oauth/exchange": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/builder/applications/{application_id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/deployments": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/latest-deployment": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/required-secrets": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/sdk-upgrade": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/sdk-upgrade-status": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/deployments": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/deployments/{deployment}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/deployments/{deployment}/promote": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/deployments/{deployment}/refresh": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/releases/activate": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/deployments/import": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/apps": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/transactions": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/usage": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/logs": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/observability": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/observability": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/payments": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/transactions": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/statement": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/usage": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/logs": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/statement": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/builder/applications/{application_id}/detail": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/builder/applications/{application_id}/tools/{tool}/trace": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/bots": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/projects/{id}/bots/{bot_id}": {
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/bots": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/bots/{bot_id}": {
+      "patch": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/model-keys": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/model-keys/{key_id}": {
+      "put": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/user/model-keys/{key_id}/grants": {
+      "put": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "service"
+        ]
+      }
+    },
+    "/api/integrations/github-app/platforms/{name}/projects/create-from-template": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "activation"
+        ]
+      }
+    },
+    "/api/platforms/{name}/activate": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "activation"
+        ]
+      }
+    },
+    "/api/platforms/{name}/deactivate": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "activation"
+        ]
+      }
+    },
+    "/api/projects/{project_id}/deploy": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "activation"
+        ]
+      }
+    },
+    "/api/platforms/{name}/apps/activate": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "activation"
+        ]
+      }
+    },
+    "/api/platforms/{name}/applications/{application_id}/deactivate": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "activation"
+        ]
+      }
+    },
+    "/api/platforms/{name}/deployments/{deployment}/status": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "activation"
+        ]
+      }
+    },
+    "/api/platforms/{name}/deployments/{deployment}/rerun": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "activation"
+        ]
+      }
+    },
+    "/api/platforms/{name}/apps/{app}/records": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "activation"
+        ]
+      }
+    },
+    "/api/platforms/{name}/projects": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "activation"
+        ]
+      }
+    },
+    "/api/platforms/{name}/tokens": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "activation"
+        ]
+      },
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "activation"
+        ]
+      }
+    },
+    "/api/platforms/{name}/tokens/{id}": {
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [],
+        "x-aomi-auth": [
+          "activation"
+        ]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {}
+  }
+}

--- a/packages/client/test/generated/backend-routes.ts
+++ b/packages/client/test/generated/backend-routes.ts
@@ -61,7 +61,7 @@ export const AOMI_BACKEND_ENDPOINTS = [
   {
     method: "DELETE",
     path: "/api/threads/:thread_id",
-    auth: ["account", "thread"],
+    auth: ["account","thread"],
   },
   {
     method: "GET",
@@ -136,6 +136,11 @@ export const AOMI_BACKEND_ENDPOINTS = [
   {
     method: "GET",
     path: "/api/admin/apps/public",
+    auth: ["admin"],
+  },
+  {
+    method: "GET",
+    path: "/api/admin/release",
     auth: ["admin"],
   },
   {
@@ -236,6 +241,11 @@ export const AOMI_BACKEND_ENDPOINTS = [
   {
     method: "GET",
     path: "/api/integrations/github-app/user/projects/:id/deployments",
+    auth: ["service"],
+  },
+  {
+    method: "GET",
+    path: "/api/integrations/github-app/user/projects/:id/deployments/:deployment",
     auth: ["service"],
   },
   {
@@ -416,12 +426,12 @@ export const AOMI_BACKEND_ENDPOINTS = [
   {
     method: "GET",
     path: "/api/threads",
-    auth: ["account", "thread"],
+    auth: ["account","thread"],
   },
   {
     method: "GET",
     path: "/api/threads/:thread_id",
-    auth: ["account", "thread"],
+    auth: ["account","thread"],
   },
   {
     method: "GET",
@@ -446,7 +456,7 @@ export const AOMI_BACKEND_ENDPOINTS = [
   {
     method: "PATCH",
     path: "/api/threads/:thread_id",
-    auth: ["account", "thread"],
+    auth: ["account","thread"],
   },
   {
     method: "POST",
@@ -500,6 +510,11 @@ export const AOMI_BACKEND_ENDPOINTS = [
   },
   {
     method: "POST",
+    path: "/api/admin/release/sentry-smoke",
+    auth: ["admin"],
+  },
+  {
+    method: "POST",
     path: "/api/admin/skills/batch",
     auth: ["admin"],
   },
@@ -536,7 +551,7 @@ export const AOMI_BACKEND_ENDPOINTS = [
   {
     method: "POST",
     path: "/api/exec/run",
-    auth: ["account", "thread"],
+    auth: ["account","thread"],
   },
   {
     method: "POST",
@@ -546,7 +561,7 @@ export const AOMI_BACKEND_ENDPOINTS = [
   {
     method: "POST",
     path: "/api/exec/tool-call",
-    auth: ["account", "thread"],
+    auth: ["account","thread"],
   },
   {
     method: "POST",
@@ -566,6 +581,26 @@ export const AOMI_BACKEND_ENDPOINTS = [
   {
     method: "POST",
     path: "/api/integrations/github-app/user/projects/:id/bots",
+    auth: ["service"],
+  },
+  {
+    method: "POST",
+    path: "/api/integrations/github-app/user/projects/:id/deployments/:deployment/promote",
+    auth: ["service"],
+  },
+  {
+    method: "POST",
+    path: "/api/integrations/github-app/user/projects/:id/deployments/:deployment/refresh",
+    auth: ["service"],
+  },
+  {
+    method: "POST",
+    path: "/api/integrations/github-app/user/projects/:id/deployments/import",
+    auth: ["service"],
+  },
+  {
+    method: "POST",
+    path: "/api/integrations/github-app/user/projects/:id/releases/activate",
     auth: ["service"],
   },
   {
@@ -636,12 +671,12 @@ export const AOMI_BACKEND_ENDPOINTS = [
   {
     method: "POST",
     path: "/api/system",
-    auth: ["account", "thread"],
+    auth: ["account","thread"],
   },
   {
     method: "POST",
     path: "/api/thread/chat",
-    auth: ["thread", "app_gate"],
+    auth: ["thread","app_gate"],
   },
   {
     method: "POST",
@@ -666,12 +701,12 @@ export const AOMI_BACKEND_ENDPOINTS = [
   {
     method: "POST",
     path: "/api/threads/:thread_id/archive",
-    auth: ["account", "thread"],
+    auth: ["account","thread"],
   },
   {
     method: "POST",
     path: "/api/threads/:thread_id/unarchive",
-    auth: ["account", "thread"],
+    auth: ["account","thread"],
   },
   {
     method: "PUT",

--- a/packages/client/test/publish-package-if-needed.test.mjs
+++ b/packages/client/test/publish-package-if-needed.test.mjs
@@ -33,7 +33,7 @@ describe("publishPackageIfNeeded", () => {
       }),
     ).resolves.toBe("published");
 
-    expect(publishImpl).toHaveBeenCalledWith("@aomi-labs/client");
+    expect(publishImpl).toHaveBeenCalledWith(packageDirectory);
   });
 
   it("fails closed on registry errors instead of guessing that a version is missing", async () => {
@@ -49,9 +49,7 @@ describe("publishPackageIfNeeded", () => {
         ),
         publishImpl,
       }),
-    ).rejects.toThrow(
-      `Registry check for ${packageSpec} failed with HTTP 503`,
-    );
+    ).rejects.toThrow(`Registry check for ${packageSpec} failed with HTTP 503`);
 
     expect(publishImpl).not.toHaveBeenCalled();
   });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: [["html", { open: "never" }], ["list"]],
+  use: {
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+});

--- a/scripts/publish-package-if-needed.mjs
+++ b/scripts/publish-package-if-needed.mjs
@@ -11,7 +11,7 @@ export async function publishPackageIfNeeded(
   packageDirectory,
   {
     fetchImpl = globalThis.fetch,
-    publishImpl = publishWithPnpm,
+    publishImpl = publishWithNpm,
     registryUrl = process.env.NPM_CONFIG_REGISTRY ??
       process.env.npm_config_registry ??
       DEFAULT_REGISTRY_URL,
@@ -35,7 +35,7 @@ export async function publishPackageIfNeeded(
 
   console.log(`${packageSpec} is not published; publishing now.`);
   try {
-    await publishImpl(manifest.name);
+    await publishImpl(packageDirectory);
   } catch (error) {
     // A concurrent run may publish after our initial 404, or npm may accept a
     // PUT but return a transient error. Treat the package's durable registry
@@ -71,20 +71,15 @@ async function checkPublishedVersion({ fetchImpl, packageSpec, versionUrl }) {
   );
 }
 
-function publishWithPnpm(packageName) {
+function publishWithNpm(packageDirectory) {
   return new Promise((resolve, reject) => {
-    const child = spawn(
-      "pnpm",
-      [
-        "--filter",
-        packageName,
-        "publish",
-        "--access",
-        "public",
-        "--no-git-checks",
-      ],
-      { stdio: "inherit" },
-    );
+    const args = ["publish", "--access", "public"];
+    const distTag = process.env.NPM_DIST_TAG?.trim();
+    if (distTag) args.push("--tag", distTag);
+    const child = spawn("npm", args, {
+      cwd: path.resolve(packageDirectory),
+      stdio: "inherit",
+    });
     child.once("error", reject);
     child.once("exit", (code, signal) => {
       if (code === 0) {
@@ -93,7 +88,7 @@ function publishWithPnpm(packageName) {
       }
       reject(
         new Error(
-          `pnpm publish for ${packageName} failed${signal ? ` with signal ${signal}` : ` with exit code ${code}`}`,
+          `npm publish for ${packageDirectory} failed${signal ? ` with signal ${signal}` : ` with exit code ${code}`}`,
         ),
       );
     });

--- a/scripts/update-backend-openapi.mjs
+++ b/scripts/update-backend-openapi.mjs
@@ -20,6 +20,10 @@ const routesPath = join(
   repoRoot,
   "packages/client/test/generated/backend-routes.ts",
 );
+const managerFixturePath = join(
+  repoRoot,
+  "packages/client/test/fixtures/manager-openapi.json",
+);
 const backendTmpPath = join(repoRoot, ".tmp/backend-openapi.json");
 const managerTmpPath = join(repoRoot, ".tmp/manager-openapi.json");
 
@@ -34,11 +38,13 @@ const managerOpenApi = exportManagerOpenApi(resolveProductMonoRoot());
 const openApi = mergeOpenApi(backendOpenApi, managerOpenApi);
 
 writeFileSync(fixturePath, `${JSON.stringify(openApi, null, 2)}\n`);
+writeFileSync(managerFixturePath, `${JSON.stringify(managerOpenApi, null, 2)}\n`);
 writeFileSync(routesPath, routeSourceFromOpenApi(openApi));
 rmSync(backendTmpPath, { force: true });
 rmSync(managerTmpPath, { force: true });
 
 console.log(`Updated ${fixturePath}`);
+console.log(`Updated ${managerFixturePath}`);
 console.log(`Updated ${routesPath}`);
 
 function resolveOpenApiUrl() {

--- a/scripts/verify-backend-openapi-file.mjs
+++ b/scripts/verify-backend-openapi-file.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const targetPath = process.argv[2];
+if (!targetPath) {
+  throw new Error("Usage: verify-backend-openapi-file.mjs <target-openapi.json>");
+}
+
+const committed = JSON.parse(
+  readFileSync("packages/client/test/fixtures/backend-openapi.json", "utf8"),
+);
+const target = JSON.parse(readFileSync(targetPath, "utf8"));
+const methods = ["get", "post", "put", "patch", "delete"];
+
+function contract(document) {
+  const routes = [];
+  for (const [path, item] of Object.entries(document.paths ?? {})) {
+    for (const method of methods) {
+      const operation = item[method];
+      if (!operation) continue;
+      routes.push(
+        `${method.toUpperCase()} ${path} ${JSON.stringify(operation["x-aomi-auth"] ?? [])}`,
+      );
+    }
+  }
+  return routes.sort();
+}
+
+const expected = contract(committed);
+const actual = contract(target);
+const actualSet = new Set(actual);
+const missing = expected.filter((route) => !actualSet.has(route));
+if (missing.length) {
+  console.error("Target backend is missing routes/auth required by production frontend:");
+  for (const route of missing) console.error(`- ${route}`);
+  process.exit(1);
+}
+console.log(`Target backend satisfies ${expected.length} committed frontend routes.`);

--- a/tests/e2e/preview-smoke.spec.ts
+++ b/tests/e2e/preview-smoke.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test, type Page } from "@playwright/test";
+
+function previewUrl(name: "PORTAL_PREVIEW_URL" | "BUILD_PREVIEW_URL") {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value.replace(/\/+$/, "");
+}
+
+function failOnServerErrors(page: Page) {
+  const failures: string[] = [];
+  page.on("response", (response: { status(): number; url(): string }) => {
+    if (response.status() >= 500)
+      failures.push(`${response.status()} ${response.url()}`);
+  });
+  return failures;
+}
+
+test("anonymous Chat preview renders its primary shell", async ({ page }) => {
+  const serverErrors = failOnServerErrors(page);
+  await page.goto(previewUrl("PORTAL_PREVIEW_URL"), {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(page.getByTestId("portal-shell")).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page).toHaveTitle(/Aomi/i);
+  expect(serverErrors).toEqual([]);
+});
+
+test("anonymous Build preview renders a read-only composer", async ({
+  page,
+}) => {
+  const serverErrors = failOnServerErrors(page);
+  await page.goto(`${previewUrl("BUILD_PREVIEW_URL")}/build`, {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(page.getByTestId("build-shell")).toBeVisible({
+    timeout: 30_000,
+  });
+  const composer = page.getByTestId("build-intent-composer");
+  await expect(composer).toBeVisible();
+  await composer.fill("preview smoke — do not submit");
+  await expect(composer).toHaveValue("preview smoke — do not submit");
+  expect(serverErrors).toEqual([]);
+});


### PR DESCRIPTION
Implements the frontend half of the release-hardening policy.

- expands the required aggregate CI across all packages and five applications
- adds SHA-bound, non-blocking Portal/Build Playwright preview smoke with nightly fallback
- adds production smoke and a live production OpenAPI contract gate
- splits npm publishing into reviewed exact-SHA token and OIDC-canary workflows
- removes PR access to environment secrets and enforces workflow policy/action pinning
- updates the committed backend OpenAPI fixture for the authenticated release metadata endpoints

The preview suite intentionally starts non-blocking. It becomes required only after the documented 10-working-day / 50-run stability window.

Backend counterpart: https://github.com/aomi-labs/product-mono/pull/958

Local verification: all five app typechecks and builds; 207 Vitest files / 1470 tests; actionlint; zizmor high-severity; workflow policy; Playwright test discovery.