### PR TITLE
fix(client): keep deployed prod routes in the backend contract

### DIFF
--- a/packages/client/test/client.unit.test.ts
+++ b/packages/client/test/client.unit.test.ts
@@ -11,7 +11,7 @@ describe("AomiClient route manifest", () => {
         `${endpoint.method} ${endpoint.path} [${endpoint.auth.join(", ")}]`,
     );
 
-    expect(routeKeys).toHaveLength(146);
+    expect(routeKeys).toHaveLength(155);
     expect(new Set(routeKeys).size).toBe(routeKeys.length);
     expect(routeKeys).toContain("GET /api/account/statement [account]");
     // Public placement probe. Kept distinct from GET /health, which stays a
@@ -62,6 +62,18 @@ describe("AomiClient route manifest", () => {
     );
     expect(routeKeys).toContain(
       "POST /api/platforms/:name/telegram/handover/:bot/:id/revoke [activation]",
+    );
+    // Routes production still serves that the candidate backend no longer
+    // exports. The promotion gate requires the manifest to cover every live
+    // route, so these stay until prod stops serving them.
+    expect(routeKeys).toContain("GET /api/secrets [thread]");
+    expect(routeKeys).toContain("POST /api/secrets [thread]");
+    expect(routeKeys).toContain("DELETE /api/secrets/:name [thread]");
+    expect(routeKeys).toContain(
+      "GET /api/widget/v1/execution-profile [account, thread]",
+    );
+    expect(routeKeys).toContain(
+      "PUT /api/widget/v1/aa-accounts/:chain_id [account, thread]",
     );
     expect(routeKeys).not.toContain("GET /api/control/apps [session]");
     expect(routeKeys.some((route) => route.includes("/api/control/"))).toBe(

--- a/packages/client/test/fixtures/backend-openapi.json
+++ b/packages/client/test/fixtures/backend-openapi.json
@@ -2176,6 +2176,165 @@
           "activation"
         ]
       }
+    },
+    "/api/widget/v1/execution-profile": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "accountBearer": [],
+            "threadId": []
+          }
+        ],
+        "x-aomi-auth": [
+          "account",
+          "thread"
+        ]
+      }
+    },
+    "/api/widget/v1/aa-accounts/{chain_id}": {
+      "put": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "accountBearer": [],
+            "threadId": []
+          }
+        ],
+        "x-aomi-auth": [
+          "account",
+          "thread"
+        ]
+      }
+    },
+    "/api/widget/v1/aa-operations/{operation_id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "accountBearer": [],
+            "threadId": []
+          }
+        ],
+        "x-aomi-auth": [
+          "account",
+          "thread"
+        ]
+      }
+    },
+    "/api/widget/v1/signing-requests": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "accountBearer": [],
+            "threadId": []
+          }
+        ],
+        "x-aomi-auth": [
+          "account",
+          "thread"
+        ]
+      }
+    },
+    "/api/widget/v1/signing-requests/{request_id}": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "accountBearer": [],
+            "threadId": []
+          }
+        ],
+        "x-aomi-auth": [
+          "account",
+          "thread"
+        ]
+      }
+    },
+    "/api/secrets": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "threadId": []
+          }
+        ],
+        "x-aomi-auth": [
+          "thread"
+        ]
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "threadId": []
+          }
+        ],
+        "x-aomi-auth": [
+          "thread"
+        ]
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "threadId": []
+          }
+        ],
+        "x-aomi-auth": [
+          "thread"
+        ]
+      }
+    },
+    "/api/secrets/{name}": {
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "threadId": []
+          }
+        ],
+        "x-aomi-auth": [
+          "thread"
+        ]
+      }
     }
   },
   "components": {
@@ -2206,6 +2365,7 @@
         "type": "http",
         "scheme": "bearer"
       }
-    }
+    },
+    "schemas": {}
   }
 }

--- a/packages/client/test/generated/backend-routes.ts
+++ b/packages/client/test/generated/backend-routes.ts
@@ -60,6 +60,16 @@ export const AOMI_BACKEND_ENDPOINTS = [
   },
   {
     method: "DELETE",
+    path: "/api/secrets",
+    auth: ["thread"],
+  },
+  {
+    method: "DELETE",
+    path: "/api/secrets/:name",
+    auth: ["thread"],
+  },
+  {
+    method: "DELETE",
     path: "/api/threads/:thread_id",
     auth: ["account","thread"],
   },
