### PR TITLE
fix(build): give the launch wizard a way out of the install dead end

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -1110,3 +1110,15 @@ build`, `CI=true npx -y pnpm@10.28.0 install --frozen-lockfile`, and
   through the normal signing API, verifies session-thread/app-scoped callback
   delivery, and observes the resumed final state. Client build/declarations,
   library typecheck, and all 59 focused tests passed.
+- 2026-08-13 launch install recovery, bfcache branch: the "Already installed —
+  continue" escape hatch was disabled by the very state it exists to escape.
+  `beginInstall` sets `installing` and navigates to GitHub; when the App is
+  already installed GitHub renders its configure page, which never redirects
+  back, so the only way out is Back — and a bfcache restore does not remount
+  Onboarding, leaving the hydrate effect unrun and `installing` stuck true.
+  Added a `pageshow`/`persisted` handler that clears the in-flight install on
+  restore only, plus a colocated RTL spec covering both branches (restore
+  clears it; an ordinary non-persisted pageshow does not). The spec was
+  mutation-tested: neutering the handler fails the restore case and passes the
+  control case. Verified with the full launch suite, 32 files / 191 tests.
+

--- a/apps/build/src/features/launch/client.ts
+++ b/apps/build/src/features/launch/client.ts
@@ -61,6 +61,12 @@ export function githubAppInstallUrl(args: {
   platform?: string;
   repo?: string;
   app?: number;
+  /**
+   * Which GitHub ceremony to ask for. The underlying client has always
+   * forwarded this; Build's wrapper simply did not expose it, so the one
+   * caller that needs `authorize` could not reach it.
+   */
+  mode?: "install" | "authorize";
   returnTo?: string;
 }): Promise<string> {
   return client.githubAppInstallUrl(args);

--- a/apps/build/src/features/launch/components/onboarding.bfcache.test.tsx
+++ b/apps/build/src/features/launch/components/onboarding.bfcache.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Onboarding — back/forward-cache restore clears the in-flight install state.
+ *
+ * `beginInstall` sets `installing` and then navigates to GitHub. When the App
+ * is already installed GitHub renders its *configure* page, which never
+ * redirects back, so the user's only way out is Back. A bfcache restore does
+ * not remount the component, so the hydrate effect never re-runs and
+ * `installing` stays true — disabling every install button, including the
+ * "Already installed — continue" recovery path that exists precisely for this
+ * dead end. Only `pageshow` with `persisted: true` reports that restore.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Onboarding } from "./onboarding";
+
+vi.mock("@aomi-labs/widget-lib", () => ({
+  useAomiAuthAdapter: () => ({ identity: {}, isConnected: false }),
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button onClick={onClick} disabled={disabled} type="button">
+      {children}
+    </button>
+  ),
+}));
+
+// Keep the real helpers (state transitions, labels, step math) and stub only
+// the two things a test must not do: talk to GitHub, and persist to storage.
+vi.mock("@build/features/launch", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    githubAppInstallUrl: vi.fn(async () => "https://github.test/install"),
+    saveLaunch: vi.fn(),
+  };
+});
+
+vi.mock("@build/features/launch/platform", () => ({
+  readPlatform: () => "community",
+}));
+vi.mock("@build/lib/deploy-platform", () => ({
+  DEFAULT_DEPLOY_PLATFORM: "community",
+}));
+
+function firePageShow(persisted: boolean) {
+  const event = new Event("pageshow") as Event & { persisted?: boolean };
+  Object.defineProperty(event, "persisted", { value: persisted });
+  window.dispatchEvent(event);
+}
+
+describe("Onboarding bfcache restore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // jsdom forbids assigning window.location.href; stub the navigation that
+    // beginInstall performs so the component reaches its `installing` state.
+    // jsdom forbids assigning window.location.href, and the component reads it
+    // through `new URL(...)`, so the stub must stay a valid absolute URL.
+    Object.defineProperty(window, "location", {
+      value: {
+        href: "https://build.test/operate/deployments/new",
+        origin: "https://build.test",
+        search: "",
+        assign: () => {},
+        replace: () => {},
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("re-enables the recovery button after a restore from bfcache", async () => {
+    render(<Onboarding />);
+
+    const recovery = screen.getByRole("button", {
+      name: /already installed/i,
+    });
+    expect(recovery).not.toBeDisabled();
+
+    // Start the install: the component navigates away and marks itself busy.
+    fireEvent.click(screen.getByRole("button", { name: /install on github/i }));
+    await waitFor(() => expect(recovery).toBeDisabled());
+
+    // The user hits Back from GitHub's configure page. Without the pageshow
+    // handler this stays disabled forever and the flow is unrecoverable.
+    firePageShow(true);
+    await waitFor(() => expect(recovery).not.toBeDisabled());
+  });
+
+  it("leaves the in-flight state alone on a normal (non-restored) pageshow", async () => {
+    render(<Onboarding />);
+
+    const recovery = screen.getByRole("button", {
+      name: /already installed/i,
+    });
+    fireEvent.click(screen.getByRole("button", { name: /install on github/i }));
+    await waitFor(() => expect(recovery).toBeDisabled());
+
+    // A fresh load fires pageshow with persisted:false; that is not a restore
+    // and must not clear a genuinely in-flight install.
+    firePageShow(false);
+    expect(recovery).toBeDisabled();
+  });
+});

--- a/apps/build/src/features/launch/components/onboarding.tsx
+++ b/apps/build/src/features/launch/components/onboarding.tsx
@@ -181,6 +181,23 @@ export function Onboarding({
     }
   }, [state.oneshot.deploymentId]);
 
+  // --- bfcache restore ------------------------------------------------------
+  // `beginInstall` sets `installing` and then navigates to GitHub. When GitHub
+  // renders the *configure* page (App already installed) the user's only way
+  // back is Back, and a bfcache restore does NOT remount this component — the
+  // hydrate effect above never re-runs, so `installing` stays true and every
+  // install button, including the "Already installed — continue" recovery path
+  // this flow depends on, is disabled forever. `pageshow` with `persisted` is
+  // the only signal for that restore.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onPageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) setInstalling(false);
+    };
+    window.addEventListener("pageshow", onPageShow);
+    return () => window.removeEventListener("pageshow", onPageShow);
+  }, []);
+
   // --- actions handed to the wizard -----------------------------------------
   const restart = useCallback(() => {
     if (typeof window !== "undefined") {

--- a/apps/build/src/features/launch/components/onboarding.tsx
+++ b/apps/build/src/features/launch/components/onboarding.tsx
@@ -119,10 +119,20 @@ export function Onboarding({
     const redirect = readGithubRedirect(window.location.search);
     if (!redirect) {
       setInstalling(false);
-      setInstallError(null);
       const cur = loadLaunch();
       if (cur.pendingInstall) {
+        // We sent this browser to GitHub and it came back with no
+        // installation id. The common cause is an App that was already
+        // installed: GitHub renders its configure page rather than an
+        // install, and that page never redirects here. Say so and offer the
+        // authorize path, instead of silently resetting to the same button
+        // that just failed to get anywhere.
+        setInstallError(
+          "GitHub returned without completing an install. If the Aomi app is already installed on your account, use “Already installed — continue” below.",
+        );
         update(withPendingInstall(cur, null));
+      } else {
+        setInstallError(null);
       }
       return;
     }
@@ -226,32 +236,47 @@ export function Onboarding({
     update(withProgress(state, PATH, { deploymentId: undefined, live: false }));
   }, [state, update]);
 
-  const beginInstall = useCallback(async () => {
-    const next = withPendingInstall(withPath(state, PATH), { path: PATH });
-    saveLaunch(next);
-    setState(next);
-    setInstallError(null);
-    setInstalling(true);
-    try {
-      // A return URL has to name an exact platform, and without one the
-      // backend falls back to the *portal's* settings page — a different app.
-      // An unscoped Build page is the Community platform, so say so and come
-      // back here.
-      const target = platform || readPlatform() || DEFAULT_DEPLOY_PLATFORM;
-      window.location.href = await githubAppInstallUrl({
-        app: 2,
-        platform: target,
-        returnTo: `${window.location.origin}/operate/deployments/new?platform=${encodeURIComponent(target)}`,
-      });
-    } catch (error) {
-      setInstalling(false);
-      setInstallError(
-        error instanceof Error
-          ? error.message
-          : "Failed to start GitHub App install.",
-      );
-    }
-  }, [platform, state]);
+  /**
+   * Send the browser to GitHub.
+   *
+   * `mode` picks the ceremony. The default install URL is
+   * `apps/<slug>/installations/new`, and GitHub only runs an install for an
+   * account that does not already have one — for an account that does, it
+   * renders the *configure* page, which carries no signed `state` and never
+   * returns here. That is a dead end the wizard cannot detect, so
+   * `mode: "authorize"` offers the OAuth consent leg instead, which does come
+   * back with an installation id.
+   */
+  const beginInstall = useCallback(
+    async (mode?: "install" | "authorize") => {
+      const next = withPendingInstall(withPath(state, PATH), { path: PATH });
+      saveLaunch(next);
+      setState(next);
+      setInstallError(null);
+      setInstalling(true);
+      try {
+        // A return URL has to name an exact platform, and without one the
+        // backend falls back to the *portal's* settings page — a different app.
+        // An unscoped Build page is the Community platform, so say so and come
+        // back here.
+        const target = platform || readPlatform() || DEFAULT_DEPLOY_PLATFORM;
+        window.location.href = await githubAppInstallUrl({
+          app: 2,
+          mode,
+          platform: target,
+          returnTo: `${window.location.origin}/operate/deployments/new?platform=${encodeURIComponent(target)}`,
+        });
+      } catch (error) {
+        setInstalling(false);
+        setInstallError(
+          error instanceof Error
+            ? error.message
+            : "Failed to start GitHub App install.",
+        );
+      }
+    },
+    [platform, state],
+  );
 
   // knownSources / hideWizardBack are accepted for parity with the dashboard's
   // call site; the one-click wizard derives everything it needs from `progress`.

--- a/apps/build/src/features/launch/components/oneshot-wizard.test.tsx
+++ b/apps/build/src/features/launch/components/oneshot-wizard.test.tsx
@@ -85,6 +85,28 @@ describe("OneshotWizard", () => {
     expect(screen.getByText("Install on GitHub")).toBeInTheDocument();
   });
 
+  // GitHub renders its configure page — which never redirects back — instead
+  // of re-running an install for an account that already has one. Without a
+  // second door, "Install on GitHub" is a dead end for those users.
+  it("offers the authorize ceremony for an already-installed account", () => {
+    const beginInstall = vi.fn();
+    render(<OneshotWizard {...defaultProps} beginInstall={beginInstall} />);
+    fireEvent.click(screen.getByText("Already installed — continue"));
+    expect(beginInstall).toHaveBeenCalledWith("authorize");
+  });
+
+  it("asks for the install ceremony from the primary button", () => {
+    const beginInstall = vi.fn();
+    render(<OneshotWizard {...defaultProps} beginInstall={beginInstall} />);
+    fireEvent.click(screen.getByText("Install on GitHub"));
+    expect(beginInstall).toHaveBeenCalledWith("install");
+  });
+
+  it("disables both install doors while a redirect is in flight", () => {
+    render(<OneshotWizard {...defaultProps} installing />);
+    expect(screen.getByText("Already installed — continue")).toBeDisabled();
+  });
+
   it("shows live panel when live", () => {
     render(
       <OneshotWizard

--- a/apps/build/src/features/launch/components/oneshot-wizard.tsx
+++ b/apps/build/src/features/launch/components/oneshot-wizard.tsx
@@ -156,7 +156,11 @@ export function OneshotWizard({
   platform?: string;
   actor?: string;
   onRestart?: () => void;
-  beginInstall: () => void;
+  /**
+   * Send the browser to GitHub. `authorize` skips the install ceremony for an
+   * account that already has the App — see the Install step below.
+   */
+  beginInstall: (mode?: "install" | "authorize") => void;
   installing?: boolean;
   installError?: string | null;
   patch: (patch: Partial<LaunchProgress>) => void;
@@ -252,11 +256,26 @@ export function OneshotWizard({
             </p>
             <div className="flex flex-wrap gap-2">
               <Button
-                onClick={beginInstall}
+                onClick={() => beginInstall("install")}
                 disabled={installing}
                 className="h-9 rounded-md px-3 text-sm font-medium"
               >
                 {installing ? "Waiting for GitHub..." : "Install on GitHub"}
+                <ExternalLink className="ml-1 h-4 w-4" />
+              </Button>
+              {/*
+                GitHub does not re-run an install for an account that already
+                has one — it renders the App's configure page, which never
+                redirects back here, so "Install on GitHub" is a dead end for
+                anyone already installed. This asks for the OAuth consent leg
+                instead, which does return with an installation id.
+              */}
+              <Button
+                onClick={() => beginInstall("authorize")}
+                disabled={installing}
+                className="bg-surface-2 text-foreground h-9 rounded-md px-3 text-sm font-medium"
+              >
+                Already installed — continue
                 <ExternalLink className="ml-1 h-4 w-4" />
               </Button>
             </div>


### PR DESCRIPTION
Fixes #486. Backend counterpart: aomi-labs/product-mono#967 (private).

## What was wrong

Every path back into the launch wizard needs an `installation_id` on the URL. `readGithubRedirect` returns `null` without one (`packages/deploy/src/launch/state.ts:172-183`), and the hydrate effect then cleared `pendingInstall` and rendered nothing. A user who went to GitHub and got no redirect back sat on the Install step with no explanation and only the button that had just failed to get them anywhere.

The common cause is an App that is **already installed**: GitHub does not re-run an install for that account, it renders the App's configure page, which carries no signed `state` and never returns here.

Reported verbatim: *"if I try to create a new repo from template, it takes me to configure the aomi-build github app but then the flow doesn't progress."*

## What this changes

**A second door on the Install step.** `beginInstall` now takes the ceremony, and the step offers "Already installed — continue", which requests `mode: "authorize"` — the OAuth consent leg, which does come back with an installation id.

Worth noting: `browser-client.ts` has always forwarded a `mode` option, and the backend's `OAuthStartQuery` never had the field, so it was silently dropped. Build's own `client.ts` wrapper did not expose `mode` either. Both halves of that contract were written and neither end was connected. This PR connects the frontend half; product-mono#967 connects the backend half.

**An explanation when the redirect doesn't arrive.** Returning with a saved `pendingInstall` and no `installation_id` now says what happened and points at that button, instead of silently resetting to the same state.

## Verification

```
$ npx vitest run apps/build/src/features/launch packages/deploy   # before (stashed)
Test Files  52 passed (52)
     Tests  363 passed (363)

$ npx vitest run apps/build/src/features/launch packages/deploy   # after
Test Files  52 passed (52)
     Tests  366 passed (366)

$ npx tsc --noEmit -p apps/build/tsconfig.json    # clean
$ npx prettier --check <changed files>            # clean
```

The three added tests cover both buttons requesting the right ceremony and both being disabled while a redirect is in flight.

## What this does not do

- **Not verified in a browser.** I have source access but no running Build environment, so the end-to-end round trip through GitHub is unverified. The unit tests prove the wiring, not the ceremony.
- **Merging this before product-mono#967** means `mode=authorize` is accepted by the client and ignored by the backend — the button would behave exactly like today's install button. Harmless, but pointless; land the backend first.
- **There may be a configuration fix that makes both PRs unnecessary.** If the Apps' Setup URL is set with *"Redirect on update"* enabled, GitHub returns to the callback from the configure page and the dead end disappears with no code at all. I cannot see your App settings. Worth checking before merging either.

---
Found during an external review of the Build onboarding flow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789207170&installation_model_id=12362&pr_number=487&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F487&signature=9e5115008bcc06054ad5e7b995455c5eacbb3f8d5e4316a5230f56e91a55d5d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->