### PR TITLE
feat(build): surface GitHub project claim

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -1184,3 +1184,15 @@ build`, `CI=true npx -y pnpm@10.28.0 install --frozen-lockfile`, and
   through the normal signing API, verifies session-thread/app-scoped callback
   delivery, and observes the resumed final state. Client build/declarations,
   library typecheck, and all 59 focused tests passed.
+- 2026-08-13 launch install recovery, bfcache branch: the "Already installed —
+  continue" escape hatch was disabled by the very state it exists to escape.
+  `beginInstall` sets `installing` and navigates to GitHub; when the App is
+  already installed GitHub renders its configure page, which never redirects
+  back, so the only way out is Back — and a bfcache restore does not remount
+  Onboarding, leaving the hydrate effect unrun and `installing` stuck true.
+  Added a `pageshow`/`persisted` handler that clears the in-flight install on
+  restore only, plus a colocated RTL spec covering both branches (restore
+  clears it; an ordinary non-persisted pageshow does not). The spec was
+  mutation-tested: neutering the handler fails the restore case and passes the
+  control case. Verified with the full launch suite, 32 files / 191 tests.
+

--- a/apps/build/src/app/api/bff/auth/github/callback/route.ts
+++ b/apps/build/src/app/api/bff/auth/github/callback/route.ts
@@ -68,7 +68,6 @@ export async function GET(req: Request) {
           client.claimGitHubProject({
             code,
             projectId: continuation.projectId,
-            app: 1,
             redirectUri: new URL(API_PATHS.bff.auth.github.callback, url.origin).toString(),
           }),
         );

--- a/apps/build/src/app/api/bff/auth/github/callback/route.ts
+++ b/apps/build/src/app/api/bff/auth/github/callback/route.ts
@@ -4,6 +4,8 @@ import { NextResponse } from "next/server";
 import {
   type GitHubOAuthContinuation,
   readGitHubOAuthRequest,
+  getGitHubSession,
+  setGitHubVisibilityGrantCookie,
   setGitHubSessionCookie,
 } from "@build/server/cookies/github";
 import {
@@ -13,6 +15,7 @@ import {
   finishCliAuthorization,
 } from "@build/server/github-auth";
 import { buildFailures } from "@build/server/bff/failures";
+import { API_PATHS } from "@build/lib/api-paths";
 
 export const runtime = "nodejs";
 
@@ -54,13 +57,38 @@ export async function GET(req: Request) {
   const continuation = oauthRequest.continuation;
 
   try {
-    const session = await exchangeGitHubSession(code, url.origin);
+    if (continuation.kind === "claim") {
+      const existingSession = await getGitHubSession();
+      if (!existingSession) {
+        return oauthError(req, continuation, "not_signed_in");
+      }
+      const claimed = await (await import("@build/server/bff/backend"))
+        .backendClient()
+        .then((client) =>
+          client.claimGitHubProject({
+            code,
+            projectId: continuation.projectId,
+            app: 1,
+            redirectUri: new URL(API_PATHS.bff.auth.github.callback, url.origin).toString(),
+          }),
+        );
+      if (claimed.githubUserId !== existingSession.githubUserId) {
+        return oauthError(req, continuation, "github_account_changed");
+      }
+      const response = NextResponse.redirect(
+        new URL(`/projects/${continuation.projectId}?claim=success`, req.url),
+      );
+      clearGitHubOAuthRequest(response);
+      return response;
+    }
+    const { session, visibilityGrant } = await exchangeGitHubSession(code, url.origin);
     const response =
       continuation.kind === "cli"
         ? await finishCliAuthorization(session, continuation)
         : NextResponse.redirect(deploymentsUrl(req));
     clearGitHubOAuthRequest(response);
     await setGitHubSessionCookie(response, session);
+    setGitHubVisibilityGrantCookie(response, visibilityGrant);
     return response;
   } catch (error) {
     const failure = buildFailures.handle({

--- a/apps/build/src/app/api/bff/auth/github/claim/route.ts
+++ b/apps/build/src/app/api/bff/auth/github/claim/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+import { startGitHubOAuth } from "@build/server/github-auth";
+import { authorize } from "@build/server/bff/auth";
+
+export const runtime = "nodejs";
+
+// The project viewer is intentionally the entry point for Claim. GitHub OAuth
+// only starts after this explicit click; loading an org project never prompts.
+export async function GET(req: Request) {
+  const auth = await authorize(req);
+  if ("response" in auth) return auth.response;
+  const projectId = Number(new URL(req.url).searchParams.get("projectId"));
+  if (!Number.isSafeInteger(projectId) || projectId <= 0) {
+    return NextResponse.json({ error: "invalid projectId" }, { status: 400 });
+  }
+  return startGitHubOAuth(req, { kind: "claim", projectId });
+}

--- a/apps/build/src/features/launch/client.ts
+++ b/apps/build/src/features/launch/client.ts
@@ -61,6 +61,12 @@ export function githubAppInstallUrl(args: {
   platform?: string;
   repo?: string;
   app?: number;
+  /**
+   * Which GitHub ceremony to ask for. The underlying client has always
+   * forwarded this; Build's wrapper simply did not expose it, so the one
+   * caller that needs `authorize` could not reach it.
+   */
+  mode?: "install" | "authorize";
   returnTo?: string;
 }): Promise<string> {
   return client.githubAppInstallUrl(args);

--- a/apps/build/src/features/launch/components/deployments/deployment-timeline.test.ts
+++ b/apps/build/src/features/launch/components/deployments/deployment-timeline.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   buildActivityList,
   buildDeploymentList,
+  deploymentIsBuilding,
+  promoteBlockedReason,
   sortDeploymentsForTimeline,
 } from "./deployment-timeline";
 
@@ -155,5 +157,80 @@ describe("buildDeploymentList", () => {
       "web:dep_1_ra_new0",
       "api:dep_1_ra_old0",
     ]);
+  });
+});
+
+describe("deploymentIsBuilding", () => {
+  it("is true while GitHub CI is pending or running", () => {
+    expect(deploymentIsBuilding({ state: null, ciStatus: "running" })).toBe(
+      true,
+    );
+    expect(deploymentIsBuilding({ state: null, ciStatus: "pending" })).toBe(
+      true,
+    );
+  });
+
+  it("is true while the deployment projection is mid-flight", () => {
+    for (const state of ["building", "releasing", "pending"]) {
+      expect(deploymentIsBuilding({ state, ciStatus: null })).toBe(true);
+    }
+  });
+
+  it("is false once settled, and for a deployment with no build state", () => {
+    expect(deploymentIsBuilding({ state: "ready", ciStatus: "passed" })).toBe(
+      false,
+    );
+    expect(deploymentIsBuilding({ state: "failed", ciStatus: "failed" })).toBe(
+      false,
+    );
+    expect(deploymentIsBuilding({ state: "no_ci", ciStatus: "no_ci" })).toBe(
+      false,
+    );
+    // A deployment known only from promotion records carries no build state;
+    // it is historical, not in flight, so it must not read as building.
+    expect(deploymentIsBuilding({ state: null, ciStatus: null })).toBe(false);
+  });
+});
+
+describe("promoteBlockedReason", () => {
+  const settled = { state: "ready", ciStatus: "passed" };
+  const idle = { busy: false, secretsBlocked: false };
+
+  it("allows promotion of a settled deployment", () => {
+    expect(promoteBlockedReason(settled, idle)).toBeNull();
+  });
+
+  // The reported bug: promote stayed clickable during CI, and each click
+  // dispatched another run that queued behind the first.
+  it("blocks promotion while the deployment is still building", () => {
+    const reason = promoteBlockedReason(
+      { state: "building", ciStatus: "running" },
+      idle,
+    );
+    expect(reason).toMatch(/still building/i);
+    expect(reason).toMatch(/second CI run/i);
+  });
+
+  it("blocks promotion while another operation is running", () => {
+    expect(promoteBlockedReason(settled, { ...idle, busy: true })).toMatch(
+      /still running/i,
+    );
+  });
+
+  it("blocks promotion when required secrets are missing", () => {
+    expect(
+      promoteBlockedReason(settled, { ...idle, secretsBlocked: true }),
+    ).toMatch(/secrets/i);
+  });
+
+  // An in-flight build is the more actionable thing to say: setting secrets
+  // would not make the button work yet.
+  it("reports the build before missing secrets", () => {
+    expect(
+      promoteBlockedReason(
+        { state: "building", ciStatus: "running" },
+        { busy: false, secretsBlocked: true },
+      ),
+    ).toMatch(/still building/i);
   });
 });

--- a/apps/build/src/features/launch/components/deployments/deployment-timeline.ts
+++ b/apps/build/src/features/launch/components/deployments/deployment-timeline.ts
@@ -119,6 +119,10 @@ export function buildDeploymentList(
  * | passed | failed`); `state` is the backend's deployment projection
  * (`no_ci | building | releasing | ready | failed | pending`). Either can be
  * the one that knows, so both are checked.
