### PR TITLE
ci(release): verify published manifests carry no workspace: protocol

### DIFF
--- a/packages/client/test/publish-package-if-needed.test.mjs
+++ b/packages/client/test/publish-package-if-needed.test.mjs
@@ -9,13 +9,20 @@ const packageManifest = JSON.parse(
 );
 const packageSpec = `${packageManifest.name}@${packageManifest.version}`;
 
+// Registry manifest response for the post-publish verification fetch.
+const manifestResponse = (manifest = {}) =>
+  new Response(JSON.stringify(manifest), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+
 describe("publishPackageIfNeeded", () => {
   it("skips an exact version that is already published", async () => {
     const publishImpl = vi.fn();
 
     await expect(
       publishPackageIfNeeded(packageDirectory, {
-        fetchImpl: vi.fn(async () => new Response(null, { status: 200 })),
+        fetchImpl: vi.fn(async () => manifestResponse()),
         publishImpl,
       }),
     ).resolves.toBe("skipped");
@@ -28,7 +35,10 @@ describe("publishPackageIfNeeded", () => {
 
     await expect(
       publishPackageIfNeeded(packageDirectory, {
-        fetchImpl: vi.fn(async () => new Response(null, { status: 404 })),
+        fetchImpl: vi
+          .fn()
+          .mockResolvedValueOnce(new Response(null, { status: 404 }))
+          .mockResolvedValueOnce(manifestResponse()),
         publishImpl,
       }),
     ).resolves.toBe("published");
@@ -58,7 +68,8 @@ describe("publishPackageIfNeeded", () => {
     const fetchImpl = vi
       .fn()
       .mockResolvedValueOnce(new Response(null, { status: 404 }))
-      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(manifestResponse());
 
     await expect(
       publishPackageIfNeeded(packageDirectory, {
@@ -69,7 +80,47 @@ describe("publishPackageIfNeeded", () => {
       }),
     ).resolves.toBe("published");
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  // The 2.0.0 incident, encoded: a publish that reaches the registry with
+  // workspace-protocol dependencies must FAIL the job even though npm
+  // accepted the upload — the artifact is unusable and immutable, and the
+  // operator needs to know while a bump-and-republish is still cheap.
+  it("fails after publish when the registry manifest still carries workspace:*", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(
+        manifestResponse({
+          dependencies: { "@aomi-labs/react": "workspace:*" },
+        }),
+      );
+
+    await expect(
+      publishPackageIfNeeded(packageDirectory, {
+        fetchImpl,
+        publishImpl: vi.fn(async () => undefined),
+      }),
+    ).rejects.toThrow(/workspace-protocol dependencies/);
+  });
+
+  it("flags a workspace:* range in any dependency field", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(
+        manifestResponse({
+          peerDependencies: { "@aomi-labs/client": "workspace:^" },
+        }),
+      );
+
+    await expect(
+      publishPackageIfNeeded(packageDirectory, {
+        fetchImpl,
+        publishImpl: vi.fn(async () => undefined),
+      }),
+    ).rejects.toThrow(/peerDependencies.@aomi-labs\/client=workspace:\^/);
   });
 
   // Regression guard for the 2.0.0 release: publishing moved to `npm publish`

--- a/scripts/publish-package-if-needed.mjs
+++ b/scripts/publish-package-if-needed.mjs
@@ -30,6 +30,7 @@ export async function publishPackageIfNeeded(
 
   if (await isPublished()) {
     console.log(`${packageSpec} is already published; skipping.`);
+    await verifyPublishedManifest({ fetchImpl, packageSpec, versionUrl });
     return "skipped";
   }
 
@@ -42,11 +43,55 @@ export async function publishPackageIfNeeded(
     // state as authoritative before failing the job.
     if (await isPublished()) {
       console.log(`${packageSpec} is now published; continuing.`);
+      await verifyPublishedManifest({ fetchImpl, packageSpec, versionUrl });
       return "published";
     }
     throw error;
   }
+  await verifyPublishedManifest({ fetchImpl, packageSpec, versionUrl });
   return "published";
+}
+
+// A green publish is not proof of a usable package: on 2026-08-14,
+// widget-lib@2.0.0 and react@0.6.0 shipped with `workspace:*` dependencies
+// intact (npm-transport publish skipped pnpm's rewrite) and both runs passed.
+// Published versions are immutable, so the only cheap place to catch this is
+// immediately after the registry write — read the manifest BACK from the
+// registry and fail the job on any workspace-protocol dependency, while the
+// operator can still bump and republish in the same sitting.
+async function verifyPublishedManifest({ fetchImpl, packageSpec, versionUrl }) {
+  const response = await fetchImpl(versionUrl, {
+    headers: { accept: "application/json" },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Post-publish verification for ${packageSpec} failed: registry returned HTTP ${response.status}`,
+    );
+  }
+  const manifest = await response.json();
+  const offenders = [];
+  for (const field of [
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+  ]) {
+    for (const [name, range] of Object.entries(manifest[field] ?? {})) {
+      if (String(range).includes("workspace:")) {
+        offenders.push(`${field}.${name}=${range}`);
+      }
+    }
+  }
+  if (offenders.length > 0) {
+    throw new Error(
+      `${packageSpec} is published with unresolvable workspace-protocol dependencies ` +
+        `(${offenders.join(", ")}). npm/yarn consumers cannot install it. ` +
+        `Published versions are immutable: bump the version, publish through pnpm ` +
+        `(which rewrites workspace:*), and deprecate this one.`,
+    );
+  }
+  console.log(`${packageSpec} verified on the registry: no workspace-protocol dependencies.`);
 }
 
 async function checkPublishedVersion({ fetchImpl, packageSpec, versionUrl }) {


### PR DESCRIPTION
## What changed

After every publish (and on the skip/concurrent paths), `publish-package-if-needed.mjs` reads the manifest **back from the registry** and fails the job if any dependency field carries the pnpm `workspace:` protocol. Two new tests encode the incident; existing tests updated for the verification fetch.

## Why

On 2026-08-14, `widget-lib@2.0.0` and `react@0.6.0` shipped with `workspace:*` dependencies intact — unresolvable by npm/yarn — and **both publish runs were green**. Published versions are immutable, so the cheapest possible catch is immediately after the registry write, while a bump-and-republish costs minutes (#494 was the cleanup). This closes the class: a green publish now proves the artifact is installable, not just that npm accepted the upload.

## Validation

- 7/7 tests in `packages/client/test/publish-package-if-needed.test.mjs`
- Failure message names the offending field/dep and the remediation (bump, republish via pnpm, deprecate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789714315&installation_model_id=12362&pr_number=505&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F505&signature=aa4d59d26255138267a691a18f170f6275bfd9f30ca06f4556da8a03388144f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->