@@ -390,6 +400,11 @@ export const AOMI_BACKEND_ENDPOINTS = [
   },
   {
     method: "GET",
+    path: "/api/secrets",
+    auth: ["thread"],
+  },
+  {
+    method: "GET",
     path: "/api/skills",
     auth: [],
   },
@@ -431,6 +446,21 @@ export const AOMI_BACKEND_ENDPOINTS = [
   {
     method: "GET",
     path: "/api/threads/:thread_id",
+    auth: ["account","thread"],
+  },
+  {
+    method: "GET",
+    path: "/api/widget/v1/aa-operations/:operation_id",
+    auth: ["account","thread"],
+  },
+  {
+    method: "GET",
+    path: "/api/widget/v1/execution-profile",
+    auth: ["account","thread"],
+  },
+  {
+    method: "GET",
+    path: "/api/widget/v1/signing-requests",
     auth: ["account","thread"],
   },
   {
@@ -670,6 +700,11 @@ export const AOMI_BACKEND_ENDPOINTS = [
   },
   {
     method: "POST",
+    path: "/api/secrets",
+    auth: ["thread"],
+  },
+  {
+    method: "POST",
     path: "/api/system",
     auth: ["account","thread"],
   },
@@ -709,6 +744,11 @@ export const AOMI_BACKEND_ENDPOINTS = [
     auth: ["account","thread"],
   },
   {
+    method: "POST",
+    path: "/api/widget/v1/signing-requests/:request_id",
+    auth: ["account","thread"],
+  },
+  {
     method: "PUT",
     path: "/api/account/apps",
     auth: ["account"],
@@ -732,5 +772,10 @@ export const AOMI_BACKEND_ENDPOINTS = [
     method: "PUT",
     path: "/api/integrations/github-app/user/model-keys/:key_id/grants",
     auth: ["service"],
+  },
+  {
+    method: "PUT",
+    path: "/api/widget/v1/aa-accounts/:chain_id",
+    auth: ["account","thread"],
   },
 ] as const satisfies readonly AomiEndpointSpec[];


### PR DESCRIPTION
Unblocks the `Production Promotion Policy` gate on #502.

## What was failing

That gate's last step runs the client route contract against the **deployed**
production API (`https://api.aomi.dev/api/openapi.json`) and requires the client
route manifest to cover every route production actually serves. It failed on
four routes at CI time, and nine as of now — prod gained the widget routes in
between:

- `GET`/`POST`/`DELETE /api/secrets` and `DELETE /api/secrets/{name}` `[thread]`
- `GET /api/widget/v1/execution-profile`, `GET /api/widget/v1/signing-requests`,
  `POST /api/widget/v1/signing-requests/{request_id}`,
  `GET /api/widget/v1/aa-operations/{operation_id}`,
  `PUT /api/widget/v1/aa-accounts/{chain_id}` — all `[account, thread]`

`46b0832f` ("Enforce strict Project V2 frontend contract") dropped the
`/api/secrets` routes from the fixture and manifest, undoing `86983eb1` ("Keep
deployed OpenAPI baseline during rollout"), which had kept them for exactly this
gate. The widget routes were never exported into the fixture.

## What this does

Unions the checked-in contract with the live production document instead of
regenerating from it, so the candidate-only surface survives — notably
`POST /api/aa/v1/{chain_slug}`, which a straight regenerate would have deleted.

- no `x-aomi-auth` conflicts between the two documents
- every added operation's schemas were already present, so no dangling `$ref`s
- `packages/client/test/fixtures/manager-openapi.json` is untouched; the manager
  half still exports exactly 61 operations
- manifest count assertion moves 146 → 155, with the restored routes named
  explicitly and a note on why they stay

## Verification

- `pnpm run test:openapi` — passes
- `NEXT_PUBLIC_BACKEND_URL=https://api.aomi.dev pnpm run test:openapi:live` — passes (this is the gate that was red)
- `pnpm exec vitest run` — 211 files, 1491 tests pass
- `pnpm run lint` (0 errors) and `pnpm run typecheck` — clean

Lands on `main` first because the promotion policy requires the release head to
be an ancestor of `main`; `release/2026-08-18` fast-forwards here afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789659128&installation_model_id=12362&pr_number=503&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F503&signature=e74db381e6289d33db322696fc2266a90840bd1803b72f4d1a4571dc48115706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->