### PR TITLE
fix(build): carry CI state onto the deployment timeline and gate promote

### DIFF
--- a/apps/build/src/features/launch/components/deployments/deployment-timeline.test.ts
+++ b/apps/build/src/features/launch/components/deployments/deployment-timeline.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   buildActivityList,
   buildDeploymentList,
+  deploymentIsBuilding,
+  promoteBlockedReason,
   sortDeploymentsForTimeline,
 } from "./deployment-timeline";
 
@@ -155,5 +157,80 @@ describe("buildDeploymentList", () => {
       "web:dep_1_ra_new0",
       "api:dep_1_ra_old0",
     ]);
+  });
+});
+
+describe("deploymentIsBuilding", () => {
+  it("is true while GitHub CI is pending or running", () => {
+    expect(deploymentIsBuilding({ state: null, ciStatus: "running" })).toBe(
+      true,
+    );
+    expect(deploymentIsBuilding({ state: null, ciStatus: "pending" })).toBe(
+      true,
+    );
+  });
+
+  it("is true while the deployment projection is mid-flight", () => {
+    for (const state of ["building", "releasing", "pending"]) {
+      expect(deploymentIsBuilding({ state, ciStatus: null })).toBe(true);
+    }
+  });
+
+  it("is false once settled, and for a deployment with no build state", () => {
+    expect(deploymentIsBuilding({ state: "ready", ciStatus: "passed" })).toBe(
+      false,
+    );
+    expect(deploymentIsBuilding({ state: "failed", ciStatus: "failed" })).toBe(
+      false,
+    );
+    expect(deploymentIsBuilding({ state: "no_ci", ciStatus: "no_ci" })).toBe(
+      false,
+    );
+    // A deployment known only from promotion records carries no build state;
+    // it is historical, not in flight, so it must not read as building.
+    expect(deploymentIsBuilding({ state: null, ciStatus: null })).toBe(false);
+  });
+});
+
+describe("promoteBlockedReason", () => {
+  const settled = { state: "ready", ciStatus: "passed" };
+  const idle = { busy: false, secretsBlocked: false };
+
+  it("allows promotion of a settled deployment", () => {
+    expect(promoteBlockedReason(settled, idle)).toBeNull();
+  });
+
+  // The reported bug: promote stayed clickable during CI, and each click
+  // dispatched another run that queued behind the first.
+  it("blocks promotion while the deployment is still building", () => {
+    const reason = promoteBlockedReason(
+      { state: "building", ciStatus: "running" },
+      idle,
+    );
+    expect(reason).toMatch(/still building/i);
+    expect(reason).toMatch(/second CI run/i);
+  });
+
+  it("blocks promotion while another operation is running", () => {
+    expect(promoteBlockedReason(settled, { ...idle, busy: true })).toMatch(
+      /still running/i,
+    );
+  });
+
+  it("blocks promotion when required secrets are missing", () => {
+    expect(
+      promoteBlockedReason(settled, { ...idle, secretsBlocked: true }),
+    ).toMatch(/secrets/i);
+  });
+
+  // An in-flight build is the more actionable thing to say: setting secrets
+  // would not make the button work yet.
+  it("reports the build before missing secrets", () => {
+    expect(
+      promoteBlockedReason(
+        { state: "building", ciStatus: "running" },
+        { busy: false, secretsBlocked: true },
+      ),
+    ).toMatch(/still building/i);
   });
 });

