### PR TITLE
Auto-switch wallet chain for staged transactions

### DIFF
--- a/apps/shadcn-registry/src/components/runtime-tx-handler.test.tsx
+++ b/apps/shadcn-registry/src/components/runtime-tx-handler.test.tsx
@@ -30,6 +30,10 @@ const authState = vi.hoisted(() => ({
     cluster: "solana:devnet",
   },
   supportedNetworks: {
+    evm: [
+      { id: 8453, name: "Base" },
+      { id: 42161, name: "Arbitrum One" },
+    ],
     solana: [
       { id: "solana-devnet", cluster: "solana:devnet" },
       { id: "solana-mainnet", cluster: "solana:mainnet" },
@@ -45,6 +49,8 @@ const authState = vi.hoisted(() => ({
     | undefined,
   signMessage: vi.fn(),
   signAaRequests: vi.fn(),
+  sendTransaction: vi.fn(),
+  switchChain: vi.fn() as ((chainId: number) => Promise<void>) | undefined,
   supportedChains: [{ id: 4326, name: "MegaETH" }],
 }));
 
@@ -56,7 +62,10 @@ vi.mock("@aomi-labs/react", () => ({
   },
   appendFeeCallToPayload: vi.fn(),
   hydrateTxPayloadFromUserState: vi.fn((payload) => payload),
-  parseChainId: vi.fn(),
+  parseChainId: vi.fn((value: unknown) => {
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+  }),
   toViemSignTypedDataArgs: vi.fn(),
   toViemSignMessageArgs: vi.fn((payload: Record<string, unknown>) =>
     typeof payload.non_typed_data === "string"
@@ -87,6 +96,13 @@ describe("RuntimeTxHandler", () => {
     authState.signTypedData = undefined;
     authState.signMessage.mockReset();
     authState.signAaRequests.mockReset();
+    authState.sendTransaction.mockReset();
+    authState.switchChain = vi.fn(async () => undefined);
+    authState.identity.chainId = 8453;
+    authState.supportedNetworks.evm = [
+      { id: 8453, name: "Base" },
+      { id: 42161, name: "Arbitrum One" },
+    ];
     authState.selectedSolanaNetwork = {
       id: "solana-devnet",
       cluster: "solana:devnet",
@@ -96,6 +112,111 @@ describe("RuntimeTxHandler", () => {
 
   afterEach(() => {
     cleanup();
+  });
+
+  function stageTransaction(chainId: number) {
+    runtimeState.simulateBatchTransactions.mockResolvedValue({ fee: null });
+    authState.sendTransaction.mockResolvedValue({ txHash: "0xabc" });
+    runtimeState.pendingWalletRequests = [
+      {
+        id: `transaction-${chainId}`,
+        kind: "transaction",
+        payload: {
+          calls: [
+            {
+              txId: 1,
+              to: "0x1111111111111111111111111111111111111111",
+              value: "0",
+              data: "0x",
+              chainId,
+            },
+          ],
+        },
+        timestamp: Date.now(),
+      },
+    ];
+  }
+
+  it("switches to the staged transaction chain before simulation and send", async () => {
+    stageTransaction(42161);
+
+    render(<RuntimeTxHandler />);
+
+    await waitFor(() => {
+      expect(authState.sendTransaction).toHaveBeenCalledTimes(1);
+    });
+    expect(authState.switchChain).toHaveBeenCalledWith(42161);
+    expect(runtimeState.simulateBatchTransactions).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ chainId: 42161 }),
+    );
+    expect(
+      (authState.switchChain as ReturnType<typeof vi.fn>).mock
+        .invocationCallOrder[0],
+    ).toBeLessThan(
+      runtimeState.simulateBatchTransactions.mock.invocationCallOrder[0],
+    );
+    expect(
+      runtimeState.simulateBatchTransactions.mock.invocationCallOrder[0],
+    ).toBeLessThan(authState.sendTransaction.mock.invocationCallOrder[0]);
+  });
+
+  it("does not switch when the staged transaction is already on the wallet chain", async () => {
+    stageTransaction(8453);
+
+    render(<RuntimeTxHandler />);
+
+    await waitFor(() => {
+      expect(authState.sendTransaction).toHaveBeenCalledTimes(1);
+    });
+    expect(authState.switchChain).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unsupported staged transaction chain before simulation or send", async () => {
+    stageTransaction(10);
+
+    render(<RuntimeTxHandler />);
+
+    await waitFor(() => {
+      expect(runtimeState.rejectWalletRequest).toHaveBeenCalledWith(
+        "transaction-10",
+        expect.stringContaining("does not support chain 10"),
+      );
+    });
+    expect(runtimeState.simulateBatchTransactions).not.toHaveBeenCalled();
+    expect(authState.sendTransaction).not.toHaveBeenCalled();
+  });
+
+  it("rejects with manual guidance when the adapter cannot switch chains", async () => {
+    stageTransaction(42161);
+    authState.switchChain = undefined;
+
+    render(<RuntimeTxHandler />);
+
+    await waitFor(() => {
+      expect(runtimeState.rejectWalletRequest).toHaveBeenCalledWith(
+        "transaction-42161",
+        expect.stringContaining("Switch networks manually"),
+      );
+    });
+    expect(authState.sendTransaction).not.toHaveBeenCalled();
+  });
+
+  it("routes a rejected wallet switch through the existing request rejection", async () => {
+    stageTransaction(42161);
+    authState.switchChain = vi.fn(async () => {
+      throw new Error("User rejected the request");
+    });
+
+    render(<RuntimeTxHandler />);
+
+    await waitFor(() => {
+      expect(runtimeState.rejectWalletRequest).toHaveBeenCalledWith(
+        "transaction-42161",
+        "User rejected the request",
+      );
+    });
+    expect(authState.sendTransaction).not.toHaveBeenCalled();
   });
 
   it("dispatches solana_sign requests through signSolanaTransaction", async () => {

--- a/apps/shadcn-registry/src/components/runtime-tx-handler.tsx
+++ b/apps/shadcn-registry/src/components/runtime-tx-handler.tsx
@@ -141,6 +141,25 @@ export function RuntimeTxHandler() {
       }
     }
 
+    async function maybeSwitchEvmChain(targetChainId: number): Promise<void> {
+      if (!targetChainId || targetChainId === currentChainId) return;
+
+      const supported = adapter.supportedNetworks?.evm?.some(
+        (network) => parseChainId(network.id) === targetChainId,
+      );
+      if (supported === false) {
+        throw new Error(
+          `This wallet does not support chain ${targetChainId}. Reconnect with a wallet that does.`,
+        );
+      }
+      if (!adapter.switchChain) {
+        throw new Error(
+          `Cannot switch the wallet to chain ${targetChainId}. Switch networks manually and retry.`,
+        );
+      }
+      await adapter.switchChain(targetChainId);
+    }
+
     async function processRequest(req: WalletRequest) {
       try {
         if (req.kind === "transaction") {
@@ -161,6 +180,7 @@ export function RuntimeTxHandler() {
             payload.calls?.[0]?.chainId ??
             currentChainId ??
             1;
+          await maybeSwitchEvmChain(defaultChainId);
           const simulationResult = await simulateBatchTransactions(
             toSimulationTransactions(payload),
             {

--- a/apps/shadcn-registry/src/lib/wallet-kit/execution/wallet-execution.test.ts
+++ b/apps/shadcn-registry/src/lib/wallet-kit/execution/wallet-execution.test.ts
@@ -47,6 +47,44 @@ function singleCallPayload(): WalletTxPayload {
 }
 
 describe("executeWalletKitTransaction native execution", () => {
+  it("switches when the connected wallet chain is unknown", async () => {
+    const switchChainAsync = vi.fn(async () => undefined);
+    const sendTransactionAsync = vi.fn().mockResolvedValue("0x111");
+
+    await executeWalletKitTransaction({
+      payload: singleCallPayload(),
+      state: {
+        currentChainId: undefined,
+        sendCallsSyncAsync: vi.fn(),
+        sendTransactionAsync,
+        switchChainAsync,
+        chainsById: { [mainnet.id]: mainnet },
+      },
+    });
+
+    expect(switchChainAsync).toHaveBeenCalledWith({ chainId: 1 });
+    expect(switchChainAsync.mock.invocationCallOrder[0]).toBeLessThan(
+      sendTransactionAsync.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not switch when the connected wallet is already on the target chain", async () => {
+    const switchChainAsync = vi.fn(async () => undefined);
+
+    await executeWalletKitTransaction({
+      payload: singleCallPayload(),
+      state: {
+        currentChainId: 1,
+        sendCallsSyncAsync: vi.fn(),
+        sendTransactionAsync: vi.fn().mockResolvedValue("0x111"),
+        switchChainAsync,
+        chainsById: { [mainnet.id]: mainnet },
+      },
+    });
+
+    expect(switchChainAsync).not.toHaveBeenCalled();
+  });
+
   it("executes batches sequentially when the wallet has no atomic capability", async () => {
     const sendTransactionAsync = vi
       .fn()

--- a/apps/shadcn-registry/src/lib/wallet-kit/execution/wallet-execution.ts
+++ b/apps/shadcn-registry/src/lib/wallet-kit/execution/wallet-execution.ts
@@ -234,7 +234,7 @@ export async function executeWalletKitTransaction({
   try {
     execution = await executeWalletCalls({
       callList,
-      currentChainId: state.currentChainId ?? callList[0]?.chainId ?? 1,
+      currentChainId: state.currentChainId,
       capabilities: state.capabilities,
       localPrivateKey: null,
       nativeWalletExecution,

--- a/packages/client/dist/index.d.cts
+++ b/packages/client/dist/index.d.cts
@@ -1076,7 +1076,7 @@ interface NativeWalletExecutionPolicy {
 }
 interface ExecuteWalletCallsParams {
     callList: AAWalletCall[];
-    currentChainId: number;
+    currentChainId: number | undefined;
     capabilities: Record<string, WalletCapabilities> | undefined;
     localPrivateKey: `0x${string}` | null;
     nativeWalletExecution?: NativeWalletExecutionPolicy;

--- a/packages/client/dist/index.d.ts
+++ b/packages/client/dist/index.d.ts
@@ -1076,7 +1076,7 @@ interface NativeWalletExecutionPolicy {
 }
 interface ExecuteWalletCallsParams {
     callList: AAWalletCall[];
-    currentChainId: number;
+    currentChainId: number | undefined;
     capabilities: Record<string, WalletCapabilities> | undefined;
     localPrivateKey: `0x${string}` | null;
     nativeWalletExecution?: NativeWalletExecutionPolicy;

--- a/packages/client/src/aa/types.ts
+++ b/packages/client/src/aa/types.ts
@@ -112,7 +112,7 @@ export interface NativeWalletExecutionPolicy {
 
 export interface ExecuteWalletCallsParams {
   callList: AAWalletCall[];
-  currentChainId: number;
+  currentChainId: number | undefined;
   capabilities: Record<string, WalletCapabilities> | undefined;
   localPrivateKey: `0x${string}` | null;
   nativeWalletExecution?: NativeWalletExecutionPolicy;

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,18 @@
 
 ## Last Updated
 
+2026-08-12 — **Cross-chain wallet approvals now switch EVM networks automatically.**
+  `RuntimeTxHandler` compares every staged transaction's chain with the connected
+  wallet before simulation, rejects unsupported chains with actionable copy, and
+  invokes the adapter's network switch before simulating or sending. Wallets that
+  cannot switch get manual-switch guidance; a rejected wallet popup continues
+  through the existing request-rejection path. The shared AA executor now keeps an
+  unknown current chain as `undefined`, so it attempts a switch instead of masking
+  the state as already on the target chain. Added seven regression cases covering
+  switch ordering, same-chain behavior, unsupported/missing adapters, rejected
+  prompts, and unknown/current AA execution state. Joint backend work lives on
+  product-mono `feat/cross-chain-continuity` and must ship with this branch.
+
 2026-08-04 — PROJECT HOME "KEYS MISSING" FALSE ALARM (apps/build, committed
   on `feat/build-new-app-two-starts`). The Environment card warned whenever no
   key was set

--- a/specs/WALLET-AUTO-CHAIN-SWITCH-PLAN.md
+++ b/specs/WALLET-AUTO-CHAIN-SWITCH-PLAN.md
@@ -1,6 +1,6 @@
 # Wallet auto chain-switch at tx approval (W2)
 
-Status: planned, not started. Branch: `feat/wallet-auto-chain-switch`. This is the frontend workstream of the cross-chain continuity fix; the backend plan (child wallet context, bridge monitoring) lives at `product-mono/docs/plans/2026-08-12-cross-chain-orchestrator-continuity.md`. Bug 1 there is only fully fixed when both land — ship in the same release.
+Status: implemented; automated verification completed on 2026-08-12. Branch: `feat/wallet-auto-chain-switch`. This is the frontend workstream of the cross-chain continuity fix; the backend plan (child wallet context, bridge monitoring) lives at `product-mono/docs/plans/2026-08-12-cross-chain-orchestrator-continuity.md`. Bug 1 there is only fully fixed when both land — ship in the same release.
 
 ## Problem
 

--- a/specs/WALLET-AUTO-CHAIN-SWITCH-PLAN.md
+++ b/specs/WALLET-AUTO-CHAIN-SWITCH-PLAN.md
@@ -1,0 +1,78 @@
+# Wallet auto chain-switch at tx approval (W2)
+
+Status: planned, not started. Branch: `feat/wallet-auto-chain-switch`. This is the frontend workstream of the cross-chain continuity fix; the backend plan (child wallet context, bridge monitoring) lives at `product-mono/docs/plans/2026-08-12-cross-chain-orchestrator-continuity.md`. Bug 1 there is only fully fixed when both land — ship in the same release.
+
+## Problem
+
+When the agent stages a transaction on a chain other than the wallet's current chain (e.g. the Aave leg on Arbitrum after bridging from Base), the `transaction` approval branch sends it without switching the wallet's network, and the user is told to switch manually (or wagmi throws `ChainMismatchError`). The eip712 branch and the Solana path already auto-switch; plain EVM transactions are the one path that doesn't.
+
+## Changes
+
+### 1. `apps/shadcn-registry/src/components/runtime-tx-handler.tsx` — add `maybeSwitchEvmChain`
+
+Define next to `maybeSwitchSolanaCluster` (~line 96), mirroring it and the eip712 branch (~405-415):
+
+```ts
+async function maybeSwitchEvmChain(targetChainId: number): Promise<void> {
+  if (!targetChainId || targetChainId === currentChainId) return;
+  const supported = adapter.supportedNetworks?.evm?.some(
+    (n) => parseChainId(n.chainId) === targetChainId, // verify exact network entry shape
+  );
+  if (supported === false) {
+    throw new Error(
+      `This wallet does not support chain ${targetChainId}. Reconnect with a wallet that does.`,
+    );
+  }
+  if (!adapter.switchChain) {
+    throw new Error(
+      `Cannot switch the wallet to chain ${targetChainId}. Switch networks manually and retry.`,
+    );
+  }
+  await adapter.switchChain(targetChainId); // wallet popup — expected UX
+}
+```
+
+Call it in the `transaction` branch immediately after `defaultChainId` is computed (~line 159-163) and **before** `simulateBatchTransactions` (~line 164), so simulation, fee injection, and send all run against the switched chain, and the user gets one "switch network" wallet prompt before the sign prompt. A thrown error (including user-rejected switch) flows to the existing catch → `rejectWalletRequest(req.id, message)`; staged txs stay staged backend-side so the orchestrator can re-request.
+
+Optionally share the guard logic with the eip712 branch's existing switch (it currently switches without a supported-networks check); if not trivial, leave eip712 as-is for scope control.
+
+**Do not switch back afterwards.** The `wallet:state_changed` sync (`packages/react/src/runtime/user-state-provider.tsx:157-159`) updates backend user state to the new chain — which is the desired state for the next leg of a cross-chain flow.
+
+### 2. Fix latent skip-switch bug — `apps/shadcn-registry/src/lib/wallet-kit/execution/wallet-execution.ts:237`
+
+`currentChainId: state.currentChainId ?? callList[0]?.chainId ?? 1` masks "wallet chain unknown" (embedded/Para/Privy lanes, right after connect) as "already on target", so the switch in `packages/client/src/aa/execute.ts:136-145` is silently skipped and wagmi throws `ChainMismatchError`.
+
+- Change `executeWalletCalls`'s `currentChainId` param to `number | undefined`; switch when `currentChainId === undefined || currentChainId !== chainId`.
+- Pass `state.currentChainId` through unmodified in `wallet-execution.ts`.
+- Grep for other `executeWalletCalls` callers and update. Touches `packages/client` + `apps/shadcn-registry` — land as one PR.
+
+### 3. Deferred (follow-up, not this branch)
+
+`chain_id` hint on the `EvmTxApproval` wire payload. Hydration from user_state pending entries already supplies per-call `chainId` (`packages/client/src/wallet-utils.ts:371-449`) and the backend enforces single-chain batches, so `defaultChainId` is reliable today.
+
+## Test cases
+
+Vitest, mocked adapter with a `switchChain` spy (precedent for switch-mock tests: `apps/portal/src/lib/payment-fetch.test.ts` in the `aomi` repo history):
+
+| # | Given | Expect |
+|---|---|---|
+| 1 | tx target chain ≠ wallet current chain, chain supported | `switchChain(target)` called **before** `sendTransaction`; send uses target chain |
+| 2 | target === current | `switchChain` NOT called; send proceeds |
+| 3 | target chain not in `adapter.supportedNetworks.evm` | request rejected with readable message; `sendTransaction` never called |
+| 4 | adapter has no `switchChain` | request rejected with "switch manually" message; no send |
+| 5 | user rejects the switch popup (switchChain throws) | request rejected via existing catch; no send; staged tx untouched |
+| 6 | `executeWalletCalls` with `currentChainId: undefined` | switch IS attempted (regression for the :237 fallback bug) |
+| 7 | `executeWalletCalls` with `currentChainId` = target | no switch (unchanged) |
+
+## Risks / edge cases
+
+- WalletConnect wallets may reject `wallet_switchEthereumChain` for chains not added to the wallet; wagmi's `switchChainAsync` handles add-then-switch for chains in the wagmi config — verify Arbitrum (42161) is in the configured chain list (`wallet-kit/config/AomiWalletKitProvider.tsx`, `routing.routedChains`).
+- Privy/Para/Base Account lanes: confirm `selectNetwork`/`switchChain` multiplexing in `wallet-kit/runtime/evm/wallet-runtime.ts:580-600` covers each; adapters lacking it hit the readable-error path (case 4).
+- Local-private-key executor builds a viem client per `call.chainId` and needs no switch (unchanged).
+
+## Verification
+
+- `pnpm lint` + targeted vitest runs.
+- Manual: with wallet on Base, have the agent stage an Arbitrum tx → expect network-switch popup, then sign popup, no manual fiddling; joint e2e with the backend changes is described in the backend plan's verification gate.
+
+After landing, update `specs/STATE.md` per repo convention.


### PR DESCRIPTION
## What changed

- switches the connected EVM wallet to a staged transaction's requested chain before simulation and submission
- carries chain-selection support through the wallet execution adapter types
- rejects unsupported chains and adapters without switching support with actionable guidance
- documents the cross-chain wallet behavior and adds focused regression tests

## Why

Cross-chain orchestration can prepare the source and destination legs correctly, but the browser wallet may still be connected to the previous chain. Transaction execution must switch to the staged request's chain before simulation or signing.

## Impact

Users can approve sequential cross-chain legs without manually changing networks when their wallet supports programmatic switching. Unsupported or rejected switches continue through the existing request-rejection path.

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/components/runtime-tx-handler.test.tsx src/lib/wallet-kit/execution/wallet-execution.test.ts` from `apps/shadcn-registry`
- 24 focused tests passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789217809&installation_model_id=12362&pr_number=492&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F492&signature=0479c088f2769a4aec6a3bb896e23a9fb950a37d95492521935b7b09f279ce82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->