### PR TITLE
fix(landing): fall back local widget proxy to production API

### DIFF
--- a/apps/landing/app/api/[...slug]/route.ts
+++ b/apps/landing/app/api/[...slug]/route.ts
@@ -129,6 +129,12 @@ export const { GET, POST, PUT, PATCH, DELETE } = createBackendProxy({
   allowedRoutes: ALLOWED_ROUTES,
   resolveCanonicalUserId: async () => null,
   applyDefaults: rewriteLegacyThreadPath,
+  // Local landing has no Rust backend, so the shared proxy's 127.0.0.1:8080
+  // default 502s the demo widget. Keep Vercel preview→staging and
+  // production→prod. Override anytime with AOMI_PROXY_BACKEND_URL.
+  upstreamBaseUrl:
+    process.env.AOMI_PROXY_BACKEND_URL ||
+    (process.env.VERCEL_ENV ? undefined : "https://api.aomi.dev"),
 });
 
 export const dynamic = "force-dynamic";


### PR DESCRIPTION
## Summary
- Local landing has no Rust backend, so the demo widget 502s against `127.0.0.1:8080`.
- Fall back to `https://api.aomi.dev` **only when not on Vercel**. Preview stays on staging; production stays on prod.
- Override anytime with `AOMI_PROXY_BACKEND_URL`.

Independent of the `/v2` stack.

## Test plan
- [ ] Local `/` or `/v2` widget `GET /api/thread/models` is not a 502 without a local backend
- [ ] Vercel preview still proxies to staging (no `upstreamBaseUrl` when `VERCEL_ENV` is set)
- [ ] `AOMI_PROXY_BACKEND_URL` still wins when set

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789327797&installation_model_id=12362&pr_number=497&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F497&signature=5bac5b538ba6f8c6179fb3b7aab7b1588e0c6689476eea5dd905319a1a5fcc02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->