### PR TITLE
fix(landing): isolate fumadocs and lazy-load the homepage demo

### DIFF
--- a/apps/landing/app/docs-ui.css
+++ b/apps/landing/app/docs-ui.css
@@ -1,0 +1,3 @@
+/* Leftover in-app docs (playground / examples). Marketing routes must not import this. */
+@import "fumadocs-ui/css/shadcn.css";
+@import "fumadocs-ui/css/preset.css";

--- a/apps/landing/app/docs-ui.css
+++ b/apps/landing/app/docs-ui.css
@@ -1,3 +1,6 @@
-/* Leftover in-app docs (playground / examples). Marketing routes must not import this. */
+/* Leftover in-app docs (playground / examples). Marketing routes must not import this.
+   Fumadocs CSS uses @apply; Tailwind must be present in this stylesheet entry or the
+   production build fails with "Cannot apply unknown utility class". */
+@import "tailwindcss";
 @import "fumadocs-ui/css/shadcn.css";
 @import "fumadocs-ui/css/preset.css";

--- a/apps/landing/app/examples/layout.tsx
+++ b/apps/landing/app/examples/layout.tsx
@@ -1,6 +1,8 @@
 import { DocsLayout } from "fumadocs-ui/layouts/notebook";
 import type { ReactNode } from "react";
 import { examples } from "@/lib/source";
+import { Provider } from "../provider";
+import "../docs-ui.css";
 import {
   baseLayoutOptions,
   navTabs,
@@ -9,14 +11,16 @@ import {
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <DocsLayout
-      {...baseLayoutOptions}
-      nav={{ ...baseLayoutOptions.nav, mode: "top" }}
-      tree={examples.pageTree}
-      tabMode="navbar"
-      sidebar={{ ...sharedSidebarOptions, tabs: navTabs }}
-    >
-      {children}
-    </DocsLayout>
+    <Provider>
+      <DocsLayout
+        {...baseLayoutOptions}
+        nav={{ ...baseLayoutOptions.nav, mode: "top" }}
+        tree={examples.pageTree}
+        tabMode="navbar"
+        sidebar={{ ...sharedSidebarOptions, tabs: navTabs }}
+      >
+        {children}
+      </DocsLayout>
+    </Provider>
   );
 }

--- a/apps/landing/app/globals.css
+++ b/apps/landing/app/globals.css
@@ -1,8 +1,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Playfair+Display:ital,wght@0,400;0,500;0,600;1,400&family=Geist:wght@300;400;500;600;700&family=PT+Serif:wght@400;700&display=swap");
 @import "tailwindcss";
 @import "tw-animate-css";
-@import "fumadocs-ui/css/shadcn.css";
-@import "fumadocs-ui/css/preset.css";
 @import "../../shadcn-registry/src/themes/default.css";
 
 /* Scan the npm package dist so Tailwind picks up component classes */

--- a/apps/landing/app/layout.tsx
+++ b/apps/landing/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { Source_Serif_4 } from "next/font/google";
 import "./globals.css";