+ *
+ * `pending` means waiting on CI in both vocabularies — never waiting on a
+ * person — so it belongs in flight. Promoting during it would dispatch the
+ * second run this guard exists to prevent.
  */
 const CI_IN_FLIGHT = new Set(["pending", "running"]);
 const STATE_IN_FLIGHT = new Set(["pending", "building", "releasing"]);

--- a/apps/build/src/features/launch/components/deployments/deployment-timeline.ts
+++ b/apps/build/src/features/launch/components/deployments/deployment-timeline.ts
@@ -13,6 +13,15 @@ export type TimelineDeployment = {
   actor: string | null;
   sdkVersion: string | null;
   createdAt: number;
+  /**
+   * Build state for this deployment, carried from history so the row can tell
+   * whether work is still in flight. Promotion records describe what was
+   * *already* promoted and say nothing about CI, so both are null for a
+   * deployment known only from records.
+   */
+  state: string | null;
+  ciStatus: string | null;
+  ciUrl: string | null;
 };
 
 /** One promotion record, tagged with the app it belongs to (for the activity feed). */
@@ -48,6 +57,11 @@ export function buildDeploymentList(
           actor: row.actor,
           sdkVersion: row.sdkVersion,
           createdAt: row.createdAt,
+          // Promotion records carry no build state. History fills these in
+          // below when it knows this deployment.
+          state: null,
+          ciStatus: null,
+          ciUrl: null,
         });
         continue;
       }
@@ -88,10 +102,67 @@ export function buildDeploymentList(
       actor: existing?.actor ?? null,
       sdkVersion,
       createdAt: entry.createdAt,
+      // History is the only source that knows whether CI is still running.
+      state: entry.state ?? null,
+      ciStatus: entry.ciStatus ?? null,
+      ciUrl: entry.ciUrl ?? null,
     });
   }
 
   return [...byId.values()].sort((a, b) => b.createdAt - a.createdAt);
+}
+
+/**
+ * CI states that mean work is still in flight for a deployment.
+ *
+ * `ciStatus` is GitHub's aggregate for the commit (`no_ci | pending | running
+ * | passed | failed`); `state` is the backend's deployment projection
+ * (`no_ci | building | releasing | ready | failed | pending`). Either can be
+ * the one that knows, so both are checked.
+ */
+const CI_IN_FLIGHT = new Set(["pending", "running"]);
+const STATE_IN_FLIGHT = new Set(["pending", "building", "releasing"]);
+
+export function deploymentIsBuilding(deployment: {
+  state: string | null;
+  ciStatus: string | null;
+}): boolean {
+  return (
+    CI_IN_FLIGHT.has(deployment.ciStatus ?? "") ||
+    STATE_IN_FLIGHT.has(deployment.state ?? "")
+  );
+}
+
+/**
+ * Why promotion is unavailable, or null when it is available.
+ *
+ * Promoting a deployment whose build is still running does not queue politely:
+ * it dispatches another CI job that lands behind the first, so the click that
+ * was meant to hurry things up makes the wait longer. The window is wide —
+ * `busy` only knows about an operation *this* browser tab started, so a
+ * reload, a second tab, or a promotion by a teammate all leave the button live
+ * unless the deployment's own build state is consulted.
+ *
+ * Returned as a reason rather than a boolean because a greyed-out button with
+ * no explanation is its own bug report.
+ */
+export function promoteBlockedReason(
+  deployment: { state: string | null; ciStatus: string | null },
+  options: {
+    /** An operation this tab started, for this project, is still running. */
+    busy: boolean;
+    /** One or more of the deployment's apps is missing a required secret. */
+    secretsBlocked: boolean;
+  },
+): string | null {
+  if (options.busy) return "Another deployment operation is still running.";
+  if (deploymentIsBuilding(deployment)) {
+    return "This deployment is still building. Promoting now would queue a second CI run behind the first.";
+  }
+  if (options.secretsBlocked) {
+    return "Set the required secrets for this deployment's apps first.";
+  }
+  return null;
 }
 
 /** Current first, then newest. Used after runtime remaps `current`. */

