### PR TITLE
Add OAuth MCP chat parity and CLI signing handoff

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -122,6 +122,18 @@ through the canonical Session contract.
   `/wallet`, `/permission`, `/tx`, `/app`, `/model`, `/network`, and
   `/disconnect`.
 
+## MCP Chat Parity
+
+Current session goal: **IMPLEMENTED AND LOCALLY VERIFIED 2026-08-12** — make
+the OAuth MCP surface supervise the same asynchronous Aomi
+agent turns as the TS CLI. `/api/mcp` now has four chat/session tools with rich
+cursor deltas, task/tool narration, wallet-request handoff, and account-wallet
+hydration; the prior direct tool funnel remains at `/api/mcp/direct` behind the
+same OAuth resource metadata. SIWE → dynamic registration → PKCE/consent →
+refresh-token OAuth, real agent replies, resume/list/interrupt, a locally
+staged manual-wallet transaction, and the browser handoff into its exact
+conversation are all covered by the local smoke.
+
 ## Chat Composer Parity
 
 Current session goal: **IMPLEMENTED AND LOCALLY VERIFIED 2026-08-05** — keep the active-thread

--- a/GOAL.md
+++ b/GOAL.md
@@ -1,5 +1,12 @@
 # Auth BFF BetterAuth Cleanup Goal
 
+## MCP explicit chain context
+
+Current session goal: **IMPLEMENTED AND LOCALLY VERIFIED 2026-08-13** —
+remove fabricated Ethereum and Solana mainnet state from headless MCP chat.
+`aomi_chat` accepts an optional explicit EVM chain or supported Solana cluster;
+omission retains account wallet identity without claiming an active network.
+
 ## Safari wallet-state sync containment
 
 Current session goal: **IMPLEMENTED AND LOCALLY VERIFIED; STAGING ROLLOUT IN

--- a/GOAL.md
+++ b/GOAL.md
@@ -124,7 +124,7 @@ through the canonical Session contract.
 
 ## MCP Chat Parity
 
-Current session goal: **IMPLEMENTED AND LOCALLY VERIFIED 2026-08-12** — make
+Current session goal: **IMPLEMENTED AND LIVE-CHAIN VERIFIED 2026-08-13** — make
 the OAuth MCP surface supervise the same asynchronous Aomi
 agent turns as the TS CLI. `/api/mcp` now has four chat/session tools with rich
 cursor deltas, task/tool narration, wallet-request handoff, and account-wallet
@@ -133,6 +133,12 @@ same OAuth resource metadata. SIWE → dynamic registration → PKCE/consent →
 refresh-token OAuth, real agent replies, resume/list/interrupt, a locally
 staged manual-wallet transaction, and the browser handoff into its exact
 conversation are all covered by the local smoke.
+The funded-wallet follow-up attached the local OAuth server to a fresh Codex
+process, made progress cursors self-contained after that client exposed a
+missing-session retry loop, imported the account-owned MCP thread into the CLI,
+and signed its one-wei Base self-transfer. Both the requested transaction and
+service-fee transaction confirmed, and a later MCP check returned an empty
+pending queue plus both hashes.
 
 ## Chat Composer Parity
 

--- a/apps/portal/src/app/api/mcp/direct/route.ts
+++ b/apps/portal/src/app/api/mcp/direct/route.ts
@@ -1,0 +1,35 @@
+import { auth } from "@aomi-labs/account/better-auth";
+import { withMcpAuth } from "better-auth/plugins";
+
+import { handleMcpPost, mcpMethodNotAllowed } from "@portal/server/mcp/rpc";
+import { resolveMcpCanonicalUser } from "@portal/server/mcp/session";
+import { MCP_TOOLS, dispatchTool } from "@portal/server/mcp/tools";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+const DIRECT_INSTRUCTIONS = [
+  "Aomi direct tools execute Web3 operations through a broad-to-narrow tool funnel.",
+  "Workflow: aomi_list_apps -> aomi_select_app -> aomi_list_tools -> aomi_describe_tool -> aomi_call_tool.",
+  "When the goal is already known, use aomi_search_apps and aomi_search_tools before describing and calling the tool.",
+  "Use aomi_run for multi-step flows whose intermediate results feed later calls; use aomi_call_tool for one action.",
+  "Pass app explicitly because this endpoint has no server-side selection state.",
+].join(" ");
+
+/** Alternative low-level tool funnel retained at /api/mcp/direct. */
+export const POST = withMcpAuth(auth, async (request, session) =>
+  handleMcpPost(request, {
+    tools: MCP_TOOLS,
+    instructions: DIRECT_INSTRUCTIONS,
+    dispatchTool: async (name, args) => {
+      const canonicalUser = await resolveMcpCanonicalUser({
+        betterAuthUserId: session.userId,
+      });
+      return dispatchTool(canonicalUser.id, name, args);
+    },
+  }),
+);
+
+export const GET = mcpMethodNotAllowed;
+export const DELETE = mcpMethodNotAllowed;

--- a/apps/portal/src/app/api/mcp/route.ts
+++ b/apps/portal/src/app/api/mcp/route.ts
@@ -1,126 +1,31 @@
 import { auth } from "@aomi-labs/account/better-auth";
 import { withMcpAuth } from "better-auth/plugins";
 
-import { MCP_TOOLS, dispatchTool } from "@portal/server/mcp/tools";
+import {
+  CHAT_MCP_INSTRUCTIONS,
+  CHAT_MCP_TOOLS,
+  dispatchChatTool,
+} from "@portal/server/mcp/chat-tools";
+import { handleMcpPost, mcpMethodNotAllowed } from "@portal/server/mcp/rpc";
 import { resolveMcpCanonicalUser } from "@portal/server/mcp/session";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
 
-/**
- * The Aomi MCP port: a stateless MCP streamable-HTTP endpoint at
- * `POST /api/mcp`. better-auth's MCP plugin owns the OAuth handshake
- * (`withMcpAuth` answers unauthenticated calls with the WWW-Authenticate
- * challenge pointing at our protected-resource metadata); tool handlers are
- * read-throughs to the backend catalog plus the thread-scoped tool syscall.
- *
- * Stateless subset of the protocol on purpose: one JSON-RPC message per
- * POST, JSON response, no server-issued session, no SSE push. Vercel
- * functions cannot hold an in-process runtime — which is exactly the
- * resources/services/kernel discipline: this process is a port, the kernel
- * lives behind /api/exec/tool-call.
- */
-const PROTOCOL_VERSION = "2025-06-18";
-const SERVER_INFO = { name: "aomi", version: "0.1.0" };
-const INSTRUCTIONS = [
-  "Aomi executes Web3 operations (balances, swaps, transactions) through a broad-to-narrow tool funnel.",
-  "Workflow: aomi_list_apps -> aomi_select_app -> aomi_list_tools (namespace optional) -> aomi_describe_tool -> aomi_call_tool.",
-  "Faster path when you know the goal: aomi_search_apps then aomi_search_tools (ranked, with match reasons) -> aomi_describe_tool -> aomi_call_tool.",
-  "Single action -> aomi_call_tool. Multi-step flow (results feeding later calls, loops over lists) -> write a program for aomi_run; intermediates stay server-side.",
-  "Pass the app name explicitly on every call; there is no server-side selection state.",
-  "Tool results may include followup.route_steps: call them in order with aomi_call_tool unless the user asked to stop.",
-].join(" ");
-
-type JsonRpcRequest = {
-  jsonrpc?: string;
-  id?: number | string | null;
-  method?: string;
-  params?: Record<string, unknown>;
-};
-
-export const POST = withMcpAuth(auth, async (request, session) => {
-  let message: JsonRpcRequest;
-  try {
-    message = (await request.json()) as JsonRpcRequest;
-  } catch {
-    return rpcError(
-      null,
-      -32700,
-      "parse error: body must be a JSON-RPC message",
-    );
-  }
-  if (Array.isArray(message)) {
-    return rpcError(null, -32600, "batch requests are not supported");
-  }
-
-  const { id, method, params } = message;
-  switch (method) {
-    case "initialize":
-      return rpcResult(id ?? null, {
-        protocolVersion: PROTOCOL_VERSION,
-        capabilities: { tools: { listChanged: false } },
-        serverInfo: SERVER_INFO,
-        instructions: INSTRUCTIONS,
-      });
-    case "ping":
-      return rpcResult(id ?? null, {});
-    case "tools/list":
-      return rpcResult(id ?? null, { tools: MCP_TOOLS });
-    case "tools/call": {
-      const name = typeof params?.name === "string" ? params.name : "";
-      const args =
-        params?.arguments && typeof params.arguments === "object"
-          ? (params.arguments as Record<string, unknown>)
-          : {};
+/** OAuth-protected, stateless MCP port for supervising Aomi agent turns. */
+export const POST = withMcpAuth(auth, async (request, session) =>
+  handleMcpPost(request, {
+    tools: CHAT_MCP_TOOLS,
+    instructions: CHAT_MCP_INSTRUCTIONS,
+    dispatchTool: async (name, args) => {
       const canonicalUser = await resolveMcpCanonicalUser({
         betterAuthUserId: session.userId,
       });
-      const outcome = await dispatchTool(canonicalUser.id, name, args);
-      return rpcResult(id ?? null, {
-        content: [
-          { type: "text", text: JSON.stringify(outcome.result, null, 2) },
-        ],
-        isError: outcome.isError,
-      });
-    }
-    default:
-      // Notifications (no id) get an empty 202 per streamable HTTP.
-      if (id === undefined || id === null) {
-        return new Response(null, { status: 202, headers: baseHeaders() });
-      }
-      return rpcError(id, -32601, `method '${method}' not found`);
-  }
-});
+      return dispatchChatTool(canonicalUser.id, name, args);
+    },
+  }),
+);
 
-// Streamable HTTP allows servers without server-push to reject GET.
-export function GET() {
-  return new Response(null, { status: 405, headers: baseHeaders() });
-}
-
-export function DELETE() {
-  // Stateless: there is no server session to terminate.
-  return new Response(null, { status: 405, headers: baseHeaders() });
-}
-
-function baseHeaders(): HeadersInit {
-  return { "mcp-protocol-version": PROTOCOL_VERSION };
-}
-
-function rpcResult(id: number | string | null, result: unknown): Response {
-  return Response.json(
-    { jsonrpc: "2.0", id, result },
-    { headers: baseHeaders() },
-  );
-}
-
-function rpcError(
-  id: number | string | null,
-  code: number,
-  message: string,
-): Response {
-  return Response.json(
-    { jsonrpc: "2.0", id, error: { code, message } },
-    { headers: baseHeaders() },
-  );
-}
+export const GET = mcpMethodNotAllowed;
+export const DELETE = mcpMethodNotAllowed;

