### PR TITLE
fix(release): publish through pnpm so workspace:* is rewritten

### DIFF
--- a/apps/shadcn-registry/package.json
+++ b/apps/shadcn-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/widget-lib",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Shadcn registry for the Aomi widget.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/client/test/publish-package-if-needed.test.mjs
+++ b/packages/client/test/publish-package-if-needed.test.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { publishPackageIfNeeded } from "../../../scripts/publish-package-if-needed.mjs";
@@ -70,5 +70,36 @@ describe("publishPackageIfNeeded", () => {
     ).resolves.toBe("published");
 
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  // Regression guard for the 2.0.0 release: publishing moved to `npm publish`
+  // in the release hardening (fdbea398), which uploads the manifest verbatim.
+  // Every publishable manifest declares its siblings as `workspace:*`, a
+  // pnpm-only protocol, so @aomi-labs/widget-lib@2.0.0 and
+  // @aomi-labs/react@0.6.0 reached the registry unresolvable by npm/yarn
+  // consumers — with a green publish job both times. Only `pnpm publish`
+  // rewrites the protocol, so the default implementation must stay pnpm.
+  it("defaults to pnpm publish so workspace:* is rewritten in the published manifest", async () => {
+    // Walk up from cwd: vitest runs from the repo root, but the suite is also
+    // runnable from packages/client. `import.meta.url` is not a file: URL once
+    // vitest has transformed the module, so it cannot be used here.
+    let dir = process.cwd();
+    let scriptPath = "";
+    for (let i = 0; i < 5; i += 1) {
+      const candidate = path.join(dir, "scripts/publish-package-if-needed.mjs");
+      if (existsSync(candidate)) {
+        scriptPath = candidate;
+        break;
+      }
+      dir = path.dirname(dir);
+    }
+    expect(scriptPath, "publish script not found from cwd").not.toBe("");
+    const source = readFileSync(scriptPath, "utf8");
+    expect(source).toMatch(/publishImpl\s*=\s*publishWithPnpm/);
+    expect(source).toMatch(/spawn\(\s*["']pnpm["']/);
+    // `npm publish` must not be the transport, under any function name.
+    expect(source).not.toMatch(/spawn\(\s*["']npm["']/);
+    // Detached candidate-SHA checkouts have no branch; pnpm refuses without it.
+    expect(source).toContain("--no-git-checks");
   });
 });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/react",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Runtime, state, and utilities for the Aomi widget.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/scripts/publish-package-if-needed.mjs
+++ b/scripts/publish-package-if-needed.mjs
@@ -11,7 +11,7 @@ export async function publishPackageIfNeeded(
   packageDirectory,
   {
     fetchImpl = globalThis.fetch,
-    publishImpl = publishWithNpm,
+    publishImpl = publishWithPnpm,
     registryUrl = process.env.NPM_CONFIG_REGISTRY ??
       process.env.npm_config_registry ??
       DEFAULT_REGISTRY_URL,
@@ -71,12 +71,34 @@ async function checkPublishedVersion({ fetchImpl, packageSpec, versionUrl }) {
   );
 }
 
-function publishWithNpm(packageDirectory) {
+/**
+ * Publish through pnpm, NOT `npm publish`.
+ *
+ * Every publishable manifest here declares its siblings with pnpm's
+ * `workspace:*` protocol. `pnpm publish` replaces that with the sibling's
+ * concrete version in the PUBLISHED manifest; `npm publish` uploads the
+ * manifest verbatim, and `workspace:*` is meaningless to an npm/yarn consumer
+ * — the install fails to resolve it.
+ *
+ * This is not hypothetical. Publishing moved to `npm publish` in the release
+ * hardening (fdbea398), and the first release after it shipped broken:
+ *   @aomi-labs/widget-lib@1.4.29 (pnpm) -> react 0.5.13, client 0.4.5   ✅
+ *   @aomi-labs/widget-lib@2.0.0  (npm)  -> react workspace:*, client workspace:*  ❌
+ *   @aomi-labs/react@0.6.0       (npm)  -> client workspace:*                     ❌
+ * The publish job went green both times; only the registry metadata differs,
+ * so nothing caught it until a consumer tried to install. See the guard test
+ * in packages/client/test/publish-package-if-needed.test.mjs.
+ *
+ * `--no-git-checks` is required because the release workflow publishes from a
+ * detached checkout of the candidate SHA. `--tag` is kept so NPM_DIST_TAG
+ * still works for prereleases.
+ */
+function publishWithPnpm(packageDirectory) {
   return new Promise((resolve, reject) => {
-    const args = ["publish", "--access", "public"];
+    const args = ["publish", "--access", "public", "--no-git-checks"];
     const distTag = process.env.NPM_DIST_TAG?.trim();
     if (distTag) args.push("--tag", distTag);
-    const child = spawn("npm", args, {
+    const child = spawn("pnpm", args, {
       cwd: path.resolve(packageDirectory),
       stdio: "inherit",
     });
@@ -88,7 +110,7 @@ function publishWithNpm(packageDirectory) {
       }
       reject(
         new Error(
-          `npm publish for ${packageDirectory} failed${signal ? ` with signal ${signal}` : ` with exit code ${code}`}`,
+          `pnpm publish for ${packageDirectory} failed${signal ? ` with signal ${signal}` : ` with exit code ${code}`}`,
         ),
       );
     });


### PR DESCRIPTION
## What changed

- restores the `pnpm publish` transport in `scripts/publish-package-if-needed.mjs` (kept `--no-git-checks` for detached candidate-SHA checkouts, and `--tag` for `NPM_DIST_TAG`)
- bumps `@aomi-labs/react` 0.6.0 → 0.6.1 and `@aomi-labs/widget-lib` 2.0.0 → 2.0.1 so corrected manifests can ship
- adds a guard test pinning the pnpm default and failing if `spawn("npm", ...)` ever returns

## Why

The release hardening (fdbea398) swapped the publish transport from `pnpm --filter <pkg> publish` to `npm publish`. Every publishable manifest declares its siblings with pnpm's `workspace:*` protocol. `pnpm publish` replaces that with the sibling's concrete version in the **published** manifest; `npm publish` uploads it verbatim.

The first release after that swap shipped unusable:

| published | `@aomi-labs` deps as published |
| --- | --- |
| `widget-lib@1.4.29` (pnpm) | `react: 0.5.13`, `client: 0.4.5` ✅ |
| `widget-lib@2.0.0` (npm) | `react: workspace:*`, `client: workspace:*` ❌ |
| `react@0.6.0` (npm) | `client: workspace:*` ❌ |

`workspace:*` is a pnpm-only protocol — npm and yarn cannot resolve it, so `npm install @aomi-labs/widget-lib@2.0.0` fails. Both publish runs were green; nothing inspects published metadata, so it stayed invisible until a consumer tried to install.

The manifests have used `workspace:*` all along (it predates #469) — only the transport changed.

## Validation

- `pnpm pack` on the built packages, inspecting the manifest inside the tarball:
  - `@aomi-labs/react@0.6.1` → `@aomi-labs/client: 0.5.0`
  - `@aomi-labs/widget-lib@2.0.1` → `@aomi-labs/client: 0.5.0`, `@aomi-labs/react: 0.6.1`
  - no `workspace:` protocol remaining in either
- `packages/client/test/publish-package-if-needed.test.mjs` — 5/5 passing
- `pnpm install --lockfile-only` leaves `pnpm-lock.yaml` unchanged, so `--frozen-lockfile` still holds

## Notes

`@aomi-labs/client@0.5.0` and `@aomi-labs/deploy@0.7.0` published correctly (no `@aomi-labs` dependencies) and are unchanged. `2.0.0` and `0.6.0` are immutable on the registry; they can be deprecated or unpublished separately (within npm's 72h window) — this PR does not touch them.

After merge, publish with:

```
gh workflow run publish-npm-token.yml --repo aomi-labs/aomi -f candidate_sha=<new main SHA>
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789268499&installation_model_id=12362&pr_number=494&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F494&signature=1b3d6d938515c450f3cb6f7825167513d379d5534441324778a70eb3e08f618d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->