--- a/apps/build/src/features/launch/components/deployments/tabs/deployments-tab.tsx
+++ b/apps/build/src/features/launch/components/deployments/tabs/deployments-tab.tsx
@@ -15,6 +15,7 @@ import { LoadingPanel, EmptyPanel } from "../ui/state-panels";
 import {
   buildActivityList,
   buildDeploymentList,
+  promoteBlockedReason,
   sortDeploymentsForTimeline,
 } from "../deployment-timeline";
 import { formatRelativeTime } from "../format-relative-time";
@@ -486,9 +487,10 @@ export function DeploymentsTab({
         />
       ) : view === "deployments" && deployments.length > 0 ? (
         deployments.map((deployment) => {
-          const running =
-            op?.deploymentId === deployment.deploymentId &&
-            op.status === "running";
+          // Any running operation in this project blocks promotion, not only
+          // one on this row: two promotions in the same project dispatch two
+          // CI runs that queue behind each other just the same.
+          const running = op?.status === "running";
           const message =
             op?.deploymentId === deployment.deploymentId ? op.message : null;
           const hasUnloadedCurrentApp =
@@ -505,11 +507,16 @@ export function DeploymentsTab({
           const secretsBlocked = deployment.apps.some((app) =>
             detail.hasMissingSecrets(app),
           );
+          const promoteBlocked = promoteBlockedReason(deployment, {
+            busy: running,
+            secretsBlocked,
+          });
           return (
             <div key={deployment.deploymentId}>
               <TimelineDeploymentRow
                 deployment={deployment}
                 busy={running}
+                promoteBlocked={promoteBlocked}
                 message={message}
                 runtimeState={hasUnloadedCurrentApp ? "not-loaded" : "loaded"}
                 requiredSdk={requiredSdk}

--- a/apps/build/src/features/launch/components/deployments/tabs/settings-tab.tsx
+++ b/apps/build/src/features/launch/components/deployments/tabs/settings-tab.tsx
@@ -41,6 +41,22 @@ export function SettingsTab({ detail }: { detail: Detail }) {
         <SdkBadge stamped={stamped} required={required} />
       </div>
       <div className="border-border border-t px-4 py-4">
+        <div className="text-foreground text-sm font-medium">
+          Operator access
+        </div>
+        <p className="text-dim mt-1 text-xs leading-5">
+          Claim operator access transfers project writes and its project bots
+          from the current operator to you. GitHub will verify that you are a
+          repository administrator before the transfer.
+        </p>
+        <a
+          href={`/api/bff/auth/github/claim?projectId=${source.id}`}
+          className="border-border text-foreground mt-3 inline-flex h-8 items-center rounded-md border px-3 text-xs font-medium hover:bg-muted"
+        >
+          Claim operator access
+        </a>
+      </div>
+      <div className="border-border border-t px-4 py-4">
         <div className="text-foreground text-sm font-medium">Danger zone</div>
         <p className="text-dim mt-1 text-xs">
           Disconnect project is coming soon.

--- a/apps/build/src/features/launch/components/deployments/ui/timeline-deployment-row.tsx
+++ b/apps/build/src/features/launch/components/deployments/ui/timeline-deployment-row.tsx
@@ -5,7 +5,10 @@ import {
   RotateCcw,
 } from "lucide-react";
 import { HelpBadge } from "@build/components/help-badge";
-import type { TimelineDeployment } from "../deployment-timeline";
+import {
+  deploymentIsBuilding,
+  type TimelineDeployment,
+} from "../deployment-timeline";
 import { formatRelativeTime } from "../format-relative-time";
 import { sdkCompatibility } from "../sdk-compatibility";
 
@@ -17,6 +20,7 @@ export function TimelineDeploymentRow({
   runtimeState,
   requiredSdk,
   secretsBlocked,
+  promoteBlocked,
   onPromote,
   onUpgrade,
   upgradePr,
@@ -28,6 +32,13 @@ export function TimelineDeploymentRow({
   runtimeState?: "loaded" | "not-loaded";
   requiredSdk?: string | null;
   secretsBlocked?: boolean;
+  /**
+   * Why promotion is unavailable, or null when it is available. Shown as the
+   * button's tooltip, so the disabled state explains itself. Undefined means
+   * the caller has not adopted this yet and the legacy busy/secrets gate
+   * applies.
+   */
+  promoteBlocked?: string | null;
   onPromote: () => void;
   onUpgrade?: () => void;
   /** Open upgrade PR: replaces the Upgrade button with a review link. */
@@ -39,6 +50,7 @@ export function TimelineDeploymentRow({
     deployment;
   const title = apps.join(", ") || "Deployment";
   const absolute = new Date(createdAt * 1000).toLocaleString();
+  const building = deploymentIsBuilding(deployment);
   const outdated =
     current && sdkCompatibility(sdkVersion, requiredSdk) === "outdated";
 
@@ -127,17 +139,26 @@ export function TimelineDeploymentRow({
         {!current && (
           <button
             type="button"
-            disabled={busy || secretsBlocked}
+            // `promoteBlocked` supersedes the older busy/secrets pair and
+            // additionally covers "this deployment is still building". The
+            // fallback keeps the previous behaviour for any call site that
+            // has not been updated to pass a reason.
+            disabled={
+              promoteBlocked !== undefined
+                ? promoteBlocked !== null
+                : busy || secretsBlocked
+            }
             onClick={onPromote}
             className="border-border bg-surface-1 text-foreground hover:bg-accent-hover inline-flex h-8 items-center justify-center gap-1.5 rounded-md border px-2.5 text-xs font-medium disabled:cursor-not-allowed disabled:opacity-50"
             title={
-              secretsBlocked
+              promoteBlocked ??
+              (secretsBlocked
                 ? "Required secrets missing — set them in the Environment tab"
-                : "Promote this deployment to live"
+                : "Promote this deployment to live")
             }
           >
             <RotateCcw className="size-3.5" aria-hidden />
-            Promote
+            {building ? "Building…" : "Promote"}
           </button>
         )}
       </div>

--- a/apps/build/src/features/launch/components/deployments/use-global-deployment-records.ts
+++ b/apps/build/src/features/launch/components/deployments/use-global-deployment-records.ts
@@ -38,6 +38,9 @@ function globalDeployment(deployment: UserDeployment): GlobalDeployment | null {
     actor: null,
     sdkVersion: deployment.sdkVersion ?? null,
     createdAt: deployment.createdAt,
+    state: deployment.state ?? null,
+    ciStatus: deployment.ciStatus ?? null,
+    ciUrl: deployment.ciUrl ?? null,
     projectId: deployment.projectId,
     repositoryLink: deployment.repositoryLink,
   };

--- a/apps/build/src/features/launch/components/onboarding.bfcache.test.tsx
+++ b/apps/build/src/features/launch/components/onboarding.bfcache.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Onboarding — back/forward-cache restore clears the in-flight install state.
+ *
+ * `beginInstall` sets `installing` and then navigates to GitHub. When the App
+ * is already installed GitHub renders its *configure* page, which never
+ * redirects back, so the user's only way out is Back. A bfcache restore does
+ * not remount the component, so the hydrate effect never re-runs and
+ * `installing` stays true — disabling every install button, including the
+ * "Already installed — continue" recovery path that exists precisely for this
+ * dead end. Only `pageshow` with `persisted: true` reports that restore.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Onboarding } from "./onboarding";
+
+vi.mock("@aomi-labs/widget-lib", () => ({
+  useAomiAuthAdapter: () => ({ identity: {}, isConnected: false }),
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button onClick={onClick} disabled={disabled} type="button">
+      {children}
+    </button>
+  ),
+}));
+
+// Keep the real helpers (state transitions, labels, step math) and stub only
+// the two things a test must not do: talk to GitHub, and persist to storage.
+vi.mock("@build/features/launch", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    githubAppInstallUrl: vi.fn(async () => "https://github.test/install"),
+    saveLaunch: vi.fn(),
+  };
+});
+
+vi.mock("@build/features/launch/platform", () => ({
+  readPlatform: () => "community",
+}));
+vi.mock("@build/lib/deploy-platform", () => ({
+  DEFAULT_DEPLOY_PLATFORM: "community",
+}));
+
+function firePageShow(persisted: boolean) {
+  const event = new Event("pageshow") as Event & { persisted?: boolean };
+  Object.defineProperty(event, "persisted", { value: persisted });
+  window.dispatchEvent(event);
+}
+
+describe("Onboarding bfcache restore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // jsdom forbids assigning window.location.href; stub the navigation that
+    // beginInstall performs so the component reaches its `installing` state.
+    // jsdom forbids assigning window.location.href, and the component reads it
+    // through `new URL(...)`, so the stub must stay a valid absolute URL.
+    Object.defineProperty(window, "location", {
+      value: {
+        href: "https://build.test/operate/deployments/new",
+        origin: "https://build.test",
+        search: "",
+        assign: () => {},
+        replace: () => {},
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("re-enables the recovery button after a restore from bfcache", async () => {
+    render(<Onboarding />);
+
+    const recovery = screen.getByRole("button", {
+      name: /already installed/i,
+    });
+    expect(recovery).not.toBeDisabled();
+
+    // Start the install: the component navigates away and marks itself busy.
+    fireEvent.click(screen.getByRole("button", { name: /install on github/i }));
+    await waitFor(() => expect(recovery).toBeDisabled());
+
+    // The user hits Back from GitHub's configure page. Without the pageshow
+    // handler this stays disabled forever and the flow is unrecoverable.
+    firePageShow(true);
+    await waitFor(() => expect(recovery).not.toBeDisabled());
+  });
+
+  it("leaves the in-flight state alone on a normal (non-restored) pageshow", async () => {
+    render(<Onboarding />);
+
+    const recovery = screen.getByRole("button", {
+      name: /already installed/i,
+    });
+    fireEvent.click(screen.getByRole("button", { name: /install on github/i }));
+    await waitFor(() => expect(recovery).toBeDisabled());
+
+    // A fresh load fires pageshow with persisted:false; that is not a restore
+    // and must not clear a genuinely in-flight install.
+    firePageShow(false);
+    expect(recovery).toBeDisabled();
+  });
+});

--- a/apps/build/src/features/launch/components/onboarding.tsx
+++ b/apps/build/src/features/launch/components/onboarding.tsx
@@ -181,6 +181,23 @@ export function Onboarding({
     }
   }, [state.oneshot.deploymentId]);
 
+  // --- bfcache restore ------------------------------------------------------
+  // `beginInstall` sets `installing` and then navigates to GitHub. When GitHub
+  // renders the *configure* page (App already installed) the user's only way
+  // back is Back, and a bfcache restore does NOT remount this component — the
+  // hydrate effect above never re-runs, so `installing` stays true and every
+  // install button, including the "Already installed — continue" recovery path
+  // this flow depends on, is disabled forever. `pageshow` with `persisted` is
+  // the only signal for that restore.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onPageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) setInstalling(false);
+    };
+    window.addEventListener("pageshow", onPageShow);
+    return () => window.removeEventListener("pageshow", onPageShow);
+  }, []);
+
   // --- actions handed to the wizard -----------------------------------------
   const restart = useCallback(() => {
     if (typeof window !== "undefined") {

--- a/apps/build/src/features/launch/components/onboarding.tsx
+++ b/apps/build/src/features/launch/components/onboarding.tsx
@@ -119,10 +119,20 @@ export function Onboarding({
     const redirect = readGithubRedirect(window.location.search);
     if (!redirect) {
       setInstalling(false);
-      setInstallError(null);
       const cur = loadLaunch();
       if (cur.pendingInstall) {
+        // We sent this browser to GitHub and it came back with no
+        // installation id. The common cause is an App that was already
+        // installed: GitHub renders its configure page rather than an
+        // install, and that page never redirects here. Say so and offer the
+        // authorize path, instead of silently resetting to the same button
+        // that just failed to get anywhere.
+        setInstallError(
+          "GitHub returned without completing an install. If the Aomi app is already installed on your account, use “Already installed — continue” below.",
+        );
         update(withPendingInstall(cur, null));
+      } else {
+        setInstallError(null);
       }
       return;
     }
@@ -226,32 +236,47 @@ export function Onboarding({
     update(withProgress(state, PATH, { deploymentId: undefined, live: false }));
   }, [state, update]);
 
-  const beginInstall = useCallback(async () => {
-    const next = withPendingInstall(withPath(state, PATH), { path: PATH });
-    saveLaunch(next);
-    setState(next);
-    setInstallError(null);
-    setInstalling(true);
-    try {
-      // A return URL has to name an exact platform, and without one the
-      // backend falls back to the *portal's* settings page — a different app.
-      // An unscoped Build page is the Community platform, so say so and come
-      // back here.
-      const target = platform || readPlatform() || DEFAULT_DEPLOY_PLATFORM;
-      window.location.href = await githubAppInstallUrl({
-        app: 2,
-        platform: target,
-        returnTo: `${window.location.origin}/operate/deployments/new?platform=${encodeURIComponent(target)}`,
-      });
-    } catch (error) {
-      setInstalling(false);
-      setInstallError(
-        error instanceof Error
-          ? error.message
-          : "Failed to start GitHub App install.",
-      );
-    }
-  }, [platform, state]);
+  /**
+   * Send the browser to GitHub.
+   *
+   * `mode` picks the ceremony. The default install URL is
+   * `apps/<slug>/installations/new`, and GitHub only runs an install for an
+   * account that does not already have one — for an account that does, it
+   * renders the *configure* page, which carries no signed `state` and never
+   * returns here. That is a dead end the wizard cannot detect, so
+   * `mode: "authorize"` offers the OAuth consent leg instead, which does come
+   * back with an installation id.
+   */
+  const beginInstall = useCallback(
+    async (mode?: "install" | "authorize") => {
+      const next = withPendingInstall(withPath(state, PATH), { path: PATH });
+      saveLaunch(next);
+      setState(next);
+      setInstallError(null);
+      setInstalling(true);
+      try {
+        // A return URL has to name an exact platform, and without one the
+        // backend falls back to the *portal's* settings page — a different app.
+        // An unscoped Build page is the Community platform, so say so and come
+        // back here.
+        const target = platform || readPlatform() || DEFAULT_DEPLOY_PLATFORM;
+        window.location.href = await githubAppInstallUrl({
+          app: 2,
+          mode,
+          platform: target,
+          returnTo: `${window.location.origin}/operate/deployments/new?platform=${encodeURIComponent(target)}`,
+        });
+      } catch (error) {
+        setInstalling(false);
+        setInstallError(
+          error instanceof Error
+            ? error.message
+            : "Failed to start GitHub App install.",
+        );
+      }
+    },
+    [platform, state],
+  );
 
   // knownSources / hideWizardBack are accepted for parity with the dashboard's
   // call site; the one-click wizard derives everything it needs from `progress`.

--- a/apps/build/src/features/launch/components/oneshot-wizard.test.tsx
+++ b/apps/build/src/features/launch/components/oneshot-wizard.test.tsx
@@ -85,6 +85,28 @@ describe("OneshotWizard", () => {
     expect(screen.getByText("Install on GitHub")).toBeInTheDocument();
   });
 
+  // GitHub renders its configure page — which never redirects back — instead
+  // of re-running an install for an account that already has one. Without a
+  // second door, "Install on GitHub" is a dead end for those users.
+  it("offers the authorize ceremony for an already-installed account", () => {
+    const beginInstall = vi.fn();
+    render(<OneshotWizard {...defaultProps} beginInstall={beginInstall} />);
+    fireEvent.click(screen.getByText("Already installed — continue"));
+    expect(beginInstall).toHaveBeenCalledWith("authorize");
+  });
+
+  it("asks for the install ceremony from the primary button", () => {
+    const beginInstall = vi.fn();
+    render(<OneshotWizard {...defaultProps} beginInstall={beginInstall} />);
+    fireEvent.click(screen.getByText("Install on GitHub"));
+    expect(beginInstall).toHaveBeenCalledWith("install");
+  });
+
+  it("disables both install doors while a redirect is in flight", () => {
+    render(<OneshotWizard {...defaultProps} installing />);
+    expect(screen.getByText("Already installed — continue")).toBeDisabled();
+  });
+
   it("shows live panel when live", () => {
     render(
       <OneshotWizard

--- a/apps/build/src/features/launch/components/oneshot-wizard.tsx
+++ b/apps/build/src/features/launch/components/oneshot-wizard.tsx
@@ -156,7 +156,11 @@ export function OneshotWizard({
   platform?: string;
   actor?: string;
   onRestart?: () => void;
-  beginInstall: () => void;
+  /**
+   * Send the browser to GitHub. `authorize` skips the install ceremony for an
+   * account that already has the App — see the Install step below.
+   */
+  beginInstall: (mode?: "install" | "authorize") => void;
   installing?: boolean;
   installError?: string | null;
   patch: (patch: Partial<LaunchProgress>) => void;
@@ -252,11 +256,26 @@ export function OneshotWizard({
             </p>
             <div className="flex flex-wrap gap-2">
               <Button
-                onClick={beginInstall}
+                onClick={() => beginInstall("install")}
                 disabled={installing}
                 className="h-9 rounded-md px-3 text-sm font-medium"
               >
                 {installing ? "Waiting for GitHub..." : "Install on GitHub"}
+                <ExternalLink className="ml-1 h-4 w-4" />
+              </Button>
+              {/*
+                GitHub does not re-run an install for an account that already
+                has one — it renders the App's configure page, which never
+                redirects back here, so "Install on GitHub" is a dead end for
+                anyone already installed. This asks for the OAuth consent leg
+                instead, which does return with an installation id.
+              */}
+              <Button
+                onClick={() => beginInstall("authorize")}
+                disabled={installing}
+                className="bg-surface-2 text-foreground h-9 rounded-md px-3 text-sm font-medium"
+              >
+                Already installed — continue
                 <ExternalLink className="ml-1 h-4 w-4" />
               </Button>
             </div>

--- a/apps/build/src/server/bff/auth.ts
+++ b/apps/build/src/server/bff/auth.ts
@@ -9,10 +9,23 @@ import {
   getGitHubSession,
 } from "@build/server/cookies/github";
 
-type AuthResult = { session: GitHubSession } | { response: NextResponse };
+type AuthResult =
+  | { session: GitHubSession; visibilityGrant: string | null }
+  | { response: NextResponse };
 type AnonymousAuthResult =
   | { session: GitHubSession | null }
   | { response: NextResponse };
+
+function visibilityGrantFromRequest(req: Request): string | null {
+  const cookie = req.headers.get("cookie") ?? "";
+  const value = cookie
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith("aomi_github_visibility="))
+    ?.slice("aomi_github_visibility=".length)
+    ?.trim();
+  return value || null;
+}
 
 export function authorize(
   req: Request,
@@ -32,7 +45,7 @@ export async function authorize(
 ): Promise<AuthResult | AnonymousAuthResult> {
   if (options.cliScope) {
     const cli = await getGitHubCliSessionFromRequest(req, options.cliScope);
-    if (cli) return { session: cli };
+    if (cli) return { session: cli, visibilityGrant: null };
   }
   if (options.write && !validateOrigin(req)) {
     return {
@@ -49,7 +62,7 @@ export async function authorize(
     return { session: null };
   }
   return session
-    ? { session }
+    ? { session, visibilityGrant: visibilityGrantFromRequest(req) }
     : {
         response: NextResponse.json(
           { error: "not signed in with GitHub" },

--- a/apps/build/src/server/bff/launch/routes.ts
+++ b/apps/build/src/server/bff/launch/routes.ts
@@ -277,7 +277,7 @@ export function launchDeployRoute(preflight: boolean) {
 export async function createLaunchRepoRoute(req: Request) {
   const auth = await authorize(req, { write: true });
   if ("response" in auth) return auth.response;
-  const { session } = auth;
+  const { session, visibilityGrant } = auth;
 
   try {
     const body = (await req.json().catch(() => ({}))) as {
@@ -1058,7 +1058,7 @@ export async function redeployLaunchRoute(req: Request) {
 export async function userProjectsRoute(req: Request) {
   const auth = await authorize(req);
   if ("response" in auth) return auth.response;
-  const { session } = auth;
+  const { session, visibilityGrant } = auth;
 
   try {
     const config = launchConfig();
@@ -1088,23 +1088,25 @@ export async function userProjectsRoute(req: Request) {
     const projects =
       projectId === undefined
         ? await readCache.projects.get(
-            [session.githubUserId, listPlatform ?? null],
+            [session.githubUserId, listPlatform ?? null, visibilityGrant ?? ""],
             () =>
               timedManagerRead("list_user_projects", () =>
                 client.listUserProjects({
                   githubUserId: session.githubUserId,
                   platform: listPlatform,
+                  ...(visibilityGrant ? { visibilityGrant } : {}),
                 }),
               ),
           )
         : [
             await readCache.projectDetails.get(
-              [session.githubUserId, projectId],
+              [session.githubUserId, projectId, visibilityGrant ?? ""],
               () =>
                 timedManagerRead("get_user_project", () =>
                   client.getUserProject({
                     githubUserId: session.githubUserId,
                     projectId,
+                    ...(visibilityGrant ? { visibilityGrant } : {}),
                   }),
                 ),
             ),

--- a/apps/build/src/server/bff/operate/routes.ts
+++ b/apps/build/src/server/bff/operate/routes.ts
@@ -423,7 +423,7 @@ async function operateSession(
   try {
     const auth = await authorize(req);
     if ("response" in auth) return auth;
-    const { session } = auth;
+    const { session, visibilityGrant } = auth;
     const config = launchConfig();
     const params = new URL(req.url).searchParams;
     const requestedPlatform = params.get("platform") ?? undefined;
@@ -442,17 +442,19 @@ async function operateSession(
       platform,
       client,
       projects: () =>
-        readCache.projects.get([session.githubUserId, null], () =>
+        readCache.projects.get([session.githubUserId, null, visibilityGrant ?? ""], () =>
           client.listUserProjects({
             githubUserId: session.githubUserId,
             platform: undefined,
+            ...(visibilityGrant ? { visibilityGrant } : {}),
           }),
         ),
       platformProjects: () =>
-        readCache.projects.get([session.githubUserId, platform], () =>
+        readCache.projects.get([session.githubUserId, platform, visibilityGrant ?? ""], () =>
           client.listUserProjects({
             githubUserId: session.githubUserId,
             platform,
+            ...(visibilityGrant ? { visibilityGrant } : {}),
           }),
         ),
     };

--- a/apps/build/src/server/cookies/github.ts
+++ b/apps/build/src/server/cookies/github.ts
@@ -17,6 +17,8 @@ import {
  * browser control-plane request from it.
  */
 export const GITHUB_SESSION_COOKIE = "aomi_github";
+/** Opaque Manager-signed grant, intentionally separate from the session. */
+export const GITHUB_VISIBILITY_GRANT_COOKIE = "aomi_github_visibility";
 const SESSION_TTL_SECONDS = 7 * 24 * 60 * 60;
 const CLI_SESSION_AUDIENCE = "aomi-build-cli";
 const CLI_EXCHANGE_TYPE = "aomi-build-cli-exchange";
@@ -47,6 +49,7 @@ export interface GitHubCliLoginRequest {
 
 export type GitHubOAuthContinuation =
   | { kind: "browser" }
+  | { kind: "claim"; projectId: number }
   | ({ kind: "cli" } & GitHubCliLoginRequest);
 
 export interface GitHubOAuthRequest {
@@ -130,6 +133,14 @@ function cliContinuation(value: unknown): GitHubOAuthContinuation | null {
   const candidate = value as Record<string, unknown>;
   if (candidate.kind === "browser") return { kind: "browser" };
   if (
+    candidate.kind === "claim" &&
+    typeof candidate.projectId === "number" &&
+    Number.isSafeInteger(candidate.projectId) &&
+    candidate.projectId > 0
+  ) {
+    return { kind: "claim", projectId: candidate.projectId };
+  }
+  if (
     candidate.kind !== "cli" ||
     typeof candidate.redirectUri !== "string" ||
     typeof candidate.state !== "string" ||
@@ -158,6 +169,20 @@ export async function readGitHubSession(
 ): Promise<GitHubSession | null> {
   const payload = await verify(token);
   return payload ? sessionFromPayload(payload) : null;
+}
+
+export function setGitHubVisibilityGrantCookie(
+  response: NextResponse,
+  grant: string | null | undefined,
+): void {
+  response.cookies.set(GITHUB_VISIBILITY_GRANT_COOKIE, grant?.trim() ?? "", {
+    ...SESSION_COOKIE_OPTIONS,
+    maxAge: grant?.trim() ? 10 * 60 : 0,
+  });
+}
+
+export async function getGitHubVisibilityGrant(): Promise<string | null> {
+  return (await cookies()).get(GITHUB_VISIBILITY_GRANT_COOKIE)?.value?.trim() || null;
 }
 
 export async function issueGitHubCliSession(

--- a/apps/build/src/server/github-auth.ts
+++ b/apps/build/src/server/github-auth.ts
@@ -100,7 +100,7 @@ export async function startGitHubOAuth(
 export async function exchangeGitHubSession(
   code: string,
   origin: string,
-): Promise<GitHubSession> {
+): Promise<{ session: GitHubSession; visibilityGrant: string | null }> {
   const callback = new URL(API_PATHS.bff.auth.github.callback, origin);
   const identity = await (
     await backendClient()
@@ -113,9 +113,12 @@ export async function exchangeGitHubSession(
     throw new Error("GitHub identity could not be resolved");
   }
   return {
-    githubUserId: identity.githubUserId,
-    githubLogin: identity.githubLogin,
-    installationId: identity.installationId,
+    session: {
+      githubUserId: identity.githubUserId,
+      githubLogin: identity.githubLogin,
+      installationId: identity.installationId,
+    },
+    visibilityGrant: identity.visibilityGrant ?? null,
   };
 }
 

--- a/packages/deploy/src/backend/core.ts
+++ b/packages/deploy/src/backend/core.ts
@@ -192,6 +192,7 @@ export class BackendClientCore {
       bearer?: string;
       actor?: string;
       projectId?: number;
+      visibilityGrant?: string;
     },
     pathSuffix: string,
     action: AuditEvent["action"],
@@ -205,6 +206,9 @@ export class BackendClientCore {
       this.userPath(pathSuffix, params),
       action,
       bearer,
+      input.visibilityGrant?.trim()
+        ? { "X-Aomi-Visibility-Grant": input.visibilityGrant.trim() }
+        : undefined,
     );
     await this.audit(action, input.actor, auditExtra);
     return map(raw);
@@ -228,8 +232,9 @@ export class BackendClientCore {
     path: string,
     operation: string,
     bearer: string,
+    headers?: Record<string, string>,
   ): Promise<Resp> {
-    return this.request<Resp>(path, "GET", undefined, operation, bearer);
+    return this.request<Resp>(path, "GET", undefined, operation, bearer, headers);
   }
 
   protected post<Resp>(
@@ -237,8 +242,9 @@ export class BackendClientCore {
     body: unknown,
     operation: string,
     bearer: string,
+    headers?: Record<string, string>,
   ): Promise<Resp> {
-    return this.request<Resp>(path, "POST", body, operation, bearer);
+    return this.request<Resp>(path, "POST", body, operation, bearer, headers);
   }
 
   protected patch<Resp>(
@@ -246,8 +252,9 @@ export class BackendClientCore {
     body: unknown,
     operation: string,
     bearer: string,
+    headers?: Record<string, string>,
   ): Promise<Resp> {
-    return this.request<Resp>(path, "PATCH", body, operation, bearer);
+    return this.request<Resp>(path, "PATCH", body, operation, bearer, headers);
   }
 
   protected put<Resp>(
@@ -255,8 +262,9 @@ export class BackendClientCore {
     body: unknown,
     operation: string,
     bearer: string,
+    headers?: Record<string, string>,
   ): Promise<Resp> {
-    return this.request<Resp>(path, "PUT", body, operation, bearer);
+    return this.request<Resp>(path, "PUT", body, operation, bearer, headers);
   }
 
   protected del<Resp>(
@@ -264,8 +272,9 @@ export class BackendClientCore {
     operation: string,
     bearer: string,
     body?: unknown,
+    headers?: Record<string, string>,
   ): Promise<Resp> {
-    return this.request<Resp>(path, "DELETE", body, operation, bearer);
+    return this.request<Resp>(path, "DELETE", body, operation, bearer, headers);
   }
 
   private async request<Resp>(
@@ -274,6 +283,7 @@ export class BackendClientCore {
     body: unknown,
     operation: string,
     bearer: string,
+    headers?: Record<string, string>,
   ): Promise<Resp> {
     const url = this.endpoint(path);
     let res: Response;
@@ -282,6 +292,7 @@ export class BackendClientCore {
         method,
         headers: {
           Authorization: `Bearer ${bearer}`,
+          ...headers,
           ...(body === undefined ? {} : { "Content-Type": "application/json" }),
         },
         ...(body === undefined ? {} : { body: JSON.stringify(body) }),

--- a/packages/deploy/src/backend/user.ts
+++ b/packages/deploy/src/backend/user.ts
@@ -10,6 +10,8 @@ import type {
   DeleteUserBotInput,
   DeleteUserProjectBotInput,
   ExchangeGitHubCodeInput,
+  ClaimGitHubProjectInput,
+  ClaimGitHubProjectResult,
   GetBuilderApplicationDetailInput,
   GetBuilderApplicationInput,
   GetUserProjectInput,
@@ -120,6 +122,7 @@ export class BackendClient extends BackendPlatformClient {
       github_user_id?: string;
       github_login?: string;
       installation_id?: number | string | null;
+      visibility_grant?: string | null;
     }>(
       `/api/integrations/github-app/oauth/exchange?${params.toString()}`,
       "exchange_github_code",
@@ -132,6 +135,32 @@ export class BackendClient extends BackendPlatformClient {
         raw.installation_id === null || raw.installation_id === undefined
           ? null
           : String(raw.installation_id),
+      visibilityGrant:
+        typeof raw.visibility_grant === "string" ? raw.visibility_grant : null,
+    };
+  }
+
+  async claimGitHubProject(
+    input: ClaimGitHubProjectInput,
+  ): Promise<ClaimGitHubProjectResult> {
+    if (!Number.isSafeInteger(input.projectId) || input.projectId <= 0) {
+      throw new Error("projectId must be a positive integer");
+    }
+    const bearer = this.resolveBearer(input.bearer);
+    const raw = await this.post<Record<string, unknown>>(
+      "/api/integrations/github-app/oauth/claim",
+      {
+        code: required(input.code, "code"),
+        project_id: input.projectId,
+        app: input.app,
+        redirect_uri: input.redirectUri,
+      },
+      "claim_github_project",
+      bearer,
+    );
+    return {
+      githubUserId: String(raw.github_user_id ?? ""),
+      project: camelUserProject((raw.project ?? {}) as Record<string, unknown>),
     };
   }
 
@@ -148,6 +177,9 @@ export class BackendClient extends BackendPlatformClient {
         if (input.platform?.trim()) {
           params.set("platform", input.platform.trim());
         }
+        if (input.visibilityGrant?.trim()) {
+          params.set("visibility_grant", input.visibilityGrant.trim());
+        }
       },
       { platform: input.platform },
     );
@@ -160,6 +192,9 @@ export class BackendClient extends BackendPlatformClient {
     const githubUserId = required(input.githubUserId, "githubUserId");
     const bearer = this.resolveBearer(input.bearer);
     const params = new URLSearchParams({ github_user_id: githubUserId });
+    if (input.visibilityGrant?.trim()) {
+      params.set("visibility_grant", input.visibilityGrant.trim());
+    }
     const raw = await this.get<Record<string, unknown>>(
       this.ownedProjectBasePath(input.projectId, params),
       "get_user_project",

--- a/packages/deploy/src/backend/user.ts
+++ b/packages/deploy/src/backend/user.ts
@@ -152,7 +152,6 @@ export class BackendClient extends BackendPlatformClient {
       {
         code: required(input.code, "code"),
         project_id: input.projectId,
-        app: input.app,
         redirect_uri: input.redirectUri,
       },
       "claim_github_project",
@@ -177,9 +176,6 @@ export class BackendClient extends BackendPlatformClient {
         if (input.platform?.trim()) {
           params.set("platform", input.platform.trim());
         }
-        if (input.visibilityGrant?.trim()) {
-          params.set("visibility_grant", input.visibilityGrant.trim());
-        }
       },
       { platform: input.platform },
     );
@@ -192,13 +188,13 @@ export class BackendClient extends BackendPlatformClient {
     const githubUserId = required(input.githubUserId, "githubUserId");
     const bearer = this.resolveBearer(input.bearer);
     const params = new URLSearchParams({ github_user_id: githubUserId });
-    if (input.visibilityGrant?.trim()) {
-      params.set("visibility_grant", input.visibilityGrant.trim());
-    }
     const raw = await this.get<Record<string, unknown>>(
       this.ownedProjectBasePath(input.projectId, params),
       "get_user_project",
       bearer,
+      input.visibilityGrant?.trim()
+        ? { "X-Aomi-Visibility-Grant": input.visibilityGrant.trim() }
+        : undefined,
     );
     await this.audit("get_user_project", input.actor, {
       projectId: input.projectId,

--- a/packages/deploy/src/types.ts
+++ b/packages/deploy/src/types.ts
@@ -485,7 +485,6 @@ export interface ExchangeGitHubCodeInput extends BearerOverride {
 export interface ClaimGitHubProjectInput extends BearerOverride {
   code: string;
   projectId: number;
-  app?: number;
   redirectUri?: string;
 }
 

--- a/packages/deploy/src/types.ts
+++ b/packages/deploy/src/types.ts
@@ -482,6 +482,18 @@ export interface ExchangeGitHubCodeInput extends BearerOverride {
   redirectUri?: string;
 }
 
+export interface ClaimGitHubProjectInput extends BearerOverride {
+  code: string;
+  projectId: number;
+  app?: number;
+  redirectUri?: string;
+}
+
+export interface ClaimGitHubProjectResult {
+  githubUserId: string;
+  project: UserProject;
+}
+
 export interface GitHubIdentity {
   githubUserId: string;
   githubLogin: string;
@@ -490,16 +502,20 @@ export interface GitHubIdentity {
    * Lets the portal skip the install step when the App is already installed.
    */
   installationId: string | null;
+  /** Opaque Manager-signed, 10-minute installation visibility snapshot. */
+  visibilityGrant?: string | null;
 }
 
 export interface ListUserProjectsInput extends BearerOverride {
   githubUserId: string;
   platform?: string;
+  visibilityGrant?: string;
 }
 
 export interface GetUserProjectInput extends BearerOverride {
   githubUserId: string;
   projectId: number;
+  visibilityGrant?: string;
 }
 
 export interface GetBuilderApplicationInput extends BearerOverride {


### PR DESCRIPTION
## Summary

Adds the Build-side flow for the GitHub App recovery work.

- store the Manager-signed visibility grant in a separate HTTP-only cookie
- forward the grant only for project read visibility
- add an explicit Claim operator access entry point from project settings
- perform the fresh OAuth/admin check only after the user clicks Claim

## Included upstream PRs

- #487 — installation/onboarding recovery and bfcache handling
- #489 — CI status, Promote blocking reason, and in-flight refresh behavior

## Related backend work

This PR pairs with product-mono `feat/zaki-github-app-recovery`, which includes #965, #966, #969 and the Manager-side Claim/grant/reconciliation implementation.

## Not included / rollout gated

- The #967 recovery path is not included until staging validates whether GitHub App configuration resolves the Configure/Update dead end.
- Staging E2E and production release remain separate operational steps.

## Validation

- `pnpm typecheck:aomi-build`
- `pnpm --filter @aomi-labs/deploy build`
- targeted GitHub callback, project-list, and operate BFF tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789310182&installation_model_id=12362&pr_number=495&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F495&signature=46ebace6668881d0c241986b166092fbbeb5d1141600bb6f58f4b3680f73ddc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->