--- a/apps/build/src/features/launch/components/deployments/deployment-timeline.ts
+++ b/apps/build/src/features/launch/components/deployments/deployment-timeline.ts
@@ -119,6 +119,10 @@ export function buildDeploymentList(
  * | passed | failed`); `state` is the backend's deployment projection
  * (`no_ci | building | releasing | ready | failed | pending`). Either can be
  * the one that knows, so both are checked.
+ *
+ * `pending` means waiting on CI in both vocabularies — never waiting on a
+ * person — so it belongs in flight. Promoting during it would dispatch the
+ * second run this guard exists to prevent.
  */
 const CI_IN_FLIGHT = new Set(["pending", "running"]);
 const STATE_IN_FLIGHT = new Set(["pending", "building", "releasing"]);

--- a/apps/build/src/features/launch/components/deployments/deployment-timeline.ts
+++ b/apps/build/src/features/launch/components/deployments/deployment-timeline.ts
@@ -13,6 +13,15 @@ export type TimelineDeployment = {
   actor: string | null;
   sdkVersion: string | null;
   createdAt: number;
+  /**
+   * Build state for this deployment, carried from history so the row can tell
+   * whether work is still in flight. Promotion records describe what was
+   * *already* promoted and say nothing about CI, so both are null for a
+   * deployment known only from records.
+   */
+  state: string | null;
+  ciStatus: string | null;
+  ciUrl: string | null;
 };
 
 /** One promotion record, tagged with the app it belongs to (for the activity feed). */
@@ -48,6 +57,11 @@ export function buildDeploymentList(
           actor: row.actor,
           sdkVersion: row.sdkVersion,
           createdAt: row.createdAt,
+          // Promotion records carry no build state. History fills these in
+          // below when it knows this deployment.
+          state: null,
+          ciStatus: null,
+          ciUrl: null,
         });
         continue;
       }
@@ -88,10 +102,67 @@ export function buildDeploymentList(
       actor: existing?.actor ?? null,
       sdkVersion,
       createdAt: entry.createdAt,
+      // History is the only source that knows whether CI is still running.
+      state: entry.state ?? null,
+      ciStatus: entry.ciStatus ?? null,
+      ciUrl: entry.ciUrl ?? null,
     });
   }
 
   return [...byId.values()].sort((a, b) => b.createdAt - a.createdAt);
+}
+
+/**
+ * CI states that mean work is still in flight for a deployment.
+ *
+ * `ciStatus` is GitHub's aggregate for the commit (`no_ci | pending | running
+ * | passed | failed`); `state` is the backend's deployment projection
+ * (`no_ci | building | releasing | ready | failed | pending`). Either can be
+ * the one that knows, so both are checked.
+ */
+const CI_IN_FLIGHT = new Set(["pending", "running"]);
+const STATE_IN_FLIGHT = new Set(["pending", "building", "releasing"]);
+
+export function deploymentIsBuilding(deployment: {
+  state: string | null;
+  ciStatus: string | null;
+}): boolean {
+  return (
+    CI_IN_FLIGHT.has(deployment.ciStatus ?? "") ||
+    STATE_IN_FLIGHT.has(deployment.state ?? "")
+  );
+}
+
+/**
+ * Why promotion is unavailable, or null when it is available.
+ *
+ * Promoting a deployment whose build is still running does not queue politely:
+ * it dispatches another CI job that lands behind the first, so the click that
+ * was meant to hurry things up makes the wait longer. The window is wide —
+ * `busy` only knows about an operation *this* browser tab started, so a
+ * reload, a second tab, or a promotion by a teammate all leave the button live
+ * unless the deployment's own build state is consulted.
+ *
+ * Returned as a reason rather than a boolean because a greyed-out button with
+ * no explanation is its own bug report.
+ */
+export function promoteBlockedReason(
+  deployment: { state: string | null; ciStatus: string | null },
+  options: {
+    /** An operation this tab started, for this project, is still running. */
+    busy: boolean;
+    /** One or more of the deployment's apps is missing a required secret. */
+    secretsBlocked: boolean;
+  },
+): string | null {
+  if (options.busy) return "Another deployment operation is still running.";
+  if (deploymentIsBuilding(deployment)) {
+    return "This deployment is still building. Promoting now would queue a second CI run behind the first.";
+  }
+  if (options.secretsBlocked) {
+    return "Set the required secrets for this deployment's apps first.";
+  }
+  return null;
 }
 
 /** Current first, then newest. Used after runtime remaps `current`. */

--- a/apps/build/src/features/launch/components/deployments/tabs/deployments-tab.tsx
+++ b/apps/build/src/features/launch/components/deployments/tabs/deployments-tab.tsx
@@ -15,6 +15,7 @@ import { LoadingPanel, EmptyPanel } from "../ui/state-panels";
 import {
   buildActivityList,
   buildDeploymentList,
+  promoteBlockedReason,
   sortDeploymentsForTimeline,
 } from "../deployment-timeline";
 import { formatRelativeTime } from "../format-relative-time";
@@ -486,9 +487,10 @@ export function DeploymentsTab({
         />
       ) : view === "deployments" && deployments.length > 0 ? (
         deployments.map((deployment) => {
-          const running =
-            op?.deploymentId === deployment.deploymentId &&
-            op.status === "running";
+          // Any running operation in this project blocks promotion, not only
+          // one on this row: two promotions in the same project dispatch two
+          // CI runs that queue behind each other just the same.
+          const running = op?.status === "running";
           const message =
             op?.deploymentId === deployment.deploymentId ? op.message : null;
           const hasUnloadedCurrentApp =
@@ -505,11 +507,16 @@ export function DeploymentsTab({
           const secretsBlocked = deployment.apps.some((app) =>
             detail.hasMissingSecrets(app),
           );
+          const promoteBlocked = promoteBlockedReason(deployment, {
+            busy: running,
+            secretsBlocked,
+          });
           return (
             <div key={deployment.deploymentId}>
               <TimelineDeploymentRow
                 deployment={deployment}
                 busy={running}
+                promoteBlocked={promoteBlocked}
                 message={message}
                 runtimeState={hasUnloadedCurrentApp ? "not-loaded" : "loaded"}
                 requiredSdk={requiredSdk}

--- a/apps/build/src/features/launch/components/deployments/ui/timeline-deployment-row.tsx
+++ b/apps/build/src/features/launch/components/deployments/ui/timeline-deployment-row.tsx
@@ -5,7 +5,10 @@ import {
   RotateCcw,
 } from "lucide-react";
 import { HelpBadge } from "@build/components/help-badge";
-import type { TimelineDeployment } from "../deployment-timeline";
+import {
+  deploymentIsBuilding,
+  type TimelineDeployment,
+} from "../deployment-timeline";
 import { formatRelativeTime } from "../format-relative-time";
 import { sdkCompatibility } from "../sdk-compatibility";
 
@@ -17,6 +20,7 @@ export function TimelineDeploymentRow({
   runtimeState,
   requiredSdk,
   secretsBlocked,
+  promoteBlocked,
   onPromote,
   onUpgrade,
   upgradePr,
@@ -28,6 +32,13 @@ export function TimelineDeploymentRow({
   runtimeState?: "loaded" | "not-loaded";
   requiredSdk?: string | null;
   secretsBlocked?: boolean;
+  /**
+   * Why promotion is unavailable, or null when it is available. Shown as the
+   * button's tooltip, so the disabled state explains itself. Undefined means
+   * the caller has not adopted this yet and the legacy busy/secrets gate
+   * applies.
+   */
+  promoteBlocked?: string | null;
   onPromote: () => void;
   onUpgrade?: () => void;
   /** Open upgrade PR: replaces the Upgrade button with a review link. */
@@ -39,6 +50,7 @@ export function TimelineDeploymentRow({
     deployment;
   const title = apps.join(", ") || "Deployment";
   const absolute = new Date(createdAt * 1000).toLocaleString();
+  const building = deploymentIsBuilding(deployment);
   const outdated =
     current && sdkCompatibility(sdkVersion, requiredSdk) === "outdated";
 
@@ -127,17 +139,26 @@ export function TimelineDeploymentRow({
         {!current && (
           <button
             type="button"
-            disabled={busy || secretsBlocked}
+            // `promoteBlocked` supersedes the older busy/secrets pair and
+            // additionally covers "this deployment is still building". The
+            // fallback keeps the previous behaviour for any call site that
+            // has not been updated to pass a reason.
+            disabled={
+              promoteBlocked !== undefined
+                ? promoteBlocked !== null
+                : busy || secretsBlocked
+            }
             onClick={onPromote}
             className="border-border bg-surface-1 text-foreground hover:bg-accent-hover inline-flex h-8 items-center justify-center gap-1.5 rounded-md border px-2.5 text-xs font-medium disabled:cursor-not-allowed disabled:opacity-50"
             title={
-              secretsBlocked
+              promoteBlocked ??
+              (secretsBlocked
                 ? "Required secrets missing — set them in the Environment tab"
-                : "Promote this deployment to live"
+                : "Promote this deployment to live")
             }
           >
             <RotateCcw className="size-3.5" aria-hidden />
-            Promote
+            {building ? "Building…" : "Promote"}
           </button>
         )}
       </div>

--- a/apps/build/src/features/launch/components/deployments/use-global-deployment-records.ts
+++ b/apps/build/src/features/launch/components/deployments/use-global-deployment-records.ts
@@ -38,6 +38,9 @@ function globalDeployment(deployment: UserDeployment): GlobalDeployment | null {
     actor: null,
     sdkVersion: deployment.sdkVersion ?? null,
     createdAt: deployment.createdAt,
+    state: deployment.state ?? null,
+    ciStatus: deployment.ciStatus ?? null,
+    ciUrl: deployment.ciUrl ?? null,
     projectId: deployment.projectId,
     repositoryLink: deployment.repositoryLink,
   };


### PR DESCRIPTION
Addresses the client-side half of #488. Server-side guard: aomi-labs/product-mono#968.

## What was wrong

Promote stayed clickable while a deployment's CI was still running, and each click dispatched another activation — a second CI run that queued behind the first. The click meant to hurry things up made the wait longer.

The row could not do better with the data it had. `TimelineDeployment` carried no build state at all, and the only guard was:

```ts
const running =
  op?.deploymentId === deployment.deploymentId && op.status === "running";
```

`op` is an operation *this browser tab* started, for *this deployment id*. So the button was live after a reload, in a second tab, when a teammate promoted, or when a sibling deployment in the same project was mid-promotion.

## The data was already there

`UserProjectLatestDeployment` (`packages/deploy/src/types.ts:614-631`) carries `state` and `ciStatus`/`ciUrl`, which the backend fills from the `deployments.ci_*` columns via `deployment_json_from_row`. `buildDeploymentList` just dropped them on the floor. **No backend change is needed for this PR** — that was my first assumption when I filed #488, and it was wrong.

## What this changes

- **`state`, `ciStatus`, `ciUrl` carried through to `TimelineDeployment`.** Deployments known only from promotion records get `null`: records describe what was already promoted and say nothing about CI, and null must not read as "building" for that history. There is a test for exactly that.
- **`deploymentIsBuilding`** checks both vocabularies — `ciStatus` (`no_ci | pending | running | passed | failed`, GitHub's aggregate for the commit) and `state` (`no_ci | building | releasing | ready | failed | pending`, the deployment projection). Either can be the one that knows.
- **`promoteBlockedReason` returns a reason, not a boolean**, and it becomes the button's tooltip. A greyed-out button with no explanation is its own bug report. An in-flight build outranks missing secrets, since setting secrets would not make the button work yet.
- **Any running operation in the project blocks promotion**, not only one on the same row.
- The button reads "Building…" while the deployment is in flight.

## Verification

```
$ npx vitest run apps/build/src/features/launch packages/deploy   # before (stashed)
     Tests  366 passed (366)

$ npx vitest run apps/build/src/features/launch packages/deploy   # after
     Tests  371 passed (371)

$ npx tsc --noEmit -p apps/build/tsconfig.json    # clean
$ npx prettier --check <changed files>            # clean
```

**Mutation-checked**, rather than trusting a green run: forcing `deploymentIsBuilding` to `return false` fails 4 of the new tests, including both `promoteBlockedReason` cases about an in-flight build. The tests fail for the reason they claim to.

## What this does not do

- **Not verified in a browser.** I have source access but no running Build environment. The unit tests cover the decision logic; nobody has watched the button grey out against real CI.
- **A client-side gate cannot be the whole fix.** Two tabs, a reload between render and click, or a direct API call all bypass it. product-mono#968 is where the 409 belongs; without it this reduces the window rather than closing it.
- **`promoteBlocked` is optional on `TimelineDeploymentRow`** so any call site I have not updated keeps its old behaviour. If you would rather it be required, say so and I will make it required and update the call sites.

## On `pending`

`state: "pending"` is treated as in-flight. Confirmed with the reporter: `pending` means waiting on CI in both vocabularies, never waiting on a person, so promoting during it would dispatch exactly the second run this guard exists to prevent. Recorded as a comment next to the set so it does not get re-litigated.

---
Reported by an external Build user and diagnosed from source.