--- a/apps/portal/src/app/mcp/connect/mcp-connect-client.tsx
+++ b/apps/portal/src/app/mcp/connect/mcp-connect-client.tsx
@@ -313,7 +313,8 @@ function ConsentPanel({
     <Shell title={`${name} wants to connect`}>
       <p className="text-muted-foreground mt-3 text-sm">
         Allow {name} to access your Aomi account? It will be able to act as you
-        through the Aomi tools you invoke from it.
+        by chatting with the Aomi agent and supervising the sessions you invoke
+        from it.
       </p>
       <ul className="mt-5 grid gap-2">
         {scopes.map((scope) => (

--- a/apps/portal/src/components/shell/portal-aomi-frame.test.tsx
+++ b/apps/portal/src/components/shell/portal-aomi-frame.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { PortalAomiFrame } from "./portal-aomi-frame";
+import { PortalAomiFrame, ThreadUrlBootstrap } from "./portal-aomi-frame";
 
 const walletKitState = vi.hoisted(() => ({
   current: {
@@ -23,6 +23,18 @@ const requestedAppState = vi.hoisted(() => ({
     applicationId: string | null;
     locked: boolean;
   },
+}));
+const runtimeState = vi.hoisted(() => ({
+  current: {
+    currentThreadId: "initial",
+    threadMetadata: new Map<string, unknown>(),
+    selectThread: vi.fn(),
+  },
+}));
+
+vi.mock("@aomi-labs/react", () => ({
+  useAomiRuntime: () => runtimeState.current,
+  usePerThreadControl: () => ({ actions: { onAppSelect: vi.fn() } }),
 }));
 
 vi.mock("@aomi-labs/widget-lib", async () => {
@@ -204,6 +216,36 @@ describe("PortalAomiFrame account bootstrap", () => {
     expect(screen.getByTestId("aomi-frame")).toHaveAttribute(
       "data-show-sidebar",
       "false",
+    );
+  });
+});
+
+describe("ThreadUrlBootstrap", () => {
+  afterEach(() => {
+    window.history.replaceState({}, "", "/");
+    runtimeState.current = {
+      currentThreadId: "initial",
+      threadMetadata: new Map<string, unknown>(),
+      selectThread: vi.fn(),
+    };
+  });
+
+  it("waits for remote metadata before selecting a linked MCP thread", async () => {
+    window.history.replaceState({}, "", "/?thread=mcp-linked");
+    const view = render(<ThreadUrlBootstrap />);
+    expect(runtimeState.current.selectThread).not.toHaveBeenCalled();
+
+    runtimeState.current = {
+      ...runtimeState.current,
+      threadMetadata: new Map([["mcp-linked", {}]]),
+    };
+    await act(async () => {
+      view.rerender(<ThreadUrlBootstrap />);
+    });
+
+    expect(runtimeState.current.selectThread).toHaveBeenCalledOnce();
+    expect(runtimeState.current.selectThread).toHaveBeenCalledWith(
+      "mcp-linked",
     );
   });
 });

--- a/apps/portal/src/components/shell/portal-aomi-frame.tsx
+++ b/apps/portal/src/components/shell/portal-aomi-frame.tsx
@@ -98,6 +98,32 @@ function AppSelectUrlBootstrap({
   return null;
 }
 
+/** Open an account-owned thread linked by MCP wallet-approval handoff. */
+export function ThreadUrlBootstrap() {
+  const { currentThreadId, selectThread, threadMetadata } = useAomiRuntime();
+  const appliedRef = useRef(false);
+
+  useEffect(() => {
+    if (appliedRef.current) return;
+    const threadId = new URLSearchParams(window.location.search)
+      .get("thread")
+      ?.trim();
+    if (!threadId) return;
+    if (threadId === currentThreadId) {
+      appliedRef.current = true;
+      return;
+    }
+    // selectThread intentionally creates a new local thread for unknown ids.
+    // Wait for the authenticated remote-thread list to hydrate first so an
+    // MCP handoff cannot race startup and silently land on a blank chat.
+    if (!threadMetadata.has(threadId)) return;
+    appliedRef.current = true;
+    selectThread(threadId);
+  }, [currentThreadId, selectThread, threadMetadata]);
+
+  return null;
+}
+
 export function PortalAomiFrame() {
   const { accountStatus, accountUser } = useAomiWalletKit();
   const accountUserId = accountUser?.id;
@@ -172,6 +198,7 @@ export function PortalAomiFrame() {
         className="portal-aomi-frame aui-suggestions-marquee rounded-none border-0 shadow-none"
         clientOptions={clientOptions}
       >
+        <ThreadUrlBootstrap />
         <AppSelectUrlBootstrap
           requestedApp={requestedApp.app}
           requestedApplicationId={requestedApp.applicationId}

--- a/apps/portal/src/server/mcp/chat-backend.test.ts
+++ b/apps/portal/src/server/mcp/chat-backend.test.ts
@@ -55,7 +55,7 @@ describe("MCP chat backend", () => {
     expect(fetchMock.mock.calls[0][1]?.method).toBe("POST");
   });
 
-  it("hydrates primary EVM and Solana keys into the first chat turn", async () => {
+  it("hydrates wallet addresses without inventing active mainnet defaults", async () => {
     mocks.query.mockResolvedValue({
       rows: [
         { chain_type: "evm", address: "0xabc" },
@@ -74,8 +74,47 @@ describe("MCP chat backend", () => {
     expect(url.searchParams.get("app")).toBe("default");
     expect(JSON.parse(url.searchParams.get("user_state")!)).toEqual({
       connection: { is_connected: true },
-      evm: { address: "0xabc", chain_id: 1 },
-      svm: { address: "SolanaAddress", cluster: "solana:mainnet" },
+      evm: { address: "0xabc" },
+      svm: { address: "SolanaAddress" },
+      ext: { client_type: "mcp" },
+    });
+  });
+
+  it("preserves an explicit Base chain context", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+
+    await sendChat("user-1", "mcp-new", "swap", undefined, {
+      family: "evm",
+      chain_id: 8453,
+    });
+
+    const url = new URL(String(fetchMock.mock.calls[0][0]));
+    expect(JSON.parse(url.searchParams.get("user_state")!)).toEqual({
+      connection: { is_connected: false },
+      evm: { chain_id: 8453 },
+      ext: { client_type: "mcp" },
+    });
+  });
+
+  it("preserves an explicit supported Solana cluster context", async () => {
+    mocks.query.mockResolvedValue({
+      rows: [{ chain_type: "svm", address: "SolanaAddress" }],
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+
+    await sendChat("user-1", "mcp-new", "swap", undefined, {
+      family: "solana",
+      cluster: "solana:devnet",
+    });
+
+    const url = new URL(String(fetchMock.mock.calls[0][0]));
+    expect(JSON.parse(url.searchParams.get("user_state")!)).toEqual({
+      connection: { is_connected: true },
+      svm: { address: "SolanaAddress", cluster: "solana:devnet" },
       ext: { client_type: "mcp" },
     });
   });

--- a/apps/portal/src/server/mcp/chat-backend.test.ts
+++ b/apps/portal/src/server/mcp/chat-backend.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  mintAccountBearer: vi.fn(),
+  query: vi.fn(),
+  failure: vi.fn(),
+}));
+
+vi.mock("@aomi-labs/account", () => ({
+  mintAccountBearer: mocks.mintAccountBearer,
+  getPool: () => ({ query: mocks.query }),
+}));
+vi.mock("@portal/server/backend-url", () => ({
+  configuredBackendUrl: () => "https://api.example.test",
+}));
+vi.mock("@portal/server/bff/failures", () => ({
+  portalFailures: { handle: mocks.failure },
+}));
+vi.mock("@portal/server/mcp/thread", () => ({
+  mcpThreadId: () => "mcp-caller",
+}));
+
+import {
+  ensureThread,
+  fetchState,
+  listThreads,
+  sendChat,
+} from "./chat-backend";
+
+describe("MCP chat backend", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mocks.mintAccountBearer.mockReset().mockResolvedValue({ bearer: "secret" });
+    mocks.query.mockReset().mockResolvedValue({ rows: [] });
+    mocks.failure.mockReset();
+  });
+
+  it("uses both migration-era thread headers on every thread call", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => new Response("{}", { status: 200 }));
+    await ensureThread("user-1", "mcp-new");
+    await fetchState("user-1", "mcp-new");
+
+    for (const [, init] of fetchMock.mock.calls) {
+      const headers = new Headers(init?.headers);
+      expect(headers.get("authorization")).toBe("Bearer secret");
+      expect(headers.get("x-session-id")).toBe("mcp-new");
+      expect(headers.get("x-thread-id")).toBe("mcp-new");
+    }
+    expect(new URL(String(fetchMock.mock.calls[0][0])).pathname).toBe(
+      "/api/threads",
+    );
+    expect(fetchMock.mock.calls[0][1]?.method).toBe("POST");
+  });
+
+  it("hydrates primary EVM and Solana keys into the first chat turn", async () => {
+    mocks.query.mockResolvedValue({
+      rows: [
+        { chain_type: "evm", address: "0xabc" },
+        { chain_type: "svm", address: "SolanaAddress" },
+      ],
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+
+    await sendChat("user-1", "mcp-new", "swap", "default");
+
+    const url = new URL(String(fetchMock.mock.calls[0][0]));
+    expect(url.pathname).toBe("/api/thread/chat");
+    expect(url.searchParams.get("message")).toBe("swap");
+    expect(url.searchParams.get("app")).toBe("default");
+    expect(JSON.parse(url.searchParams.get("user_state")!)).toEqual({
+      connection: { is_connected: true },
+      evm: { address: "0xabc", chain_id: 1 },
+      svm: { address: "SolanaAddress", cluster: "solana:mainnet" },
+      ext: { client_type: "mcp" },
+    });
+  });
+
+  it("lists account threads with a bounded caller context", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("[]", { status: 200 }));
+    await listThreads("user-1", 12);
+    const url = new URL(String(fetchMock.mock.calls[0][0]));
+    const headers = new Headers(fetchMock.mock.calls[0][1]?.headers);
+    expect(url.pathname).toBe("/api/threads");
+    expect(url.searchParams.get("limit")).toBe("12");
+    expect(headers.get("x-thread-id")).toBe("mcp-caller");
+  });
+
+  it("reports upstream 5xx without exposing its body to telemetry", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("private failure", { status: 503 }),
+    );
+    await fetchState("user-1", "mcp-new");
+    expect(mocks.failure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        upstream: "rust",
+        status: 503,
+        context: expect.objectContaining({ operation: "mcp_chat_state" }),
+      }),
+    );
+    expect(JSON.stringify(mocks.failure.mock.calls)).not.toContain(
+      "private failure",
+    );
+  });
+});

--- a/apps/portal/src/server/mcp/chat-backend.ts
+++ b/apps/portal/src/server/mcp/chat-backend.ts
@@ -1,0 +1,181 @@
+import "server-only";
+
+import { getPool, mintAccountBearer } from "@aomi-labs/account";
+import { configuredBackendUrl } from "@portal/server/backend-url";
+import { portalFailures } from "@portal/server/bff/failures";
+import { mcpThreadId } from "@portal/server/mcp/thread";
+
+export type ChatBackendResult = {
+  ok: boolean;
+  status: number;
+  body: unknown;
+};
+
+type HeadlessUserState = {
+  connection: { is_connected: true };
+  evm?: { address: string; chain_id: number };
+  svm?: { address: string; cluster: string };
+  ext: { client_type: "mcp" };
+};
+
+/** Register a freshly generated thread against the authenticated account. */
+export async function ensureThread(
+  canonicalUserId: string,
+  sessionId: string,
+): Promise<ChatBackendResult> {
+  return threadRequest(
+    canonicalUserId,
+    sessionId,
+    "/api/threads",
+    { method: "POST" },
+    "mcp_chat_ensure_thread",
+  );
+}
+
+/** Fire one agent turn, seeding account wallets for this headless surface. */
+export async function sendChat(
+  canonicalUserId: string,
+  sessionId: string,
+  message: string,
+  app?: string,
+): Promise<ChatBackendResult> {
+  const url = new URL(`${configuredBackendUrl()}/api/thread/chat`);
+  url.searchParams.set("message", message);
+  if (app) url.searchParams.set("app", app);
+  const userState = await headlessUserState(canonicalUserId);
+  if (userState) {
+    url.searchParams.set("user_state", JSON.stringify(userState));
+  }
+  return threadRequest(
+    canonicalUserId,
+    sessionId,
+    url,
+    { method: "POST" },
+    "mcp_chat_send",
+  );
+}
+
+export async function fetchState(
+  canonicalUserId: string,
+  sessionId: string,
+): Promise<ChatBackendResult> {
+  return threadRequest(
+    canonicalUserId,
+    sessionId,
+    "/api/thread/state",
+    { method: "GET" },
+    "mcp_chat_state",
+  );
+}
+
+export async function interrupt(
+  canonicalUserId: string,
+  sessionId: string,
+): Promise<ChatBackendResult> {
+  return threadRequest(
+    canonicalUserId,
+    sessionId,
+    "/api/thread/interrupt",
+    { method: "POST" },
+    "mcp_chat_interrupt",
+  );
+}
+
+export async function listThreads(
+  canonicalUserId: string,
+  limit?: number,
+): Promise<ChatBackendResult> {
+  const url = new URL(`${configuredBackendUrl()}/api/threads`);
+  if (limit !== undefined) url.searchParams.set("limit", String(limit));
+  return threadRequest(
+    canonicalUserId,
+    mcpThreadId(canonicalUserId),
+    url,
+    { method: "GET" },
+    "mcp_chat_list_threads",
+  );
+}
+
+async function threadRequest(
+  canonicalUserId: string,
+  sessionId: string,
+  path: string | URL,
+  init: RequestInit,
+  operation: string,
+): Promise<ChatBackendResult> {
+  const { bearer } = await mintAccountBearer(canonicalUserId);
+  const headers = new Headers(init.headers);
+  headers.set("authorization", `Bearer ${bearer}`);
+  headers.set("x-session-id", sessionId);
+  headers.set("x-thread-id", sessionId);
+  const url =
+    path instanceof URL ? path : new URL(`${configuredBackendUrl()}${path}`);
+  return backendJson(url, { ...init, headers }, operation);
+}
+
+async function backendJson(
+  url: URL,
+  init: RequestInit,
+  operation: string,
+): Promise<ChatBackendResult> {
+  const response = await fetch(url, { ...init, cache: "no-store" });
+  const text = await response.text();
+  let body: unknown;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = { error: text };
+  }
+  if (response.status >= 500) {
+    portalFailures.handle({
+      source: "upstream_response",
+      upstream: "rust",
+      status: response.status,
+      response: { status: 200, error: "upstream_unavailable" },
+      context: {
+        routeFamily: "/api/mcp",
+        operation,
+        method: typeof init.method === "string" ? init.method : "GET",
+      },
+    });
+  }
+  return { ok: response.ok, status: response.status, body };
+}
+
+async function headlessUserState(
+  canonicalUserId: string,
+): Promise<HeadlessUserState | undefined> {
+  try {
+    const result = await getPool().query(
+      `select chain_type, address
+         from public_keys
+        where user_id = $1
+        order by is_primary desc, created_at asc`,
+      [canonicalUserId],
+    );
+    const evm = result.rows.find(
+      (row) => String(row.chain_type).toLowerCase() === "evm",
+    );
+    const svm = result.rows.find((row) =>
+      ["svm", "solana"].includes(String(row.chain_type).toLowerCase()),
+    );
+    if (!evm && !svm) return undefined;
+    return {
+      connection: { is_connected: true },
+      ...(evm ? { evm: { address: String(evm.address), chain_id: 1 } } : {}),
+      ...(svm
+        ? {
+            svm: {
+              address: String(svm.address),
+              cluster: "solana:mainnet",
+            },
+          }
+        : {}),
+      ext: { client_type: "mcp" },
+    };
+  } catch {
+    // Wallet hydration is advisory. The agent can still return its normal
+    // connect/authorize guidance when the account graph cannot be read.
+    return undefined;
+  }
+}

--- a/apps/portal/src/server/mcp/chat-backend.ts
+++ b/apps/portal/src/server/mcp/chat-backend.ts
@@ -11,10 +11,17 @@ export type ChatBackendResult = {
   body: unknown;
 };
 
+export type McpChainContext =
+  | { family: "evm"; chain_id: number }
+  | {
+      family: "solana";
+      cluster: "solana:mainnet" | "solana:devnet" | "solana:testnet";
+    };
+
 type HeadlessUserState = {
-  connection: { is_connected: true };
-  evm?: { address: string; chain_id: number };
-  svm?: { address: string; cluster: string };
+  connection: { is_connected: boolean };
+  evm?: { address?: string; chain_id?: number };
+  svm?: { address?: string; cluster?: string };
   ext: { client_type: "mcp" };
 };
 
@@ -38,11 +45,12 @@ export async function sendChat(
   sessionId: string,
   message: string,
   app?: string,
+  chainContext?: McpChainContext,
 ): Promise<ChatBackendResult> {
   const url = new URL(`${configuredBackendUrl()}/api/thread/chat`);
   url.searchParams.set("message", message);
   if (app) url.searchParams.set("app", app);
-  const userState = await headlessUserState(canonicalUserId);
+  const userState = await headlessUserState(canonicalUserId, chainContext);
   if (userState) {
     url.searchParams.set("user_state", JSON.stringify(userState));
   }
@@ -144,7 +152,9 @@ async function backendJson(
 
 async function headlessUserState(
   canonicalUserId: string,
+  chainContext?: McpChainContext,
 ): Promise<HeadlessUserState | undefined> {
+  let rows: Array<Record<string, unknown>> = [];
   try {
     const result = await getPool().query(
       `select chain_type, address
@@ -153,29 +163,41 @@ async function headlessUserState(
         order by is_primary desc, created_at asc`,
       [canonicalUserId],
     );
-    const evm = result.rows.find(
-      (row) => String(row.chain_type).toLowerCase() === "evm",
-    );
-    const svm = result.rows.find((row) =>
-      ["svm", "solana"].includes(String(row.chain_type).toLowerCase()),
-    );
-    if (!evm && !svm) return undefined;
-    return {
-      connection: { is_connected: true },
-      ...(evm ? { evm: { address: String(evm.address), chain_id: 1 } } : {}),
-      ...(svm
-        ? {
-            svm: {
-              address: String(svm.address),
-              cluster: "solana:mainnet",
-            },
-          }
-        : {}),
-      ext: { client_type: "mcp" },
-    };
+    rows = result.rows;
   } catch {
     // Wallet hydration is advisory. The agent can still return its normal
-    // connect/authorize guidance when the account graph cannot be read.
-    return undefined;
+    // connect/authorize guidance when the account graph cannot be read. An
+    // explicit caller-supplied chain remains authoritative independently.
   }
+  const evm = rows.find(
+    (row) => String(row.chain_type).toLowerCase() === "evm",
+  );
+  const svm = rows.find((row) =>
+    ["svm", "solana"].includes(String(row.chain_type).toLowerCase()),
+  );
+  if (!evm && !svm && !chainContext) return undefined;
+  return {
+    connection: { is_connected: Boolean(evm || svm) },
+    ...(evm || chainContext?.family === "evm"
+      ? {
+          evm: {
+            ...(evm ? { address: String(evm.address) } : {}),
+            ...(chainContext?.family === "evm"
+              ? { chain_id: chainContext.chain_id }
+              : {}),
+          },
+        }
+      : {}),
+    ...(svm || chainContext?.family === "solana"
+      ? {
+          svm: {
+            ...(svm ? { address: String(svm.address) } : {}),
+            ...(chainContext?.family === "solana"
+              ? { cluster: chainContext.cluster }
+              : {}),
+          },
+        }
+      : {}),
+    ext: { client_type: "mcp" },
+  };
 }

--- a/apps/portal/src/server/mcp/chat-tools.test.ts
+++ b/apps/portal/src/server/mcp/chat-tools.test.ts
@@ -72,6 +72,7 @@ describe("MCP chat tools", () => {
       "mcp-generated",
       "hello",
       "default",
+      undefined,
     );
     expect(outcome.result).toMatchObject({
       session_id: "mcp-generated",
@@ -108,7 +109,50 @@ describe("MCP chat tools", () => {
       "existing",
       "continue",
       undefined,
+      undefined,
     );
+  });
+
+  it("passes explicit Base and supported Solana contexts without defaults", async () => {
+    await dispatchChatTool(USER, "aomi_chat", {
+      message: "use Base",
+      chain_context: { family: "evm", chain_id: 8453 },
+    });
+    expect(sendChat).toHaveBeenLastCalledWith(
+      USER,
+      "mcp-generated",
+      "use Base",
+      undefined,
+      { family: "evm", chain_id: 8453 },
+    );
+
+    await dispatchChatTool(USER, "aomi_chat", {
+      message: "use Solana devnet",
+      chain_context: { family: "solana", cluster: "solana:devnet" },
+    });
+    expect(sendChat).toHaveBeenLastCalledWith(
+      USER,
+      "mcp-generated",
+      "use Solana devnet",
+      undefined,
+      { family: "solana", cluster: "solana:devnet" },
+    );
+  });
+
+  it("rejects unsupported Solana cluster context", async () => {
+    const outcome = await dispatchChatTool(USER, "aomi_chat", {
+      message: "use Solana",
+      chain_context: { family: "solana", cluster: "mainnet-beta" },
+    });
+    expect(outcome).toEqual({
+      result: {
+        error:
+          "chain_context.cluster must be solana:mainnet, solana:devnet, or solana:testnet",
+      },
+      isError: true,
+    });
+    expect(ensureThread).not.toHaveBeenCalled();
+    expect(sendChat).not.toHaveBeenCalled();
   });
 
   it("returns message deltas while treating drained events as new receipts", async () => {

--- a/apps/portal/src/server/mcp/chat-tools.test.ts
+++ b/apps/portal/src/server/mcp/chat-tools.test.ts
@@ -1,0 +1,326 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@portal/server/mcp/chat-backend", () => ({
+  ensureThread: vi.fn(),
+  sendChat: vi.fn(),
+  fetchState: vi.fn(),
+  interrupt: vi.fn(),
+  listThreads: vi.fn(),
+}));
+vi.mock("@portal/server/mcp/thread", () => ({
+  newMcpThreadId: () => "mcp-generated",
+}));
+
+import {
+  ensureThread,
+  fetchState,
+  interrupt,
+  listThreads,
+  sendChat,
+} from "@portal/server/mcp/chat-backend";
+import { CHAT_MCP_TOOLS, dispatchChatTool } from "./chat-tools";
+
+const USER = "user-1";
+const ok = (body: unknown) => ({ ok: true, status: 200, body });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(ensureThread).mockResolvedValue(ok({}));
+  vi.mocked(sendChat).mockResolvedValue(
+    ok({ messages: [], system_events: [], is_processing: true }),
+  );
+  vi.mocked(fetchState).mockResolvedValue(
+    ok({ messages: [], system_events: [], is_processing: false }),
+  );
+  vi.mocked(interrupt).mockResolvedValue(
+    ok({ messages: [], system_events: [], is_processing: false }),
+  );
+  vi.mocked(listThreads).mockResolvedValue(ok([]));
+});
+
+describe("MCP chat tools", () => {
+  it("exposes exactly the four agent-path tools", () => {
+    expect(CHAT_MCP_TOOLS.map((tool) => tool.name)).toEqual([
+      "aomi_chat",
+      "aomi_check",
+      "aomi_interrupt",
+      "aomi_list_sessions",
+    ]);
+    expect(new Set(CHAT_MCP_TOOLS.map((tool) => tool.name)).size).toBe(4);
+  });
+
+  it("creates and account-binds a new session before firing chat", async () => {
+    vi.mocked(sendChat).mockResolvedValue(
+      ok({
+        messages: [
+          { sender: "user", content: "hello" },
+          { sender: "agent", content: "hi" },
+        ],
+        system_events: [],
+        is_processing: false,
+        title: "Greeting",
+      }),
+    );
+    const outcome = await dispatchChatTool(USER, "aomi_chat", {
+      message: "hello",
+      app: "default",
+    });
+    expect(ensureThread).toHaveBeenCalledWith(USER, "mcp-generated");
+    expect(sendChat).toHaveBeenCalledWith(
+      USER,
+      "mcp-generated",
+      "hello",
+      "default",
+    );
+    expect(outcome.result).toMatchObject({
+      session_id: "mcp-generated",
+      status: "complete",
+      reply: "hi",
+      new_messages: [{ sender: "agent", content: "hi" }],
+      cursor: { messages: 2, system_events: 0 },
+    });
+  });
+
+  it("continues a supplied session without recreating it", async () => {
+    await dispatchChatTool(USER, "aomi_chat", {
+      message: "continue",
+      session_id: "existing",
+    });
+    expect(ensureThread).not.toHaveBeenCalled();
+    expect(sendChat).toHaveBeenCalledWith(
+      USER,
+      "existing",
+      "continue",
+      undefined,
+    );
+  });
+
+  it("returns message deltas while treating drained events as new receipts", async () => {
+    vi.mocked(fetchState).mockResolvedValue(
+      ok({
+        messages: [
+          { sender: "user", content: "do work" },
+          { sender: "agent", content: "done" },
+        ],
+        system_events: [
+          {
+            InlineCall: {
+              type: "tool_complete",
+              payload: { tool_name: "quote", result: { amount: "1" } },
+            },
+          },
+        ],
+        is_processing: false,
+      }),
+    );
+    const outcome = await dispatchChatTool(USER, "aomi_check", {
+      session_id: "existing",
+      cursor: { messages: 1, system_events: 7 },
+    });
+    expect(outcome.result).toMatchObject({
+      status: "complete",
+      new_messages: [{ sender: "agent", content: "done" }],
+      activity: [
+        {
+          type: "tool_complete",
+          tool: "quote",
+          result_preview: '{"amount":"1"}',
+        },
+      ],
+      cursor: { messages: 2, system_events: 8 },
+    });
+  });
+
+  it("holds the mutable streaming tail so the completed reply remains a delta", async () => {
+    vi.mocked(fetchState)
+      .mockResolvedValueOnce(
+        ok({
+          messages: [
+            { sender: "user", content: "do work" },
+            { sender: "agent", content: "partial" },
+          ],
+          system_events: [],
+          is_processing: true,
+        }),
+      )
+      .mockResolvedValueOnce(
+        ok({
+          messages: [
+            { sender: "user", content: "do work" },
+            { sender: "agent", content: "finished" },
+          ],
+          system_events: [],
+          is_processing: false,
+        }),
+      );
+
+    const streaming = await dispatchChatTool(USER, "aomi_check", {
+      session_id: "existing",
+      cursor: { messages: 1, system_events: 0 },
+    });
+    expect(streaming.result).toMatchObject({
+      status: "processing",
+      new_messages: [],
+      cursor: { messages: 1, system_events: 0 },
+    });
+
+    const complete = await dispatchChatTool(USER, "aomi_check", {
+      session_id: "existing",
+      cursor: (streaming.result as { cursor: unknown }).cursor,
+    });
+    expect(complete.result).toMatchObject({
+      status: "complete",
+      new_messages: [{ sender: "agent", content: "finished" }],
+      cursor: { messages: 2, system_events: 0 },
+    });
+  });
+
+  it("compresses task narration and maps processing state", async () => {
+    vi.mocked(fetchState).mockResolvedValue(
+      ok({
+        messages: [],
+        system_events: [
+          { type: "task_started", agent_id: "agent-1", label: "Research" },
+          {
+            type: "task_activity",
+            agent_id: "agent-1",
+            kind: "tool_call",
+            tool_name: "search",
+            child_seq: 1,
+          },
+          {
+            type: "task_completed",
+            agent_id: "agent-1",
+            status: "completed",
+            steps: 1,
+          },
+        ],
+        is_processing: true,
+      }),
+    );
+    const outcome = await dispatchChatTool(USER, "aomi_check", {
+      session_id: "existing",
+    });
+    expect(outcome.result).toMatchObject({
+      status: "processing",
+      activity: [
+        { type: "task_started", agent_id: "agent-1", label: "Research" },
+        {
+          type: "task_activity",
+          agent_id: "agent-1",
+          tool: "search",
+          child_seq: 1,
+        },
+        {
+          type: "task_completed",
+          agent_id: "agent-1",
+          status: "completed",
+          steps: 1,
+        },
+      ],
+    });
+  });
+
+  it("surfaces compact wallet requests and an actionable portal handoff", async () => {
+    vi.stubEnv("BETTER_AUTH_URL", "https://portal.example");
+    vi.mocked(fetchState).mockResolvedValue(
+      ok({
+        messages: [],
+        system_events: [],
+        is_processing: true,
+        user_state: {
+          pending: {
+            evmTxs: {
+              "4": {
+                to: "0xabc",
+                value: "100",
+                chainId: 8453,
+                data: "sensitive-calldata",
+                label: "Approve transfer",
+              },
+            },
+            evmSigs: {
+              "5": {
+                chainId: 1,
+                description: "Permit",
+                typedData: {
+                  primaryType: "Permit",
+                  domain: { name: "USDC", verifyingContract: "0xdef" },
+                  message: { private: "omitted" },
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+    const outcome = await dispatchChatTool(USER, "aomi_check", {
+      session_id: "existing",
+    });
+    expect(outcome.result).toMatchObject({
+      status: "awaiting_user",
+      pending_requests: [
+        {
+          id: "tx-4",
+          kind: "transaction",
+          to: "0xabc",
+          value: "100",
+          chain_id: 8453,
+          description: "Approve transfer",
+        },
+        {
+          id: "tx-5",
+          kind: "eip712_sign",
+          primary_type: "Permit",
+          domain: "USDC",
+          verifying_contract: "0xdef",
+        },
+      ],
+      handoff: {
+        portal_url: "https://portal.example/?thread=existing",
+        cli: "aomi tx sign <request-id>",
+      },
+    });
+    expect(JSON.stringify(outcome.result)).not.toContain("sensitive-calldata");
+    expect(JSON.stringify(outcome.result)).not.toContain('"private"');
+  });
+
+  it("interrupts and lists resumable sessions", async () => {
+    vi.mocked(listThreads).mockResolvedValue(
+      ok([{ thread_id: "thread-1", title: "Swap", last_active_at: 123 }]),
+    );
+    const interrupted = await dispatchChatTool(USER, "aomi_interrupt", {
+      session_id: "thread-1",
+    });
+    expect(interrupt).toHaveBeenCalledWith(USER, "thread-1");
+    expect(interrupted.result).toMatchObject({ interrupted: true });
+
+    const listed = await dispatchChatTool(USER, "aomi_list_sessions", {
+      limit: 5,
+    });
+    expect(listThreads).toHaveBeenCalledWith(USER, 5);
+    expect(listed.result).toEqual({
+      sessions: [{ id: "thread-1", title: "Swap", updated_at: 123 }],
+    });
+  });
+
+  it("returns validation and backend failures as MCP tool errors", async () => {
+    expect((await dispatchChatTool(USER, "aomi_chat", {})).isError).toBe(true);
+    vi.mocked(fetchState).mockResolvedValue({
+      ok: false,
+      status: 503,
+      body: { error: "down" },
+    });
+    await expect(
+      dispatchChatTool(USER, "aomi_check", { session_id: "thread-1" }),
+    ).resolves.toEqual({
+      result: {
+        error: "backend request failed",
+        status: 503,
+        detail: { error: "down" },
+      },
+      isError: true,
+    });
+  });
+});

--- a/apps/portal/src/server/mcp/chat-tools.test.ts
+++ b/apps/portal/src/server/mcp/chat-tools.test.ts
@@ -78,8 +78,23 @@ describe("MCP chat tools", () => {
       status: "complete",
       reply: "hi",
       new_messages: [{ sender: "agent", content: "hi" }],
-      cursor: { messages: 2, system_events: 0 },
+      cursor: {
+        session_id: "mcp-generated",
+        messages: 2,
+        system_events: 0,
+      },
     });
+  });
+
+  it("polls from the self-contained cursor without repeating session_id", async () => {
+    await dispatchChatTool(USER, "aomi_check", {
+      cursor: {
+        session_id: "existing",
+        messages: 1,
+        system_events: 2,
+      },
+    });
+    expect(fetchState).toHaveBeenCalledWith(USER, "existing");
   });
 
   it("continues a supplied session without recreating it", async () => {

--- a/apps/portal/src/server/mcp/chat-tools.ts
+++ b/apps/portal/src/server/mcp/chat-tools.ts
@@ -1,0 +1,528 @@
+import "server-only";
+
+import {
+  ensureThread,
+  fetchState,
+  interrupt,
+  listThreads,
+  sendChat,
+  type ChatBackendResult,
+} from "@portal/server/mcp/chat-backend";
+import type { McpToolDef, ToolOutcome } from "@portal/server/mcp/rpc";
+import { newMcpThreadId } from "@portal/server/mcp/thread";
+
+export const CHAT_MCP_INSTRUCTIONS = [
+  "Chat with the Aomi agent by calling aomi_chat with the user's request.",
+  "aomi_chat starts an asynchronous turn and returns a session_id plus cursor; continue with aomi_check using both values until status is complete or awaiting_user.",
+  "Each aomi_check returns only new transcript messages and newly drained tool/task activity, so relay useful progress while supervising longer work.",
+  "When status is awaiting_user, show the pending wallet request and handoff guidance to the human; do not claim the operation completed until a later check confirms it.",
+  "Use aomi_interrupt to stop a running turn and aomi_list_sessions to find prior account-owned conversations.",
+].join(" ");
+
+const SESSION_PROPERTY = {
+  type: "string",
+  description: "Aomi session id returned by aomi_chat or aomi_list_sessions.",
+} as const;
+
+const CURSOR_PROPERTY = {
+  type: "object",
+  description: "Opaque progress cursor returned by the previous chat/check.",
+  properties: {
+    messages: { type: "integer", minimum: 0 },
+    system_events: { type: "integer", minimum: 0 },
+  },
+  required: ["messages", "system_events"],
+  additionalProperties: false,
+} as const;
+
+export const CHAT_MCP_TOOLS: McpToolDef[] = [
+  {
+    name: "aomi_chat",
+    description:
+      "Start an asynchronous turn with the Aomi agent. Omit session_id to create a new account-owned conversation, then call aomi_check with the returned session_id and cursor until terminal.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        message: { type: "string", description: "The user's request." },
+        session_id: { ...SESSION_PROPERTY },
+        app: {
+          type: "string",
+          description: "Optional Aomi app name for this turn.",
+        },
+      },
+      required: ["message"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "aomi_check",
+    description:
+      "Check a running Aomi turn. Pass the cursor from the prior chat/check to receive only new messages while still receiving every newly drained activity event.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        session_id: { ...SESSION_PROPERTY },
+        cursor: { ...CURSOR_PROPERTY },
+      },
+      required: ["session_id"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "aomi_interrupt",
+    description: "Interrupt the currently processing turn in an Aomi session.",
+    inputSchema: {
+      type: "object",
+      properties: { session_id: { ...SESSION_PROPERTY } },
+      required: ["session_id"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "aomi_list_sessions",
+    description:
+      "List recent account-owned Aomi conversations that can be resumed with aomi_chat.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: {
+          type: "integer",
+          minimum: 1,
+          maximum: 100,
+          description: "Maximum sessions to return. Defaults to 20.",
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+];
+
+type ToolArgs = Record<string, unknown>;
+type Cursor = { messages: number; system_events: number };
+type UnknownRecord = Record<string, unknown>;
+
+export async function dispatchChatTool(
+  canonicalUserId: string,
+  name: string,
+  args: ToolArgs,
+): Promise<ToolOutcome> {
+  switch (name) {
+    case "aomi_chat": {
+      const message = text(args.message);
+      if (!message) return invalid("message is required");
+      const requestedSession = text(args.session_id);
+      const sessionId = requestedSession ?? newMcpThreadId();
+      if (!requestedSession) {
+        const created = await ensureThread(canonicalUserId, sessionId);
+        if (!created.ok) return backendError(created);
+      }
+      const response = await sendChat(
+        canonicalUserId,
+        sessionId,
+        message,
+        text(args.app),
+      );
+      if (!response.ok) return backendError(response);
+      return {
+        result: chatResult(sessionId, message, response.body),
+        isError: false,
+      };
+    }
+    case "aomi_check": {
+      const sessionId = text(args.session_id);
+      if (!sessionId) return invalid("session_id is required");
+      const response = await fetchState(canonicalUserId, sessionId);
+      if (!response.ok) return backendError(response);
+      return {
+        result: stateDelta(sessionId, response.body, cursor(args.cursor)),
+        isError: false,
+      };
+    }
+    case "aomi_interrupt": {
+      const sessionId = text(args.session_id);
+      if (!sessionId) return invalid("session_id is required");
+      const response = await interrupt(canonicalUserId, sessionId);
+      if (!response.ok) return backendError(response);
+      return {
+        result: {
+          ...stateDelta(sessionId, response.body, ZERO_CURSOR),
+          interrupted: true,
+        },
+        isError: false,
+      };
+    }
+    case "aomi_list_sessions": {
+      const limit = integer(args.limit, 20, 1, 100);
+      const response = await listThreads(canonicalUserId, limit);
+      if (!response.ok) return backendError(response);
+      const rows = Array.isArray(response.body) ? response.body : [];
+      return {
+        result: {
+          sessions: rows.map((value) => {
+            const row = record(value);
+            return {
+              id: text(row?.thread_id) ?? text(row?.session_id) ?? "",
+              title: typeof row?.title === "string" ? row.title : null,
+              updated_at:
+                number(row?.last_active_at) ?? number(row?.updated_at) ?? null,
+            };
+          }),
+        },
+        isError: false,
+      };
+    }
+    default:
+      return invalid(`unknown tool '${name}'`);
+  }
+}
+
+const ZERO_CURSOR: Cursor = { messages: 0, system_events: 0 };
+
+function chatResult(
+  sessionId: string,
+  message: string,
+  body: unknown,
+): UnknownRecord {
+  const state = stateRecord(body);
+  const messages = array(state.messages);
+  let promptIndex = -1;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const candidate = record(messages[index]);
+    if (
+      candidate?.sender === "user" &&
+      (candidate.content === message || promptIndex === -1)
+    ) {
+      promptIndex = index;
+      if (candidate.content === message) break;
+    }
+  }
+  const result = stateDelta(sessionId, body, {
+    messages: promptIndex + 1,
+    system_events: 0,
+  });
+  const deliveredMessages = array(result.new_messages);
+  if (result.status === "complete") {
+    const reply = [...deliveredMessages]
+      .reverse()
+      .map(record)
+      .find((entry) =>
+        entry ? ["agent", "assistant"].includes(String(entry.sender)) : false,
+      );
+    if (typeof reply?.content === "string") result.reply = reply.content;
+  }
+  return result;
+}
+
+function stateDelta(
+  sessionId: string,
+  body: unknown,
+  previous: Cursor,
+): UnknownRecord {
+  const state = stateRecord(body);
+  const messages = array(state.messages);
+  const events = array(state.system_events);
+  const pending = pendingRequests(state, events);
+  // The runtime appends an agent message before streaming and mutates that
+  // final entry in place. Do not advance a count-only cursor past the mutable
+  // tail or the completed text would never appear as a later delta.
+  const stableMessageCount =
+    state.is_processing === true && isAgentMessage(messages.at(-1))
+      ? messages.length - 1
+      : messages.length;
+  const messageOffset = Math.min(previous.messages, stableMessageCount);
+  const result: UnknownRecord = {
+    session_id: sessionId,
+    status:
+      pending.length > 0
+        ? "awaiting_user"
+        : state.is_processing === true
+          ? "processing"
+          : "complete",
+    new_messages: messages.slice(messageOffset, stableMessageCount),
+    activity: activity(events),
+    pending_requests: pending,
+    title: typeof state.title === "string" ? state.title : null,
+    cursor: {
+      messages: stableMessageCount,
+      // HTTP state drains system events. The event cursor is therefore a
+      // monotonic receipt count, not an index into the next response.
+      system_events: previous.system_events + events.length,
+    },
+  };
+  if (pending.length > 0) {
+    result.handoff = {
+      portal_url: portalThreadUrl(sessionId),
+      cli: "aomi tx sign <request-id>",
+      guidance:
+        "Open this session in the Aomi portal to approve, or sign from an authenticated Aomi CLI whose active session is this thread. Then call aomi_check again.",
+    };
+  }
+  return result;
+}
+
+function isAgentMessage(value: unknown): boolean {
+  const sender = text(record(value)?.sender);
+  return sender === "agent" || sender === "assistant";
+}
+
+function activity(events: unknown[]): UnknownRecord[] {
+  const output: UnknownRecord[] = [];
+  for (const raw of events) {
+    const event = normalizedEvent(raw);
+    if (!event) continue;
+    const type = text(event.type);
+    if (type === "tool_complete") {
+      output.push(
+        compact({
+          type,
+          tool: text(event.tool_name) ?? text(event.name) ?? text(event.tool),
+          status: text(event.status),
+          result_preview: preview(
+            event.result_preview ?? event.result ?? event.output,
+          ),
+        }),
+      );
+    } else if (type === "task_started") {
+      output.push(
+        compact({
+          type,
+          agent_id: text(event.agent_id),
+          label: text(event.label),
+          app: text(event.app),
+          resumed:
+            typeof event.resumed === "boolean" ? event.resumed : undefined,
+        }),
+      );
+    } else if (type === "task_activity") {
+      output.push(
+        compact({
+          type,
+          agent_id: text(event.agent_id),
+          kind: text(event.kind),
+          tool: text(event.tool_name),
+          text: preview(event.text),
+          result_preview: preview(event.result_preview),
+          child_seq: number(event.child_seq),
+        }),
+      );
+    } else if (type === "task_completed") {
+      output.push(
+        compact({
+          type,
+          agent_id: text(event.agent_id),
+          status: text(event.status),
+          message: preview(event.message),
+          staged_count: number(event.staged_count),
+          steps: number(event.steps),
+          duration_ms: number(event.duration_ms),
+        }),
+      );
+    }
+  }
+  return output;
+}
+
+function pendingRequests(
+  state: UnknownRecord,
+  events: unknown[],
+): UnknownRecord[] {
+  const userState = record(state.user_state);
+  const pending = record(userState?.pending);
+  const requests: UnknownRecord[] = [];
+  addPendingBucket(requests, pending, ["evmTxs", "evm_txs"], "transaction");
+  addPendingBucket(requests, pending, ["evmSigs", "evm_sigs"], "eip712_sign");
+  addPendingBucket(
+    requests,
+    pending,
+    ["svmIxs", "svm_ixs"],
+    "solana_transaction",
+  );
+  addPendingBucket(
+    requests,
+    pending,
+    ["svmSigs", "svm_sigs"],
+    "solana_signature",
+  );
+
+  for (const raw of events) {
+    const event = normalizedEvent(raw);
+    const type = text(event?.type);
+    if (!event || !type || !type.includes("wallet")) continue;
+    const payload = record(event.payload) ?? event;
+    const kind =
+      type === "wallet_eip712_request"
+        ? "eip712_sign"
+        : type.includes("solana")
+          ? "solana_transaction"
+          : type === "wallet_tx_request"
+            ? "transaction"
+            : undefined;
+    if (!kind) continue;
+    const request = shapedPending(
+      text(payload.pending_tx_id) ??
+        text(payload.pending_eip712_id) ??
+        text(payload.tx_id) ??
+        text(payload.id) ??
+        String(requests.length + 1),
+      kind,
+      payload,
+    );
+    if (!requests.some((known) => known.id === request.id)) {
+      requests.push(request);
+    }
+  }
+  return requests;
+}
+
+function addPendingBucket(
+  output: UnknownRecord[],
+  pending: UnknownRecord | undefined,
+  keys: string[],
+  kind: string,
+): void {
+  const bucket = keys.map((key) => record(pending?.[key])).find(Boolean);
+  if (!bucket) return;
+  for (const [id, value] of Object.entries(bucket)) {
+    output.push(shapedPending(id, kind, record(value) ?? {}));
+  }
+}
+
+function shapedPending(
+  rawId: string,
+  kind: string,
+  value: UnknownRecord,
+): UnknownRecord {
+  const typedData = record(value.typedData) ?? record(value.typed_data);
+  const domain = record(typedData?.domain);
+  return compact({
+    id: rawId.startsWith("tx-") ? rawId : `tx-${rawId}`,
+    kind,
+    to: text(value.to),
+    value: text(value.value),
+    chain_id: number(value.chainId) ?? number(value.chain_id),
+    cluster: text(value.cluster),
+    description: text(value.description) ?? text(value.label),
+    primary_type: text(typedData?.primaryType) ?? text(typedData?.primary_type),
+    domain: text(domain?.name),
+    verifying_contract:
+      text(domain?.verifyingContract) ?? text(domain?.verifying_contract),
+  });
+}
+
+function normalizedEvent(value: unknown): UnknownRecord | undefined {
+  const outer = record(value);
+  if (!outer) return undefined;
+  if (typeof outer.type === "string") return outer;
+  const inline = record(outer.InlineCall);
+  if (!inline || typeof inline.type !== "string") return undefined;
+  return { ...record(inline.payload), ...inline, type: inline.type };
+}
+
+function stateRecord(value: unknown): UnknownRecord {
+  return record(value) ?? {};
+}
+
+function cursor(value: unknown): Cursor {
+  let parsed = value;
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      return ZERO_CURSOR;
+    }
+  }
+  const raw = record(parsed);
+  return {
+    messages: nonNegativeInteger(raw?.messages),
+    system_events: nonNegativeInteger(raw?.system_events),
+  };
+}
+
+function compact(value: UnknownRecord): UnknownRecord {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  );
+}
+
+function preview(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  let output: string;
+  if (typeof value === "string") {
+    output = value;
+  } else {
+    try {
+      output = JSON.stringify(value);
+    } catch {
+      output = String(value);
+    }
+  }
+  return output.length > 500 ? `${output.slice(0, 499)}…` : output;
+}
+
+function portalThreadUrl(sessionId: string): string {
+  const base =
+    process.env.BETTER_AUTH_URL?.trim() ||
+    process.env.AOMI_PORTAL_BASE_URL?.trim() ||
+    (process.env.VERCEL_ENV === "production"
+      ? "https://portal.aomi.dev"
+      : process.env.VERCEL_ENV === "preview"
+        ? "https://chat-staging.aomi.dev"
+        : "http://127.0.0.1:3000");
+  const url = new URL(base);
+  url.searchParams.set("thread", sessionId);
+  return url.toString();
+}
+
+function backendError(response: ChatBackendResult): ToolOutcome {
+  return {
+    result: {
+      error: "backend request failed",
+      status: response.status,
+      detail: response.body,
+    },
+    isError: true,
+  };
+}
+
+function invalid(message: string): ToolOutcome {
+  return { result: { error: message }, isError: true };
+}
+
+function record(value: unknown): UnknownRecord | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : undefined;
+}
+
+function array(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function text(value: unknown): string | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function number(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function nonNegativeInteger(value: unknown): number {
+  const parsed = number(value);
+  return parsed === undefined ? 0 : Math.max(0, Math.floor(parsed));
+}
+
+function integer(
+  value: unknown,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+): number {
+  const parsed = number(value);
+  return parsed === undefined
+    ? fallback
+    : Math.min(maximum, Math.max(minimum, Math.floor(parsed)));
+}

--- a/apps/portal/src/server/mcp/chat-tools.ts
+++ b/apps/portal/src/server/mcp/chat-tools.ts
@@ -7,6 +7,7 @@ import {
   listThreads,
   sendChat,
   type ChatBackendResult,
+  type McpChainContext,
 } from "@portal/server/mcp/chat-backend";
 import type { McpToolDef, ToolOutcome } from "@portal/server/mcp/rpc";
 import { newMcpThreadId } from "@portal/server/mcp/thread";
@@ -15,6 +16,7 @@ export const CHAT_MCP_INSTRUCTIONS = [
   "Chat with the Aomi agent by calling aomi_chat with the user's request.",
   "aomi_chat starts an asynchronous turn and returns a self-contained cursor; continue with aomi_check using that cursor until status is complete or awaiting_user.",
   "Each aomi_check returns only new transcript messages and newly drained tool/task activity, so relay useful progress while supervising longer work.",
+  "Pass chain_context to aomi_chat only when the active EVM chain or Solana cluster is known; omit it instead of guessing a network.",
   "When status is awaiting_user, show the pending wallet request and handoff guidance to the human; do not claim the operation completed until a later check confirms it.",
   "Use aomi_interrupt to stop a running turn and aomi_list_sessions to find prior account-owned conversations.",
 ].join(" ");
@@ -50,6 +52,37 @@ export const CHAT_MCP_TOOLS: McpToolDef[] = [
         app: {
           type: "string",
           description: "Optional Aomi app name for this turn.",
+        },
+        chain_context: {
+          description:
+            "Optional authoritative active chain for this turn. Omit it when the network is unknown; Aomi will not invent a mainnet default.",
+          oneOf: [
+            {
+              type: "object",
+              properties: {
+                family: { type: "string", const: "evm" },
+                chain_id: {
+                  type: "integer",
+                  minimum: 1,
+                  maximum: Number.MAX_SAFE_INTEGER,
+                },
+              },
+              required: ["family", "chain_id"],
+              additionalProperties: false,
+            },
+            {
+              type: "object",
+              properties: {
+                family: { type: "string", const: "solana" },
+                cluster: {
+                  type: "string",
+                  enum: ["solana:mainnet", "solana:devnet", "solana:testnet"],
+                },
+              },
+              required: ["family", "cluster"],
+              additionalProperties: false,
+            },
+          ],
         },
       },
       required: ["message"],
@@ -115,6 +148,8 @@ export async function dispatchChatTool(
     case "aomi_chat": {
       const message = text(args.message);
       if (!message) return invalid("message is required");
+      const chainContext = parseChainContext(args.chain_context);
+      if (chainContext.error) return invalid(chainContext.error);
       const requestedSession = text(args.session_id);
       const sessionId = requestedSession ?? newMcpThreadId();
       if (!requestedSession) {
@@ -126,6 +161,7 @@ export async function dispatchChatTool(
         sessionId,
         message,
         text(args.app),
+        chainContext.value,
       );
       if (!response.ok) return backendError(response);
       return {
@@ -532,4 +568,46 @@ function integer(
   return parsed === undefined
     ? fallback
     : Math.min(maximum, Math.max(minimum, Math.floor(parsed)));
+}
+
+function parseChainContext(value: unknown): {
+  value?: McpChainContext;
+  error?: string;
+} {
+  if (value === undefined) return {};
+  const context = record(value);
+  if (!context) return { error: "chain_context must be an object" };
+  const keys = Object.keys(context);
+  if (context.family === "evm") {
+    if (keys.some((key) => !["family", "chain_id"].includes(key))) {
+      return { error: "EVM chain_context contains unsupported fields" };
+    }
+    const chainId = context.chain_id;
+    if (
+      typeof chainId !== "number" ||
+      !Number.isSafeInteger(chainId) ||
+      chainId <= 0
+    ) {
+      return { error: "chain_context.chain_id must be a positive integer" };
+    }
+    return { value: { family: "evm", chain_id: chainId } };
+  }
+  if (context.family === "solana") {
+    if (keys.some((key) => !["family", "cluster"].includes(key))) {
+      return { error: "Solana chain_context contains unsupported fields" };
+    }
+    const cluster = context.cluster;
+    if (
+      cluster !== "solana:mainnet" &&
+      cluster !== "solana:devnet" &&
+      cluster !== "solana:testnet"
+    ) {
+      return {
+        error:
+          "chain_context.cluster must be solana:mainnet, solana:devnet, or solana:testnet",
+      };
+    }
+    return { value: { family: "solana", cluster } };
+  }
+  return { error: "chain_context.family must be evm or solana" };
 }

--- a/apps/portal/src/server/mcp/chat-tools.ts
+++ b/apps/portal/src/server/mcp/chat-tools.ts
@@ -13,7 +13,7 @@ import { newMcpThreadId } from "@portal/server/mcp/thread";
 
 export const CHAT_MCP_INSTRUCTIONS = [
   "Chat with the Aomi agent by calling aomi_chat with the user's request.",
-  "aomi_chat starts an asynchronous turn and returns a session_id plus cursor; continue with aomi_check using both values until status is complete or awaiting_user.",
+  "aomi_chat starts an asynchronous turn and returns a self-contained cursor; continue with aomi_check using that cursor until status is complete or awaiting_user.",
   "Each aomi_check returns only new transcript messages and newly drained tool/task activity, so relay useful progress while supervising longer work.",
   "When status is awaiting_user, show the pending wallet request and handoff guidance to the human; do not claim the operation completed until a later check confirms it.",
   "Use aomi_interrupt to stop a running turn and aomi_list_sessions to find prior account-owned conversations.",
@@ -26,8 +26,10 @@ const SESSION_PROPERTY = {
 
 const CURSOR_PROPERTY = {
   type: "object",
-  description: "Opaque progress cursor returned by the previous chat/check.",
+  description:
+    "Opaque progress cursor returned by the previous chat/check. It carries the session id, so it can be passed to aomi_check by itself.",
   properties: {
+    session_id: { ...SESSION_PROPERTY },
     messages: { type: "integer", minimum: 0 },
     system_events: { type: "integer", minimum: 0 },
   },
@@ -57,14 +59,13 @@ export const CHAT_MCP_TOOLS: McpToolDef[] = [
   {
     name: "aomi_check",
     description:
-      "Check a running Aomi turn. Pass the cursor from the prior chat/check to receive only new messages while still receiving every newly drained activity event.",
+      "Check a running Aomi turn. Pass the cursor from the prior chat/check; it contains the session id. The top-level session_id remains accepted for older cursors.",
     inputSchema: {
       type: "object",
       properties: {
         session_id: { ...SESSION_PROPERTY },
         cursor: { ...CURSOR_PROPERTY },
       },
-      required: ["session_id"],
       additionalProperties: false,
     },
   },
@@ -98,7 +99,11 @@ export const CHAT_MCP_TOOLS: McpToolDef[] = [
 ];
 
 type ToolArgs = Record<string, unknown>;
-type Cursor = { messages: number; system_events: number };
+type Cursor = {
+  session_id?: string;
+  messages: number;
+  system_events: number;
+};
 type UnknownRecord = Record<string, unknown>;
 
 export async function dispatchChatTool(
@@ -129,7 +134,8 @@ export async function dispatchChatTool(
       };
     }
     case "aomi_check": {
-      const sessionId = text(args.session_id);
+      const sessionId =
+        text(args.session_id) ?? text(record(args.cursor)?.session_id);
       if (!sessionId) return invalid("session_id is required");
       const response = await fetchState(canonicalUserId, sessionId);
       if (!response.ok) return backendError(response);
@@ -243,6 +249,7 @@ function stateDelta(
     pending_requests: pending,
     title: typeof state.title === "string" ? state.title : null,
     cursor: {
+      session_id: sessionId,
       messages: stableMessageCount,
       // HTTP state drains system events. The event cursor is therefore a
       // monotonic receipt count, not an index into the next response.

--- a/apps/portal/src/server/mcp/rpc.test.ts
+++ b/apps/portal/src/server/mcp/rpc.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+
+import { handleMcpPost, mcpMethodNotAllowed } from "./rpc";
+
+const tool = {
+  name: "aomi_test",
+  description: "test tool",
+  inputSchema: { type: "object" },
+};
+
+function request(body: unknown): Request {
+  return new Request("https://portal.example/api/mcp", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("MCP RPC shell", () => {
+  it("returns initialization metadata and model instructions", async () => {
+    const response = await handleMcpPost(
+      request({ jsonrpc: "2.0", id: 1, method: "initialize" }),
+      { tools: [tool], instructions: "chat then check", dispatchTool: vi.fn() },
+    );
+    const body = await response.json();
+    expect(body.result).toMatchObject({
+      protocolVersion: "2025-06-18",
+      instructions: "chat then check",
+      capabilities: { tools: { listChanged: false } },
+    });
+    expect(response.headers.get("mcp-protocol-version")).toBe("2025-06-18");
+  });
+
+  it("lists and calls the configured surface", async () => {
+    const dispatchTool = vi.fn().mockResolvedValue({
+      result: { status: "processing" },
+      isError: false,
+    });
+    const listed = await handleMcpPost(
+      request({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+      { tools: [tool], instructions: "", dispatchTool },
+    );
+    expect((await listed.json()).result.tools).toEqual([tool]);
+
+    const called = await handleMcpPost(
+      request({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "aomi_test", arguments: { message: "hello" } },
+      }),
+      { tools: [tool], instructions: "", dispatchTool },
+    );
+    expect(dispatchTool).toHaveBeenCalledWith("aomi_test", {
+      message: "hello",
+    });
+    expect((await called.json()).result).toMatchObject({ isError: false });
+  });
+
+  it("preserves parse, batch, notification, and method boundaries", async () => {
+    const config = { tools: [tool], instructions: "", dispatchTool: vi.fn() };
+    expect(
+      (await (await handleMcpPost(request("{"), config)).json()).error.code,
+    ).toBe(-32700);
+    expect(
+      (await (await handleMcpPost(request([]), config)).json()).error.code,
+    ).toBe(-32600);
+    expect(
+      (
+        await handleMcpPost(
+          request({ jsonrpc: "2.0", method: "notifications/initialized" }),
+          config,
+        )
+      ).status,
+    ).toBe(202);
+    expect(
+      (
+        await handleMcpPost(
+          request({ jsonrpc: "2.0", id: 9, method: "missing" }),
+          config,
+        )
+      ).status,
+    ).toBe(200);
+    expect(mcpMethodNotAllowed().status).toBe(405);
+  });
+});

--- a/apps/portal/src/server/mcp/rpc.ts
+++ b/apps/portal/src/server/mcp/rpc.ts
@@ -1,0 +1,117 @@
+import "server-only";
+
+export const MCP_PROTOCOL_VERSION = "2025-06-18";
+
+const SERVER_INFO = { name: "aomi", version: "0.2.0" };
+
+export type McpToolDef = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+};
+
+export type ToolOutcome = { result: unknown; isError: boolean };
+
+type JsonRpcRequest = {
+  jsonrpc?: string;
+  id?: number | string | null;
+  method?: string;
+  params?: Record<string, unknown>;
+};
+
+type McpRpcConfig = {
+  tools: McpToolDef[];
+  instructions: string;
+  dispatchTool: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => Promise<ToolOutcome>;
+};
+
+/** Stateless streamable-HTTP JSON-RPC shell shared by both MCP surfaces. */
+export async function handleMcpPost(
+  request: Request,
+  config: McpRpcConfig,
+): Promise<Response> {
+  let message: JsonRpcRequest;
+  try {
+    message = (await request.json()) as JsonRpcRequest;
+  } catch {
+    return rpcError(
+      null,
+      -32700,
+      "parse error: body must be a JSON-RPC message",
+    );
+  }
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return rpcError(
+      null,
+      -32600,
+      Array.isArray(message)
+        ? "batch requests are not supported"
+        : "invalid JSON-RPC request",
+    );
+  }
+
+  const { id, method, params } = message;
+  switch (method) {
+    case "initialize":
+      return rpcResult(id ?? null, {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: { tools: { listChanged: false } },
+        serverInfo: SERVER_INFO,
+        instructions: config.instructions,
+      });
+    case "ping":
+      return rpcResult(id ?? null, {});
+    case "tools/list":
+      return rpcResult(id ?? null, { tools: config.tools });
+    case "tools/call": {
+      const name = typeof params?.name === "string" ? params.name : "";
+      const args =
+        params?.arguments &&
+        typeof params.arguments === "object" &&
+        !Array.isArray(params.arguments)
+          ? (params.arguments as Record<string, unknown>)
+          : {};
+      const outcome = await config.dispatchTool(name, args);
+      return rpcResult(id ?? null, {
+        content: [
+          { type: "text", text: JSON.stringify(outcome.result, null, 2) },
+        ],
+        isError: outcome.isError,
+      });
+    }
+    default:
+      if (id === undefined || id === null) {
+        return new Response(null, { status: 202, headers: mcpHeaders() });
+      }
+      return rpcError(id, -32601, `method '${method}' not found`);
+  }
+}
+
+export function mcpMethodNotAllowed(): Response {
+  return new Response(null, { status: 405, headers: mcpHeaders() });
+}
+
+function mcpHeaders(): HeadersInit {
+  return { "mcp-protocol-version": MCP_PROTOCOL_VERSION };
+}
+
+function rpcResult(id: number | string | null, result: unknown): Response {
+  return Response.json(
+    { jsonrpc: "2.0", id, result },
+    { headers: mcpHeaders() },
+  );
+}
+
+function rpcError(
+  id: number | string | null,
+  code: number,
+  message: string,
+): Response {
+  return Response.json(
+    { jsonrpc: "2.0", id, error: { code, message } },
+    { headers: mcpHeaders() },
+  );
+}

--- a/apps/portal/src/server/mcp/thread.ts
+++ b/apps/portal/src/server/mcp/thread.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 /**
  * Deterministic MCP thread id — byte-for-byte the derivation the Rust MCP
@@ -17,6 +17,10 @@ export function mcpThreadId(
 ): string {
   const seed = `aomi:mcp:${canonicalUserId}:${sessionId?.trim() || "default"}`;
   return `mcp-${uuidV5(seed, UUID_NAMESPACE_URL)}`;
+}
+
+export function newMcpThreadId(): string {
+  return `mcp-${randomUUID()}`;
 }
 
 function uuidV5(name: string, namespace: string): string {

--- a/apps/portal/src/server/mcp/tools.ts
+++ b/apps/portal/src/server/mcp/tools.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { execRun, resourceGet, toolCall } from "@portal/server/mcp/backend";
 import { mcpThreadId } from "@portal/server/mcp/thread";
+import type { McpToolDef, ToolOutcome } from "@portal/server/mcp/rpc";
 
 /**
  * The resident Aomi MCP tool surface — same seven tools and broad→narrow
@@ -11,12 +12,6 @@ import { mcpThreadId } from "@portal/server/mcp/thread";
  * thread-scoped kernel syscall. No per-session server state; callers pass
  * `app` explicitly (select_app returns context, it does not mutate).
  */
-export type McpToolDef = {
-  name: string;
-  description: string;
-  inputSchema: Record<string, unknown>;
-};
-
 const APP_PROPERTY = {
   type: "string",
   description:
@@ -207,8 +202,6 @@ export const MCP_TOOLS: McpToolDef[] = [
 ];
 
 type ToolArgs = Record<string, unknown>;
-
-export type ToolOutcome = { result: unknown; isError: boolean };
 
 export async function dispatchTool(
   canonicalUserId: string,

--- a/memory/2026-08-12.md
+++ b/memory/2026-08-12.md
@@ -1,0 +1,30 @@
+# 2026-08-12
+
+## MCP chat parity
+
+- Replaced the primary OAuth MCP tool funnel with the four-tool asynchronous
+  agent surface from `specs/MCP-CHAT-PARITY-PLAN.md`; preserved the original
+  direct tools at `/api/mcp/direct`.
+- Extracted one stateless streamable-HTTP JSON-RPC shell so both routes share
+  initialize, ping, tool-list/call, notification, error, and method behavior.
+- Added account-bound thread creation, chat/state/interrupt/list backend calls,
+  both session/thread routing headers, and headless primary EVM/SVM wallet
+  hydration from the canonical account graph.
+- Added cursor-safe transcript deltas and receipt-counted drained system events,
+  compressed tool/orchestrator activity, redacted wallet-request summaries,
+  `awaiting_user` status, and a portal deep-link handoff.
+- Held the mutable trailing streamed agent message behind the count cursor so
+  its completed text is delivered exactly once instead of being skipped after
+  an in-place runtime update.
+- Made `?thread=` wait for authenticated remote-thread metadata before calling
+  the runtime selector; this avoids its intentional unknown-id fallback to a
+  blank local thread.
+- Added focused coverage for the RPC transport, backend routing/hydration,
+  four-tool inventory, new/resumed sessions, deltas, activity, wallet requests,
+  interrupt/list behavior, handoff bootstrapping, and failures.
+- Locally verified SIWE → OAuth dynamic registration → explicit consent → PKCE
+  token exchange and refresh, the 4-tool primary and 10-tool direct surfaces,
+  an actual async agent reply, list/resume/interrupt, and a funded local-chain
+  ETH transaction reaching `awaiting_user` with one redacted pending request.
+  `agent-browser` verified authenticated settings, the live MCP consent copy,
+  the linked transcript, and a browser-originated reply on that conversation.

--- a/memory/2026-08-13.md
+++ b/memory/2026-08-13.md
@@ -1,0 +1,18 @@
+# 2026-08-13
+
+## MCP explicit chain context
+
+- Removed the hardcoded Ethereum mainnet chain id and Solana mainnet cluster
+  from headless MCP wallet hydration. Account wallet addresses remain available
+  without claiming an active network.
+- Added optional, runtime-validated `aomi_chat.chain_context` variants for a
+  positive EVM chain id or canonical `solana:mainnet`, `solana:devnet`, and
+  `solana:testnet` clusters.
+- Updated the MCP smoke to send its configured EVM chain on every chat turn, so
+  the Base signing run explicitly supplies chain 8453.
+- Verified 62 focused MCP/CLI session tests, targeted and Portal-wide ESLint,
+  focused Prettier, `git diff --check`, and a mock-safe Portal production build.
+  Portal typecheck remains blocked by the pre-existing duplicate Para SDK/Wagmi
+  connector types; the Portal-local Vitest config likewise retains its existing
+  Vite CommonJS/ESM startup mismatch, while the same MCP tests pass through the
+  root Vitest configuration.

--- a/packages/client/dist/cli.js
+++ b/packages/client/dist/cli.js
@@ -5602,7 +5602,7 @@ var init_cli_session = __esm({
         return _CliSession.create(config);
       }
       /** Create a fresh session and persist it. */
-      static create(config, seed) {
+      static create(config, seed, sessionId = crypto.randomUUID()) {
         var _a3, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n;
         let svmPublicKey;
         if (config.solanaPrivateKey) {
@@ -5614,7 +5614,7 @@ var init_cli_session = __esm({
           }
         }
         const state = {
-          sessionId: crypto.randomUUID(),
+          sessionId,
           clientId: crypto.randomUUID(),
           baseUrl: (_b = (_a3 = config.baseUrl) != null ? _a3 : seed == null ? void 0 : seed.baseUrl) != null ? _b : DEFAULT_CLI_BASE_URL,
           app: (_c = config.app) != null ? _c : seed == null ? void 0 : seed.app,
@@ -8052,13 +8052,42 @@ function newSessionCommand(config) {
   console.log(`Active session set to ${cli.sessionId} (new).`);
   printDataFileLocation();
 }
-function resumeSessionCommand(selector) {
+async function resumeSessionCommand(selector) {
   const resumed = setActiveSession(selector);
-  if (!resumed) {
-    fatal(`No local session found for selector "${selector}".`);
+  if (resumed) {
+    console.log(
+      `Active session set to ${resumed.sessionId} (session-${resumed.localId}).`
+    );
+    printDataFileLocation();
+    return;
   }
+  const current = CliSession.load();
+  if (!current) {
+    fatal(
+      `No local session found for selector "${selector}" and no authenticated session is available to import it.`
+    );
+  }
+  const session = current.createClientSession();
+  try {
+    await session.client.fetchState(
+      selector,
+      void 0,
+      current.ensureClientId()
+    );
+  } catch (e) {
+    fatal(
+      `No account-owned local or remote session found for selector "${selector}".`
+    );
+  } finally {
+    session.close();
+  }
+  const imported = CliSession.create(
+    { secrets: {} },
+    current.toState(),
+    selector
+  );
   console.log(
-    `Active session set to ${resumed.sessionId} (session-${resumed.localId}).`
+    `Active session set to ${imported.sessionId} (imported remote session).`
   );
   printDataFileLocation();
 }
@@ -10644,7 +10673,7 @@ var sessionResumeDef = defineCommand3({
   },
   async run({ args }) {
     const { resumeSessionCommand: resumeSessionCommand2 } = await Promise.resolve().then(() => (init_sessions(), sessions_exports));
-    resumeSessionCommand2(args.id);
+    await resumeSessionCommand2(args.id);
   }
 });
 var sessionDeleteDef = defineCommand3({
@@ -11340,7 +11369,7 @@ init_shared();
 // package.json
 var package_default = {
   name: "@aomi-labs/client",
-  version: "0.4.5",
+  version: "0.4.6",
   description: "Platform-agnostic TypeScript client for the Aomi backend API",
   type: "module",
   main: "./dist/index.cjs",

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aomi-labs/client",
-  "version": "0.4.4",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aomi-labs/client",
-      "version": "0.4.4",
+      "version": "0.4.6",
       "dependencies": {
         "@getpara/aa-alchemy": "2.21.0",
         "@getpara/aa-pimlico": "2.21.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/client",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Platform-agnostic TypeScript client for the Aomi backend API",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/client/src/cli/cli-session.ts
+++ b/packages/client/src/cli/cli-session.ts
@@ -62,7 +62,11 @@ export class CliSession {
   }
 
   /** Create a fresh session and persist it. */
-  static create(config: CliConfig, seed?: CliSessionState): CliSession {
+  static create(
+    config: CliConfig,
+    seed?: CliSessionState,
+    sessionId = crypto.randomUUID(),
+  ): CliSession {
     // Derive Solana public key from private key when provided.
     let svmPublicKey: string | undefined;
     if (config.solanaPrivateKey) {
@@ -76,7 +80,7 @@ export class CliSession {
     }
 
     const state: CliSessionState = {
-      sessionId: crypto.randomUUID(),
+      sessionId,
       clientId: crypto.randomUUID(),
       baseUrl: config.baseUrl ?? seed?.baseUrl ?? DEFAULT_CLI_BASE_URL,
       app: config.app ?? seed?.app,

--- a/packages/client/src/cli/commands/defs/session.ts
+++ b/packages/client/src/cli/commands/defs/session.ts
@@ -11,7 +11,10 @@ const sessionListDef = defineCommand({
 });
 
 const sessionNewDef = defineCommand({
-  meta: { name: "new", description: "Start a fresh session and make it active" },
+  meta: {
+    name: "new",
+    description: "Start a fresh session and make it active",
+  },
   args: { ...globalArgs },
   async run({ args }) {
     const { newSessionCommand } = await import("../sessions");

--- a/packages/client/src/cli/commands/defs/session.ts
+++ b/packages/client/src/cli/commands/defs/session.ts
@@ -30,7 +30,7 @@ const sessionResumeDef = defineCommand({
   },
   async run({ args }) {
     const { resumeSessionCommand } = await import("../sessions");
-    resumeSessionCommand(args.id);
+    await resumeSessionCommand(args.id);
   },
 });
 

--- a/packages/client/src/cli/commands/sessions.ts
+++ b/packages/client/src/cli/commands/sessions.ts
@@ -124,13 +124,45 @@ export function newSessionCommand(config: CliConfig): void {
   printDataFileLocation();
 }
 
-export function resumeSessionCommand(selector: string): void {
+export async function resumeSessionCommand(selector: string): Promise<void> {
   const resumed = setActiveSession(selector);
-  if (!resumed) {
-    fatal(`No local session found for selector "${selector}".`);
+  if (resumed) {
+    console.log(
+      `Active session set to ${resumed.sessionId} (session-${resumed.localId}).`,
+    );
+    printDataFileLocation();
+    return;
   }
+
+  const current = CliSession.load();
+  if (!current) {
+    fatal(
+      `No local session found for selector "${selector}" and no authenticated session is available to import it.`,
+    );
+  }
+
+  const session = current.createClientSession();
+  try {
+    await session.client.fetchState(
+      selector,
+      undefined,
+      current.ensureClientId(),
+    );
+  } catch {
+    fatal(
+      `No account-owned local or remote session found for selector "${selector}".`,
+    );
+  } finally {
+    session.close();
+  }
+
+  const imported = CliSession.create(
+    { secrets: {} },
+    current.toState(),
+    selector,
+  );
   console.log(
-    `Active session set to ${resumed.sessionId} (session-${resumed.localId}).`,
+    `Active session set to ${imported.sessionId} (imported remote session).`,
   );
   printDataFileLocation();
 }

--- a/packages/client/test/cli/cli-session.unit.test.ts
+++ b/packages/client/test/cli/cli-session.unit.test.ts
@@ -129,6 +129,41 @@ describe("CLI session lifecycle", () => {
     );
   });
 
+  it("imports an account-owned remote session when resume has no local match", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { AomiClient } = await import("../../src/client");
+    const fetchState = vi
+      .spyOn(AomiClient.prototype, "fetchState")
+      .mockResolvedValue({ messages: [], system_events: [] } as never);
+    const { CliSession } = await import("../../src/cli/cli-session");
+    const { resumeSessionCommand } =
+      await import("../../src/cli/commands/sessions");
+    const { readState } = await import("../../src/cli/state");
+
+    const current = CliSession.create({
+      baseUrl: "https://chat.aomi.dev",
+      app: "default",
+      secrets: {},
+    });
+    current.setAuthSession({
+      sessionToken: "bff-session-token",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    await resumeSessionCommand("mcp-remote-thread");
+
+    expect(fetchState).toHaveBeenCalledWith(
+      "mcp-remote-thread",
+      undefined,
+      expect.any(String),
+    );
+    expect(readState()?.sessionId).toBe("mcp-remote-thread");
+    expect(readState()?.auth?.sessionToken).toBe("bff-session-token");
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("imported remote session"),
+    );
+  });
+
   it("persists explicit wallet, chain, and backend settings on the active session", async () => {
     const { setWalletCommand, setChainCommand, setBackendCommand } =
       await import("../../src/cli/commands/preferences");

--- a/scripts/smoke-mcp-chat.mjs
+++ b/scripts/smoke-mcp-chat.mjs
@@ -6,17 +6,26 @@ import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 // isolation knobs:
 //   AOMI_MCP_E2E_LOCAL_DB_URL — mirror the generated canonical user into the
 //     explicitly local `aomi_local` backend database.
+//   AOMI_MCP_E2E_PRIVATE_KEY — use an existing EVM test wallet for SIWE instead
+//     of generating a throwaway key. The value is never printed.
+//   AOMI_MCP_E2E_CHAIN_ID — SIWE chain id for that wallet (default: 31337).
 //   AOMI_MCP_E2E_ANVIL_URL + AOMI_MCP_E2E_WALLET_PROMPT — fund the generated
 //     wallet on local Anvil and require a real `awaiting_user` wallet handoff.
 //   AOMI_MCP_E2E_COOKIE_FILE — write a mode-0600 Cookie header for a separate
 //     agent-browser pass; delete it immediately after the browser run.
 const origin = "http://localhost:3000";
 const redirectUri = "http://127.0.0.1:49152/callback";
-const chainId = 31337;
+const chainId = Number(process.env.AOMI_MCP_E2E_CHAIN_ID?.trim() || "31337");
 const localBackendDb = process.env.AOMI_MCP_E2E_LOCAL_DB_URL?.trim();
 const browserCookieFile = process.env.AOMI_MCP_E2E_COOKIE_FILE?.trim();
 const localAnvilUrl = process.env.AOMI_MCP_E2E_ANVIL_URL?.trim();
 const walletPrompt = process.env.AOMI_MCP_E2E_WALLET_PROMPT?.trim();
+const configuredPrivateKey = process.env.AOMI_MCP_E2E_PRIVATE_KEY?.trim();
+
+assert(
+  Number.isSafeInteger(chainId) && chainId > 0,
+  "AOMI_MCP_E2E_CHAIN_ID must be a positive integer",
+);
 
 class CookieJar {
   cookies = new Map();
@@ -89,7 +98,16 @@ Issued At: ${new Date().toISOString()}`;
 }
 
 async function signIn(jar) {
-  const account = privateKeyToAccount(generatePrivateKey());
+  const privateKey = configuredPrivateKey
+    ? configuredPrivateKey.startsWith("0x")
+      ? configuredPrivateKey
+      : `0x${configuredPrivateKey}`
+    : generatePrivateKey();
+  assert(
+    /^0x[0-9a-fA-F]{64}$/.test(privateKey),
+    "AOMI_MCP_E2E_PRIVATE_KEY must be a 32-byte hexadecimal EVM private key",
+  );
+  const account = privateKeyToAccount(privateKey);
   const nonce = await json(
     await jar.fetch("/api/auth/siwe/nonce", {
       method: "POST",

--- a/scripts/smoke-mcp-chat.mjs
+++ b/scripts/smoke-mcp-chat.mjs
@@ -363,6 +363,7 @@ async function testMcp(accessToken) {
       arguments: {
         message: "Reply with exactly: MCP chat parity works",
         app: "default",
+        chain_context: { family: "evm", chain_id: chainId },
       },
     }),
   );
@@ -430,6 +431,7 @@ async function testMcp(accessToken) {
         message: "Reply with exactly: resumed",
         session_id: started.session_id,
         app: "default",
+        chain_context: { family: "evm", chain_id: chainId },
       },
     }),
   );
@@ -477,7 +479,11 @@ async function testPendingWalletRequest(accessToken) {
   let state = toolJson(
     await rpc(accessToken, "/api/mcp", "tools/call", {
       name: "aomi_chat",
-      arguments: { message: walletPrompt, app: "default" },
+      arguments: {
+        message: walletPrompt,
+        app: "default",
+        chain_context: { family: "evm", chain_id: chainId },
+      },
     }),
   );
   for (

--- a/scripts/smoke-mcp-chat.mjs
+++ b/scripts/smoke-mcp-chat.mjs
@@ -1,0 +1,506 @@
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { writeFile } from "node:fs/promises";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+
+// Local MCP acceptance smoke. It never prints credentials. Optional local
+// isolation knobs:
+//   AOMI_MCP_E2E_LOCAL_DB_URL — mirror the generated canonical user into the
+//     explicitly local `aomi_local` backend database.
+//   AOMI_MCP_E2E_ANVIL_URL + AOMI_MCP_E2E_WALLET_PROMPT — fund the generated
+//     wallet on local Anvil and require a real `awaiting_user` wallet handoff.
+//   AOMI_MCP_E2E_COOKIE_FILE — write a mode-0600 Cookie header for a separate
+//     agent-browser pass; delete it immediately after the browser run.
+const origin = "http://localhost:3000";
+const redirectUri = "http://127.0.0.1:49152/callback";
+const chainId = 31337;
+const localBackendDb = process.env.AOMI_MCP_E2E_LOCAL_DB_URL?.trim();
+const browserCookieFile = process.env.AOMI_MCP_E2E_COOKIE_FILE?.trim();
+const localAnvilUrl = process.env.AOMI_MCP_E2E_ANVIL_URL?.trim();
+const walletPrompt = process.env.AOMI_MCP_E2E_WALLET_PROMPT?.trim();
+
+class CookieJar {
+  cookies = new Map();
+
+  absorb(response) {
+    for (const cookie of response.headers.getSetCookie?.() ?? []) {
+      const pair = cookie.split(";", 1)[0];
+      const separator = pair.indexOf("=");
+      if (separator > 0) {
+        this.cookies.set(pair.slice(0, separator), pair.slice(separator + 1));
+      }
+    }
+  }
+
+  header() {
+    return [...this.cookies]
+      .map(([name, value]) => `${name}=${value}`)
+      .join("; ");
+  }
+
+  async fetch(path, init = {}) {
+    const headers = new Headers(init.headers);
+    if (init.method && init.method !== "GET" && !headers.has("origin")) {
+      headers.set("origin", origin);
+    }
+    if (this.cookies.size > 0) {
+      headers.set("cookie", this.header());
+    }
+    const response = await fetch(new URL(path, origin), {
+      ...init,
+      headers,
+      redirect: "manual",
+    });
+    this.absorb(response);
+    return response;
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function json(response, label) {
+  const text = await response.text();
+  let body;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    throw new Error(`${label}: HTTP ${response.status}, non-JSON response`);
+  }
+  if (!response.ok) {
+    throw new Error(
+      `${label}: HTTP ${response.status} ${JSON.stringify(body)}`,
+    );
+  }
+  return body;
+}
+
+function buildSiweMessage({ address, nonce, domain, uri }) {
+  return `${domain} wants you to sign in with your Ethereum account:
+${address}
+
+Sign in to Aomi.
+
+URI: ${uri}
+Version: 1
+Chain ID: ${chainId}
+Nonce: ${nonce}
+Issued At: ${new Date().toISOString()}`;
+}
+
+async function signIn(jar) {
+  const account = privateKeyToAccount(generatePrivateKey());
+  const nonce = await json(
+    await jar.fetch("/api/auth/siwe/nonce", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ walletAddress: account.address, chainId }),
+    }),
+    "SIWE nonce",
+  );
+  const message = buildSiweMessage({
+    address: account.address,
+    nonce: nonce.nonce,
+    domain: nonce.domain ?? new URL(origin).host,
+    uri: nonce.uri ?? origin,
+  });
+  const signature = await account.signMessage({ message });
+  const verified = await json(
+    await jar.fetch("/api/auth/siwe/verify", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        message,
+        signature,
+        walletAddress: account.address,
+        chainId,
+      }),
+    }),
+    "SIWE verify",
+  );
+  assert(
+    verified.success === true || verified.user_id || verified.user?.id,
+    "SIWE response did not confirm a user",
+  );
+  const graph = await json(
+    await jar.fetch("/api/aomi/account"),
+    "canonical account graph",
+  );
+  const canonicalUserId = graph?.user?.id ?? graph?.user?.user_id;
+  assert(
+    typeof canonicalUserId === "string",
+    "account graph omitted canonical user id",
+  );
+  if (localBackendDb) await mirrorAccountIntoLocalBackend(canonicalUserId);
+  console.log("ok SIWE wallet session established");
+  return { address: account.address };
+}
+
+async function mirrorAccountIntoLocalBackend(canonicalUserId) {
+  const database = new URL(localBackendDb);
+  assert(
+    ["127.0.0.1", "localhost"].includes(database.hostname) &&
+      database.pathname === "/aomi_local",
+    "AOMI_MCP_E2E_LOCAL_DB_URL must target the local aomi_local database",
+  );
+  const pg = await import("../packages/account/node_modules/pg/lib/index.js");
+  const { Client } = pg.default ?? pg;
+  const client = new Client({ connectionString: localBackendDb });
+  await client.connect();
+  try {
+    await client.query(
+      `insert into users (id)
+       values ($1)
+       on conflict (id) do nothing`,
+      [canonicalUserId],
+    );
+  } finally {
+    await client.end();
+  }
+  console.log(
+    "ok canonical account mirrored into isolated local backend database",
+  );
+}
+
+async function oauth(jar) {
+  const registered = await json(
+    await jar.fetch("/api/auth/mcp/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        redirect_uris: [redirectUri],
+        token_endpoint_auth_method: "none",
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+        client_name: `Aomi MCP E2E ${randomUUID()}`,
+        scope: "openid profile email offline_access",
+      }),
+    }),
+    "OAuth dynamic registration",
+  );
+  assert(
+    typeof registered.client_id === "string",
+    "registration omitted client_id",
+  );
+  console.log("ok OAuth dynamic client registration");
+
+  const verifier = randomBytes(48).toString("base64url");
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  const state = randomBytes(24).toString("base64url");
+  const authorize = new URL("/api/auth/mcp/authorize", origin);
+  authorize.search = new URLSearchParams({
+    client_id: registered.client_id,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope: "openid profile email offline_access",
+    state,
+    code_challenge: challenge,
+    code_challenge_method: "S256",
+    prompt: "consent",
+  });
+  const authorizeResponse = await jar.fetch(
+    authorize.pathname + authorize.search,
+  );
+  assert(
+    authorizeResponse.status === 302,
+    `authorize returned HTTP ${authorizeResponse.status}`,
+  );
+  const consentUrl = new URL(authorizeResponse.headers.get("location"), origin);
+  assert(
+    consentUrl.pathname === "/mcp/connect" &&
+      consentUrl.searchParams.has("consent_code"),
+    "authorize did not redirect to MCP consent",
+  );
+  console.log("ok OAuth authorize redirected to explicit consent");
+
+  const consent = await json(
+    await jar.fetch("/api/auth/oauth2/consent", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        accept: true,
+        consent_code: consentUrl.searchParams.get("consent_code"),
+      }),
+    }),
+    "OAuth consent",
+  );
+  const callback = new URL(consent.redirectURI);
+  assert(
+    callback.searchParams.get("state") === state,
+    "OAuth state did not round-trip",
+  );
+  const code = callback.searchParams.get("code");
+  assert(code, "consent response omitted authorization code");
+  console.log("ok OAuth consent and state round-trip");
+
+  const token = await json(
+    await jar.fetch("/api/auth/mcp/token", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: redirectUri,
+        client_id: registered.client_id,
+        code_verifier: verifier,
+      }),
+    }),
+    "OAuth token exchange",
+  );
+  assert(
+    typeof token.access_token === "string",
+    "token exchange omitted access token",
+  );
+  assert(
+    typeof token.refresh_token === "string",
+    "token exchange omitted refresh token",
+  );
+  console.log("ok OAuth PKCE token exchange");
+
+  const refreshed = await json(
+    await jar.fetch("/api/auth/mcp/token", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: token.refresh_token,
+        client_id: registered.client_id,
+      }),
+    }),
+    "OAuth refresh",
+  );
+  assert(
+    typeof refreshed.access_token === "string",
+    "refresh omitted access token",
+  );
+  console.log("ok OAuth refresh-token rotation");
+  return refreshed.access_token;
+}
+
+let rpcId = 0;
+async function rpc(accessToken, path, method, params) {
+  rpcId += 1;
+  const body = await json(
+    await fetch(new URL(path, origin), {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: rpcId, method, params }),
+    }),
+    `${path} ${method}`,
+  );
+  if (body.error)
+    throw new Error(`${path} ${method}: ${JSON.stringify(body.error)}`);
+  return body.result;
+}
+
+function toolJson(result) {
+  const item = result?.content?.find((entry) => entry.type === "text");
+  assert(typeof item?.text === "string", "tool response omitted text content");
+  const parsed = JSON.parse(item.text);
+  if (result.isError) throw new Error(`tool returned error: ${item.text}`);
+  return parsed;
+}
+
+async function testMcp(accessToken) {
+  const initialized = await rpc(accessToken, "/api/mcp", "initialize", {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "aomi-local-e2e", version: "1" },
+  });
+  assert(initialized.protocolVersion === "2025-06-18", "protocol mismatch");
+  assert(
+    initialized.instructions.includes("aomi_check"),
+    "chat instructions missing",
+  );
+  console.log("ok MCP initialize and chat supervision instructions");
+
+  const chatTools = await rpc(accessToken, "/api/mcp", "tools/list", {});
+  assert(
+    chatTools.tools.length === 4,
+    `expected 4 chat tools, got ${chatTools.tools.length}`,
+  );
+  assert(
+    chatTools.tools.map((tool) => tool.name).join(",") ===
+      "aomi_chat,aomi_check,aomi_interrupt,aomi_list_sessions",
+    "chat tool names did not match the plan",
+  );
+  const directTools = await rpc(
+    accessToken,
+    "/api/mcp/direct",
+    "tools/list",
+    {},
+  );
+  assert(
+    directTools.tools.length === 10,
+    `expected 10 direct tools, got ${directTools.tools.length}`,
+  );
+  console.log("ok primary 4-tool surface and preserved 10-tool direct surface");
+
+  const started = toolJson(
+    await rpc(accessToken, "/api/mcp", "tools/call", {
+      name: "aomi_chat",
+      arguments: {
+        message: "Reply with exactly: MCP chat parity works",
+        app: "default",
+      },
+    }),
+  );
+  assert(
+    typeof started.session_id === "string",
+    "aomi_chat omitted session id",
+  );
+  assert(started.cursor, "aomi_chat omitted cursor");
+  console.log(`ok aomi_chat created account session ${started.session_id}`);
+
+  let current = started;
+  const deliveredMessages = [...(started.new_messages ?? [])];
+  for (
+    let attempt = 0;
+    attempt < 45 && current.status === "processing";
+    attempt += 1
+  ) {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    current = toolJson(
+      await rpc(accessToken, "/api/mcp", "tools/call", {
+        name: "aomi_check",
+        arguments: { session_id: started.session_id, cursor: current.cursor },
+      }),
+    );
+    deliveredMessages.push(...current.new_messages);
+    console.log(
+      `ok aomi_check ${attempt + 1}: status=${current.status} messages=${current.new_messages.length} activity=${current.activity.length}`,
+    );
+  }
+  assert(
+    current.status !== "processing",
+    "agent turn did not reach a terminal state",
+  );
+  assert(
+    current.status === "complete",
+    `unexpected terminal state ${current.status}`,
+  );
+  assert(
+    deliveredMessages.some(
+      (message) =>
+        ["agent", "assistant"].includes(message?.sender) &&
+        typeof message?.content === "string" &&
+        message.content.includes("MCP chat parity works"),
+    ),
+    "completed turn did not deliver the assistant reply through cursor deltas",
+  );
+  console.log("ok asynchronous chat reached complete through cursor deltas");
+
+  const sessions = toolJson(
+    await rpc(accessToken, "/api/mcp", "tools/call", {
+      name: "aomi_list_sessions",
+      arguments: { limit: 10 },
+    }),
+  );
+  assert(
+    sessions.sessions.some((session) => session.id === started.session_id),
+    "new MCP session missing from account thread list",
+  );
+  console.log("ok aomi_list_sessions includes the new account-owned session");
+
+  const resumed = toolJson(
+    await rpc(accessToken, "/api/mcp", "tools/call", {
+      name: "aomi_chat",
+      arguments: {
+        message: "Reply with exactly: resumed",
+        session_id: started.session_id,
+        app: "default",
+      },
+    }),
+  );
+  assert(
+    resumed.session_id === started.session_id,
+    "resume changed session id",
+  );
+  const interrupted = toolJson(
+    await rpc(accessToken, "/api/mcp", "tools/call", {
+      name: "aomi_interrupt",
+      arguments: { session_id: started.session_id },
+    }),
+  );
+  assert(
+    interrupted.interrupted === true,
+    "interrupt result missing confirmation",
+  );
+  console.log("ok existing-session resume and aomi_interrupt");
+  if (walletPrompt) await testPendingWalletRequest(accessToken);
+  console.log(`MCP_E2E_SESSION=${started.session_id}`);
+}
+
+async function fundLocalWallet(address) {
+  const endpoint = new URL(localAnvilUrl);
+  assert(
+    ["127.0.0.1", "localhost"].includes(endpoint.hostname),
+    "AOMI_MCP_E2E_ANVIL_URL must target a local Anvil",
+  );
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "anvil_setBalance",
+      params: [address, "0x56BC75E2D63100000"],
+    }),
+  });
+  const body = await json(response, "local wallet funding");
+  assert(!body.error, "Anvil did not fund the E2E wallet");
+  console.log("ok local E2E wallet funded");
+}
+
+async function testPendingWalletRequest(accessToken) {
+  let state = toolJson(
+    await rpc(accessToken, "/api/mcp", "tools/call", {
+      name: "aomi_chat",
+      arguments: { message: walletPrompt, app: "default" },
+    }),
+  );
+  for (
+    let attempt = 0;
+    attempt < 60 && state.status === "processing";
+    attempt += 1
+  ) {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    state = toolJson(
+      await rpc(accessToken, "/api/mcp", "tools/call", {
+        name: "aomi_check",
+        arguments: { session_id: state.session_id, cursor: state.cursor },
+      }),
+    );
+    console.log(
+      `ok wallet aomi_check ${attempt + 1}: status=${state.status} pending=${state.pending_requests.length}`,
+    );
+  }
+  assert(
+    state.status === "awaiting_user",
+    `wallet turn ended as ${state.status}`,
+  );
+  assert(
+    state.pending_requests.length > 0,
+    "wallet turn omitted the pending request",
+  );
+  const exposed = JSON.stringify(state.pending_requests);
+  assert(!exposed.includes("calldata"), "pending request exposed calldata");
+  assert(!exposed.includes("typedData"), "pending request exposed typed data");
+  assert(state.handoff?.portal_url, "pending request omitted portal handoff");
+  console.log(
+    "ok real staged transaction surfaced as a redacted wallet handoff",
+  );
+}
+
+const jar = new CookieJar();
+const signedIn = await signIn(jar);
+if (localAnvilUrl) await fundLocalWallet(signedIn.address);
+const accessToken = await oauth(jar);
+if (browserCookieFile) {
+  await writeFile(browserCookieFile, `${jar.header()}\n`, { mode: 0o600 });
+  console.log("ok browser cookie handoff written to protected temporary file");
+}
+await testMcp(accessToken);

--- a/specs/MCP-CHAT-PARITY-PLAN.md
+++ b/specs/MCP-CHAT-PARITY-PLAN.md
@@ -1,0 +1,185 @@
+# MCP Chat Parity — Plan
+
+> **Implementation status (2026-08-12): complete and locally verified.** Phases
+> 1–5 are implemented in the Portal MCP route/server modules. The primary route
+> exposes the four chat tools, the direct funnel is preserved at
+> `/api/mcp/direct`, manual wallet requests have a redacted portal handoff, and
+> the shared origin-scoped OAuth metadata covers both endpoints. The local E2E
+> smoke proves SIWE, OAuth registration/PKCE/consent/refresh, chat/check/list/
+> resume/interrupt, a real staged manual-wallet transaction, and the browser
+> handoff into the owning transcript.
+
+> Goal: the MCP server exposes the **agent path** — the upper agent (Claude,
+> ChatGPT, …) chats with the Aomi agent the same way the TS CLI does — instead
+> of bare tool calls. The current tool-funnel MCP moves to an alternative
+> route and becomes the seed of the future "direct tools" path (out of scope
+> here beyond the move).
+>
+> Decisions locked with Attila (2026-08-12):
+>
+> 1. **Async turn model** — `aomi_chat` fires the turn and returns; the upper
+>    agent follows progress with `aomi_check` (rich deltas, not a bare
+>    "not done" flag) and can `aomi_interrupt`. Subagent-style ergonomics.
+> 2. **Signing** — investigated remote signing (see §4): server-side signing
+>    via the `sign` crate (Privy delegated / Para agent wallets) is live and
+>    proven; onboarding (connect + arm) is interactive. MCP surfaces pending
+>    wallet requests + handoff; no signature-submission tool in v1.
+> 3. **Routes** — chat MCP takes over `/api/mcp`; funnel moves to
+>    `/api/mcp/direct`.
+> 4. **Threads** — `aomi_chat` takes an optional `session_id`; omitted means
+>    a new session is created and returned. `aomi_list_sessions` queries
+>    existing threads. No separate create-thread tool.
+
+## 1. Where things stand
+
+**TS CLI chat path** (`packages/client/src/cli`, `src/session`):
+`CliSession` → `ClientSession` → `AomiClient` → backend
+`POST /api/thread/chat` (fire) → poll `GET /api/thread/state` until
+`is_processing` clears → wallet requests arrive via user_state/system events →
+`aomi tx sign` posts the signature back with `POST /api/system`.
+
+**Current MCP** (`apps/portal/src/app/api/mcp/route.ts` +
+`src/server/mcp/{tools,backend,session,thread}.ts`): stateless streamable-HTTP,
+one JSON-RPC message per POST, `withMcpAuth(auth, …)` (better-auth OAuth),
+`resolveMcpCanonicalUser` → `mintAccountBearer` per backend call, deterministic
+`mcp-<uuidv5>` thread, 10-tool discovery funnel hitting `/api/resource/*` and
+`/api/exec/*`.
+
+**Auth is unchanged by this plan.** OAuth handshake, canonical-user
+resolution, and AccountBearer minting stay exactly as the MCP does today.
+CLI-style SIWE/SIWS is not part of the MCP path.
+
+## 2. Target tool surface (4 tools)
+
+All tools are backed by the same backend endpoints the CLI uses, called
+server-side from the portal BFF with a minted AccountBearer and the session id
+as the thread id (same Cloudflare-worker rendezvous routing as portal chat).
+
+### `aomi_chat`
+
+- args: `message` (required), `session_id` (optional), `app` (optional).
+- `session_id` omitted → generate a fresh `mcp-<uuid>` id, ensure the
+  account-bound thread exists (CLI's `ensureAccountBoundThread` equivalent),
+  and return it. Provided → continue that thread (any account-owned thread id
+  from `aomi_list_sessions` works, including past MCP sessions).
+- Behavior: `POST /api/thread/chat`, return immediately with
+  `{ session_id, status: "processing", cursor }` (plus the final reply inline
+  when the backend happened to answer synchronously). The tool description
+  tells the model to follow up with `aomi_check`.
+
+### `aomi_check`
+
+- args: `session_id` (required), `cursor` (optional, from the previous
+  chat/check result — the server is stateless, so the cursor round-trips
+  through the caller; message-count + system-event offset).
+- Behavior: `GET /api/thread/state`; returns a **delta**, not the transcript:
+  `{ status, new_messages, activity, pending_requests, title, cursor }`.
+  - `activity`: compressed tool/task narration, same events the CLI's verbose
+    mode prints (`tool_complete`, `task_started`/`task_activity`/
+    `task_completed`) — this is what makes the check loop feel like
+    supervising a subagent rather than polling a flag.
+  - `status`: `"processing"` | `"complete"` | `"awaiting_user"` (pending
+    wallet request present).
+
+### `aomi_interrupt`
+
+- args: `session_id`. `POST /api/thread/interrupt`. Parity with CLI Ctrl-C /
+  `session.interrupt()`.
+
+### `aomi_list_sessions`
+
+- args: `limit?`. `GET /api/threads` (account-bound), returns
+  `{ id, title, updated_at }` rows so the agent can resume past conversations.
+
+App/model selection are parameters/instructions, not tools — keeps the surface
+at 4. (BYOK `/key`, secrets, deploy etc. stay CLI-only for now.)
+
+Server `instructions` (initialize result) describe the loop: chat → check
+until `complete`/`awaiting_user` → relay pending requests to the human.
+
+## 3. Route + file moves
+
+| What                      | From                                         | To                                                                                                                                                                                                                     |
+| ------------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Funnel tools + dispatcher | `src/server/mcp/tools.ts` (+`tools.test.ts`) | unchanged file, re-exported by new route                                                                                                                                                                               |
+| Funnel endpoint           | `POST /api/mcp`                              | **new** `src/app/api/mcp/direct/route.ts` (same `withMcpAuth` wrapper, same JSON-RPC shell)                                                                                                                            |
+| Chat endpoint             | —                                            | `src/app/api/mcp/route.ts` swaps `MCP_TOOLS`/`dispatchTool` for the chat set                                                                                                                                           |
+| Chat tool defs + dispatch | —                                            | **new** `src/server/mcp/chat-tools.ts`                                                                                                                                                                                 |
+| Thread-kernel calls       | —                                            | **new** `src/server/mcp/chat-backend.ts`: `sendChat`, `fetchState`, `interrupt`, `listThreads`, `ensureThread` — mirrors `backend.ts`'s mint-bearer pattern but against `/api/thread/*`, `/api/system`, `/api/threads` |
+| JSON-RPC shell            | inline in `route.ts`                         | extract to `src/server/mcp/rpc.ts` so both routes share initialize/ping/tools-list/error plumbing                                                                                                                      |
+
+The shared JSON-RPC shell keeps the two endpoints byte-compatible in
+transport behavior (stateless, one message per POST, 202 for notifications,
+405 GET/DELETE).
+
+## 4. Signing over MCP (research findings, 2026-08-12)
+
+Server-side ("remote") signing in `product-mono/aomi/crates/sign` is **done
+and live-proven**, not a stub:
+
+- Privy delegated EVM wallets at `signing_mode = auto`: stage → commit signs
+  server-side and broadcasts (plain EOA and AA lanes). Proven on MegaETH
+  mainnet (`memory/2026-08-04.md`). SVM auto works via venue/BroadcastEngine.
+- Crons already run fully headless turns through the same gate — `auto` keys
+  complete unattended; `manual` keys halt at `PendingApproval` by design.
+- Para REST signing is code-complete but **off unless `PARA_SECRET_API_KEY`
+  is deployed** (per 2026-07-31 handoff, likely unset).
+- The one-time onboarding is inherently interactive: browser connect
+  (`ask_authorization` returns a URL a human must open) + a permit signature
+  by the wallet itself to arm `auto`.
+
+Consequences for the MCP chat path:
+
+1. **No signing tools needed in v1.** For an armed (`auto`) wallet the turn
+   completes end-to-end and `aomi_check` just reports `complete` with tx
+   hashes. Onboarding happens _in the conversation_: the Aomi agent's own
+   `ask_authorization` tool returns the connect URL, which the upper agent
+   relays to the human — MCP is a pure text conduit for that.
+2. **`manual` wallets stall at `awaiting_user`.** `aomi_check` returns the
+   pending request payload (to/value/chain or EIP-712 summary, same fields the
+   CLI prints) plus handoff guidance: sign in the portal, or
+   `aomi tx sign <id>` from a CLI logged into the same account.
+3. **v2 (explicitly deferred):** an `aomi_resolve_request` tool that accepts a
+   signed tx / signature and posts the wallet system event — the `client_auto`
+   role `aomi tx sign` plays — for callers that hold keys locally (e.g. Claude
+   Code with a wallet skill).
+
+## 5. Backend integration points to verify during implementation
+
+- **user_state hydration for headless chat threads.** The exec path seeds the
+  account's primary EVM key server-side
+  (`bin/backend/src/endpoint/thread/exec_env.rs:133-162`); confirm
+  `/api/thread/chat` threads created by the MCP get equivalent hydration (or
+  have `chat-backend.ts` build a minimal `user_state` from the account graph's
+  `public_keys`, like the portal's `DelegatedWalletHydrator`).
+- **Session header name + worker routing.** The client uses a session header
+  on `/api/thread/*` while `backend.ts` sets `x-thread-id` on `/api/exec/*`;
+  confirm the Cloudflare worker hashes both to the same replica choice.
+- **Account-bound thread creation.** Mirror the CLI's
+  `client.createThread(sessionId)` before first chat on a new session.
+- **OAuth protected-resource metadata for `/api/mcp/direct`.** Existing
+  clients of `/api/mcp` get the chat surface automatically; check whether the
+  direct route needs its own `.well-known/oauth-protected-resource/...`
+  document or can share the current one.
+- **Old deterministic thread.** The funnel's per-user `mcpThreadId(user)`
+  default stays reachable via `aomi_list_sessions` → `session_id`; nothing
+  migrates.
+
+## 6. Phases
+
+1. **Move the funnel** — add `/api/mcp/direct/route.ts`, extract `rpc.ts`,
+   keep `tools.ts`/`backend.ts` untouched; port `tools.test.ts` route-level
+   assertions.
+2. **Chat backend helpers** — `chat-backend.ts` (+ tests mirroring
+   `backend.test.ts`).
+3. **Chat tools** — `chat-tools.ts` defs + dispatch + cursor/delta logic
+   (+ tests: new-session creation, cursor deltas, status mapping, activity
+   compression); swap into `/api/mcp`; new `instructions` string.
+4. **Wallet-request surfacing** — payload shaping for `awaiting_user`
+   (reuse the CLI's pending-tx field selection), portal handoff link; verify
+   the §5 hydration item end-to-end against a real staged tx.
+5. **Docs + state** — update `specs/mcp-design.md` pointer, `specs/STATE.md`,
+   and the MCP connect page copy if it mentions the funnel workflow.
+
+Out of scope: the non-chat "direct tools" path beyond the move, CLI changes,
+SSE push transport, `aomi_resolve_request` (v2).

--- a/specs/MCP-CHAT-PARITY-PLAN.md
+++ b/specs/MCP-CHAT-PARITY-PLAN.md
@@ -60,7 +60,12 @@ as the thread id (same Cloudflare-worker rendezvous routing as portal chat).
 
 ### `aomi_chat`
 
-- args: `message` (required), `session_id` (optional), `app` (optional).
+- args: `message` (required), `session_id` (optional), `app` (optional), and
+  `chain_context` (optional). Chain context is an explicit union of
+  `{ family: "evm", chain_id }` or `{ family: "solana", cluster }`, where the
+  cluster is `solana:mainnet`, `solana:devnet`, or `solana:testnet`. Omission
+  means the headless session may expose the account's wallet addresses but does
+  not fabricate an active chain.
 - `session_id` omitted → generate a fresh `mcp-<uuid>` id, ensure the
   account-bound thread exists (CLI's `ensureAccountBoundThread` equivalent),
   and return it. Provided → continue that thread (any account-owned thread id

--- a/specs/MCP-CHAT-PARITY-PLAN.md
+++ b/specs/MCP-CHAT-PARITY-PLAN.md
@@ -1,13 +1,16 @@
 # MCP Chat Parity — Plan
 
-> **Implementation status (2026-08-12): complete and locally verified.** Phases
+> **Implementation status (2026-08-13): complete and live-chain verified.** Phases
 > 1–5 are implemented in the Portal MCP route/server modules. The primary route
 > exposes the four chat tools, the direct funnel is preserved at
 > `/api/mcp/direct`, manual wallet requests have a redacted portal handoff, and
 > the shared origin-scoped OAuth metadata covers both endpoints. The local E2E
 > smoke proves SIWE, OAuth registration/PKCE/consent/refresh, chat/check/list/
 > resume/interrupt, a real staged manual-wallet transaction, and the browser
-> handoff into the owning transcript.
+> handoff into the owning transcript. A fresh Codex process completed OAuth and
+> used the four-tool surface; the funded SIWE wallet then imported the MCP
+> thread into the CLI, signed its pending Base transaction, and returned both
+> confirmed transaction hashes through `aomi_check`.
 
 > Goal: the MCP server exposes the **agent path** — the upper agent (Claude,
 > ChatGPT, …) chats with the Aomi agent the same way the TS CLI does — instead
@@ -65,13 +68,16 @@ as the thread id (same Cloudflare-worker rendezvous routing as portal chat).
 - Behavior: `POST /api/thread/chat`, return immediately with
   `{ session_id, status: "processing", cursor }` (plus the final reply inline
   when the backend happened to answer synchronously). The tool description
-  tells the model to follow up with `aomi_check`.
+  tells the model to follow up with `aomi_check`. The cursor includes its
+  `session_id`, so an MCP client can pass it unchanged without reconstructing
+  arguments from sibling result fields.
 
 ### `aomi_check`
 
-- args: `session_id` (required), `cursor` (optional, from the previous
-  chat/check result — the server is stateless, so the cursor round-trips
-  through the caller; message-count + system-event offset).
+- args: `cursor` (optional, from the previous chat/check result — the server is
+  stateless, so the cursor round-trips through the caller; session id +
+  message-count + system-event offset). A top-level `session_id` remains
+  accepted for compatibility with older/count-only cursors.
 - Behavior: `GET /api/thread/state`; returns a **delta**, not the transcript:
   `{ status, new_messages, activity, pending_requests, title, cursor }`.
   - `activity`: compressed tool/task narration, same events the CLI's verbose
@@ -138,7 +144,8 @@ Consequences for the MCP chat path:
 2. **`manual` wallets stall at `awaiting_user`.** `aomi_check` returns the
    pending request payload (to/value/chain or EIP-712 summary, same fields the
    CLI prints) plus handoff guidance: sign in the portal, or
-   `aomi tx sign <id>` from a CLI logged into the same account.
+   `aomi tx sign <id>` from a CLI logged into the same account after
+   `aomi session resume <session_id>` imports the account-owned MCP thread.
 3. **v2 (explicitly deferred):** an `aomi_resolve_request` tool that accepts a
    signed tx / signature and posts the wallet system event — the `client_auto`
    role `aomi tx sign` plays — for callers that hold keys locally (e.g. Claude
@@ -181,5 +188,6 @@ Consequences for the MCP chat path:
 5. **Docs + state** — update `specs/mcp-design.md` pointer, `specs/STATE.md`,
    and the MCP connect page copy if it mentions the funnel workflow.
 
-Out of scope: the non-chat "direct tools" path beyond the move, CLI changes,
-SSE push transport, `aomi_resolve_request` (v2).
+Out of scope: the non-chat "direct tools" path beyond the move, general CLI
+changes beyond remote MCP-thread import, SSE push transport,
+`aomi_resolve_request` (v2).

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,24 @@
 
 ## Last Updated
 
+2026-08-12 — MCP CHAT PARITY IMPLEMENTED. `/api/mcp` now exposes only
+  `aomi_chat`, `aomi_check`, `aomi_interrupt`, and `aomi_list_sessions` over a
+  shared stateless JSON-RPC shell; the unchanged direct discovery/execution
+  funnel moved to `/api/mcp/direct`. Agent turns use the canonical
+  `/api/threads` + `/api/thread/{chat,state,interrupt}` kernel paths with both
+  thread headers and BFF-minted AccountBearer. New sessions are account-bound,
+  headless turns hydrate primary EVM/SVM wallets from `public_keys`, message
+  cursors return transcript deltas without dropping the backend's drained
+  system events, and checks compress tool/task activity. Manual wallet requests
+  return `awaiting_user`, redacted request summaries, and a working portal
+  deep-link; armed auto-signing wallets need no MCP signing tool. The existing
+  origin-scoped OAuth protected-resource metadata covers both MCP routes.
+  Local E2E verification covers SIWE, dynamic OAuth registration, explicit
+  consent, PKCE exchange and refresh, both MCP tool inventories, real async
+  reply deltas, account session list/resume/interrupt, a funded local-chain
+  transaction reaching the manual-wallet approval gate, and `agent-browser`
+  opening the exact linked transcript. The message cursor deliberately holds
+  the runtime's mutable streaming tail until it becomes a completed delta.
 2026-08-08 — DEPLOY-SURFACE BUGS, BE SIDE (product-mono worktree
   `~/Code/product-mono-worktrees/deploy-feed-platform-scope`, branch
   `claude/deploy-feed-platform-scope` off origin/main f5d421933; all changes

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -8,9 +8,12 @@
   funnel moved to `/api/mcp/direct`. Agent turns use the canonical
   `/api/threads` + `/api/thread/{chat,state,interrupt}` kernel paths with both
   thread headers and BFF-minted AccountBearer. New sessions are account-bound,
-  headless turns hydrate primary EVM/SVM wallets from `public_keys`, message
-  cursors return transcript deltas without dropping the backend's drained
-  system events, and checks compress tool/task activity. Manual wallet requests
+  headless turns hydrate primary EVM/SVM wallet addresses from `public_keys`
+  without fabricating active mainnet networks. `aomi_chat` accepts an optional
+  authoritative EVM chain id or canonical supported Solana cluster; omission
+  leaves both network fields absent. Message cursors return transcript deltas
+  without dropping the backend's drained system events, and checks compress
+  tool/task activity. Manual wallet requests
   return `awaiting_user`, redacted request summaries, and a working portal
   deep-link; armed auto-signing wallets need no MCP signing tool. The existing
   origin-scoped OAuth protected-resource metadata covers both MCP routes.

--- a/specs/mcp-design.md
+++ b/specs/mcp-design.md
@@ -1,11 +1,12 @@
 # Aomi MCP — Design
 
-> Historical design note. The old MCP approval-auth surface described here has
-> been deprecated and removed from `@aomi-labs/auth`. The live portal MCP route
-> is `apps/portal/src/app/api/mcp/[transport]/route.ts` and currently exposes
-> chat / pending transaction tools; widget account auth is the separate
-> BetterAuth session -> BFF AccountBearer path documented in
-> `specs/WIDGET-AUTH-PLAN.md` and `specs/AUTH-STACK-REVIEW.md`.
+> Historical design note. The current implementation contract is
+> [`MCP-CHAT-PARITY-PLAN.md`](./MCP-CHAT-PARITY-PLAN.md): OAuth-protected
+> `/api/mcp` exposes the four-tool asynchronous Aomi agent path, while the
+> former discovery/execution funnel remains available at `/api/mcp/direct`.
+> Both endpoints use the same origin-scoped OAuth protected-resource metadata,
+> BetterAuth canonical-user resolution, and BFF-minted AccountBearer. The
+> approval-auth and `[transport]` route design below is retired context.
 
 A single design document for shipping Aomi as a Claude/Codex plugin via MCP,
 and for hosting the shared credential authority that both MCP and the Rust BE


### PR DESCRIPTION
## What changed

- Replaced the primary OAuth MCP direct-tool funnel with four asynchronous agent/session tools: `aomi_chat`, `aomi_check`, `aomi_interrupt`, and `aomi_list_sessions`.
- Preserved the ten direct resource/exec tools at `/api/mcp/direct` behind the same OAuth resource metadata.
- Added account-owned thread creation, rich cursor deltas, task/tool activity, redacted wallet-request handoff, and self-contained polling cursors.
- Added authenticated CLI import of account-owned MCP sessions so a manual request can be signed with `aomi session resume <session_id>` followed by `aomi tx sign <request-id>`.
- Removed fabricated Ethereum mainnet and Solana mainnet state from headless wallet hydration. `aomi_chat` now accepts optional authoritative `chain_context`: `{ family: "evm", chain_id }` or `{ family: "solana", cluster }` with canonical mainnet/devnet/testnet cluster validation. Omitting it preserves wallet identity without claiming an active network.
- Updated the MCP smoke so every EVM chat turn supplies its configured chain id, including Base 8453 in the funded signing run.
- Patch-bumped `@aomi-labs/client` from the current mainline version to 0.4.6.

## Why

The existing MCP exposed bare backend tools rather than the same asynchronous Aomi agent path used by the TypeScript CLI. Manual wallet requests also had no working MCP-to-CLI continuation because CLI resume only searched local state.

A fresh Codex test additionally showed that requiring a separate top-level `session_id` caused repeated invalid polls. The returned cursor now carries its owning session and can be passed unchanged.

Headless wallet hydration also hardcoded `chain_id: 1` and `solana:mainnet`, so a Base transaction could be signed while the session falsely claimed Ethereum mainnet. Network context is now explicit and optional instead of guessed.

## Branch scope

This branch was created from aomi `origin/main` at `2427bfe8` and contains three frontend MCP commits. It does not include the previously merged orchestrator branch.

## Validation

- 62 focused MCP and CLI session tests pass from the root Vitest configuration.
- Targeted and Portal-wide ESLint, focused Prettier, `git diff --check`, and a mock-safe Portal production build pass.
- Regression coverage proves no implicit EVM/Solana mainnet defaults, explicit Base 8453 preservation, supported Solana cluster preservation, and rejection of unsupported Solana clusters.
- Portal typecheck remains blocked by the pre-existing duplicate Para SDK/Wagmi connector types (`@getpara/web-sdk` 2.24 vs 2.19). The Portal-local Vitest config also retains its pre-existing Vite CommonJS/ESM startup mismatch; the same MCP suites pass through the root config.
- The local backend/Portal stack was not running for this follow-up, so the updated smoke was not rerun. The prior raw local E2E passed SIWE, dynamic OAuth registration, PKCE/consent, token exchange, refresh rotation, primary MCP tools, and all ten direct tools.
- A prior fresh Codex process connected through OAuth and completed the self-contained chat/check loop; `agent-browser` opened the exact authenticated MCP-created thread.
- A prior real 1-wei Base self-transfer was staged through MCP, signed only through the CLI, and confirmed with its service-fee transaction; the post-sign MCP check returned no pending requests.

## Related

- Backend MCP-discovered skill-scope fix: https://github.com/aomi-labs/product-mono/pull/972
- Supersedes stale-ancestry frontend draft #490.