-import { Provider } from "./provider";
 
 const sourceSerif = Source_Serif_4({
   subsets: ["latin"],
@@ -60,7 +59,7 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <body className={`${sourceSerif.variable} min-h-screen antialiased`}>
-        <Provider>{children}</Provider>
+        {children}
       </body>
       {GA_MEASUREMENT_ID && GA_MEASUREMENT_ID !== "G-XXXXXXXXXX" && (
         <GoogleAnalytics gaId={GA_MEASUREMENT_ID} />

--- a/apps/landing/app/playground/layout.tsx
+++ b/apps/landing/app/playground/layout.tsx
@@ -1,6 +1,8 @@
 import { DocsLayout } from "fumadocs-ui/layouts/notebook";
 import type { ReactNode } from "react";
 import { playground } from "@/lib/source";
+import { Provider } from "../provider";
+import "../docs-ui.css";
 import {
   baseLayoutOptions,
   navTabs,
@@ -9,22 +11,24 @@ import {
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <DocsLayout
-      {...baseLayoutOptions}
-      nav={{ ...baseLayoutOptions.nav, mode: "top" }}
-      tree={playground.pageTree}
-      tabMode="navbar"
-      sidebar={{
-        ...sharedSidebarOptions,
-        tabs: navTabs,
-        className: "!hidden",
-      }}
-      containerProps={{
-        style: { gridTemplateColumns: "0px 0px 1fr 0px 0px" },
-        className: "[&_article]:items-center",
-      }}
-    >
-      {children}
-    </DocsLayout>
+    <Provider>
+      <DocsLayout
+        {...baseLayoutOptions}
+        nav={{ ...baseLayoutOptions.nav, mode: "top" }}
+        tree={playground.pageTree}
+        tabMode="navbar"
+        sidebar={{
+          ...sharedSidebarOptions,
+          tabs: navTabs,
+          className: "!hidden",
+        }}
+        containerProps={{
+          style: { gridTemplateColumns: "0px 0px 1fr 0px 0px" },
+          className: "[&_article]:items-center",
+        }}
+      >
+        {children}
+      </DocsLayout>
+    </Provider>
   );
 }

--- a/apps/landing/app/provider.tsx
+++ b/apps/landing/app/provider.tsx
@@ -3,6 +3,7 @@
 import { RootProvider } from "fumadocs-ui/provider/next";
 import type { ReactNode } from "react";
 
+/** Docs-only. Keep this off marketing routes (`/`, `/v2`) so webpack does not load fumadocs-ui there. */
 export function Provider({ children }: { children: ReactNode }) {
   return <RootProvider>{children}</RootProvider>;
 }

--- a/apps/landing/app/sections/hero.tsx
+++ b/apps/landing/app/sections/hero.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useState, type CSSProperties } from "react";
-import { AomiFrame } from "@aomi-labs/widget-lib";
 import { AomiLogo } from "../components/aomi-logo";
-import { LandingWalletKitProvider } from "../components/landing-wallet-kit-provider";
-import styles from "./hero.module.css";
 
-const DEMO_BACKEND_URL = "/";
+const LegacyHumanDemo = dynamic(
+  () => import("./legacy-human-demo").then((mod) => mod.LegacyHumanDemo),
+  { ssr: false },
+);
 
 export function Hero() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -268,24 +269,7 @@ export function Hero() {
               id="terminal-container"
               className="mb-14 h-[680px] w-full max-w-[900px] origin-bottom-left transition-all duration-300"
             >
-              <LandingWalletKitProvider>
-                <AomiFrame.Root
-                  height="100%"
-                  width="100%"
-                  className={`${styles.demoFrame} aui-suggestions-marquee`}
-                  defaultSidebarOpen={false}
-                  walletPosition="footer"
-                  walletFamilies={["evm", "solana"]}
-                  backendUrl={DEMO_BACKEND_URL}
-                >
-                  <AomiFrame.Header />
-                  <AomiFrame.Composer
-                    withControl
-                    welcomeTitle="What should happen on-chain?"
-                    controlBarProps={{ hideApiKey: true, hideNetwork: false }}
-                  />
-                </AomiFrame.Root>
-              </LandingWalletKitProvider>
+              <LegacyHumanDemo />
             </div>
           ) : (
             <div className="mb-14 flex w-full justify-center">

--- a/apps/landing/app/sections/legacy-human-demo.tsx
+++ b/apps/landing/app/sections/legacy-human-demo.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Component, type ReactNode } from "react";
+import { AomiFrame } from "@aomi-labs/widget-lib";
+import { LandingWalletKitProvider } from "../components/landing-wallet-kit-provider";
+import styles from "./hero.module.css";
+
+const DEMO_BACKEND_URL = "/";
+
+class DemoErrorBoundary extends Component<
+  { children: ReactNode },
+  { error: Error | null }
+> {
+  state: { error: Error | null } = { error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="flex h-full min-h-[520px] w-full flex-col items-center justify-center gap-2 bg-white/10 px-6 text-center">
+          <p className="font-geist text-sm font-medium text-white">
+            Demo failed to load
+          </p>
+          <p className="font-geist max-w-md text-xs text-white/70">
+            {this.state.error.message || "Unknown error"}
+          </p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+/** Lazy-loaded so compiling `/` does not block the rest of the dev server. */
+export function LegacyHumanDemo() {
+  return (
+    <DemoErrorBoundary>
+      <LandingWalletKitProvider>
+        <AomiFrame.Root
+          height="100%"
+          width="100%"
+          className={`${styles.demoFrame} aui-suggestions-marquee`}
+          defaultSidebarOpen={false}
+          walletPosition="footer"
+          walletFamilies={["evm", "solana"]}
+          backendUrl={DEMO_BACKEND_URL}
+        >
+          <AomiFrame.Header />
+          <AomiFrame.Composer
+            withControl
+            welcomeTitle="What should happen on-chain?"
+            controlBarProps={{ hideApiKey: true, hideNetwork: false }}
+          />
+        </AomiFrame.Root>
+      </LandingWalletKitProvider>
+    </DemoErrorBoundary>
+  );
+}

--- a/apps/landing/next.config.ts
+++ b/apps/landing/next.config.ts
@@ -47,6 +47,7 @@ const turbopackAliases: Record<string, string> = {
 
 const nextConfig: NextConfig = {
   reactStrictMode: false,
+  distDir: process.env.NEXT_DIST_DIR || ".next",
   experimental: {
     externalDir: true,
   },

--- a/apps/landing/tsconfig.json
+++ b/apps/landing/tsconfig.json
@@ -60,7 +60,9 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts",
     "../../.next/types/**/*.ts",
-    "../../.next/dev/types/**/*.ts"
+    "../../.next/dev/types/**/*.ts",
+    ".next-webpack/types/**/*.ts",
+    ".next-webpack/dev/types/**/*.ts"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- Keep fumadocs-ui off `/` and `/v2` so webpack does not load that chunk on marketing routes.
- Lazy-load the live homepage AomiFrame so compiling `/` does not block `/v2`.
- Allow `NEXT_DIST_DIR` for local webpack dist folders.

Stacked under this: draft `/v2` preview PR (Visitors × v3). Independent: local widget proxy fallback.

## Test plan
- [ ] `pnpm --filter landing dev` then open `/` and `/playground` (docs still themed)
- [ ] Confirm `/` demo still renders after lazy load
- [ ] Confirm fumadocs CSS is not on `/`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789327795&installation_model_id=12362&pr_number=496&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F496&signature=e00c153047069d19baed670caf737e38ff42cfc505c9c402e45f8f879f2bbf1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->