### PR TITLE
Reuse the built release instead of asking for a second deploy

### DIFF
--- a/apps/build/src/features/launch/components/deployments/tabs/deployments-tab.test.tsx
+++ b/apps/build/src/features/launch/components/deployments/tabs/deployments-tab.test.tsx
@@ -482,6 +482,105 @@ describe("DeploymentsTab", () => {
     expect(openEnvironment).toHaveBeenCalledOnce();
   });
 
+  it("offers to activate a built release without a second build", async () => {
+    const activateBuiltRelease = vi.fn(async () => {});
+    const built = {
+      ...makeDetail(),
+      // Built, and nothing live — what a required-secrets rejection leaves.
+      source: {
+        id: 1,
+        repositoryLink: "a/b",
+        apps: [{ name: "my-bot", isActive: false, appReleaseTag: null }],
+      },
+      builtRelease: { releaseTags: ["t-new"], apps: ["my-bot"] },
+      activateBuiltRelease,
+    } as unknown as typeof detail;
+
+    renderTab(<DeploymentsTab detail={built} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /activate build/i }));
+    await waitFor(() => expect(activateBuiltRelease).toHaveBeenCalledOnce());
+    expect(built.redeploySource).not.toHaveBeenCalled();
+  });
+
+  it("resumes the promotion the secrets gate rejected, reusing the build", async () => {
+    // The client-side gate passes and the authoritative write-time check is
+    // what rejects — the case that used to send a builder back to a rebuild.
+    const gated = vi.fn(async () => {
+      throw Object.assign(new Error("missing required secrets"), {
+        status: 409,
+        body: { missing: { "my-bot": ["PROVIDER_API_KEY"] } },
+      });
+    });
+    const noteMissingRequiredSecrets = vi.fn();
+    const setEnvVars = vi.fn(async () => ({ ok: true, keys: [] }));
+    const ensureRequiredSecrets = vi.fn(async () => {});
+    const base = {
+      ...makeDetail(),
+      promote: gated,
+      noteMissingRequiredSecrets,
+      setEnvVars,
+      ensureRequiredSecrets,
+    } as unknown as typeof detail;
+
+    const { rerender } = renderTab(<DeploymentsTab detail={base} />);
+    fireEvent.click(screen.getByRole("button", { name: /promote/i }));
+    const dialog = screen.getByRole("dialog", { name: /promote deployment/i });
+    fireEvent.click(within(dialog).getByRole("button", { name: /promote/i }));
+
+    await waitFor(() =>
+      expect(noteMissingRequiredSecrets).toHaveBeenCalledWith({
+        "my-bot": ["PROVIDER_API_KEY"],
+      }),
+    );
+    expect(
+      screen.getByText(/Set them below and this promotion resumes/),
+    ).toBeInTheDocument();
+
+    // The hook now reports the key the gate named. Re-render with it so the
+    // panel appears, exactly as `noteMissingRequiredSecrets` causes.
+    const succeeding = vi.fn(async () => ({
+      ok: true,
+      promote: {
+        deploymentId: "dep_1_ra_oldcommit1",
+        releaseTags: ["t-old"],
+        status: "promoted",
+      },
+    }));
+    const withGap = {
+      ...base,
+      promote: succeeding,
+      hasMissingSecrets: (app: string) => app === "my-bot",
+      requiredSecrets: {
+        "my-bot": {
+          applicationId: 17,
+          slots: [{ name: "PROVIDER_API_KEY", required: true }],
+          missing: ["PROVIDER_API_KEY"],
+        },
+      },
+    } as unknown as typeof detail;
+    rerender(
+      <ToastProvider>
+        <DeploymentsTab detail={withGap} />
+      </ToastProvider>,
+    );
+
+    fireEvent.change(screen.getByLabelText("my-bot PROVIDER_API_KEY"), {
+      target: { value: "sk-live" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save required secrets" }),
+    );
+
+    await waitFor(() => expect(succeeding).toHaveBeenCalledOnce());
+    expect(setEnvVars).toHaveBeenCalledWith(17, {
+      PROVIDER_API_KEY: "sk-live",
+    });
+    // Saving the key resumes the promotion and never reaches for the source
+    // repo — the release CI already built is what goes live.
+    expect(base.redeploySource).not.toHaveBeenCalled();
+  });
+
   it("retries a failed required-secret check without refreshing the page", async () => {
     const refreshRequiredSecrets = vi.fn(async () => ({}));
     const failedDetail = {

--- a/apps/build/src/features/launch/components/deployments/tabs/deployments-tab.tsx
+++ b/apps/build/src/features/launch/components/deployments/tabs/deployments-tab.tsx
@@ -46,6 +46,10 @@ export function DeploymentsTab({
   const [pending, setPending] = useState<Pending>(null);
   const [view, setView] = useState<View>("deployments");
   const [expandedDetail, setExpandedDetail] = useState<string | null>(null);
+  // A promote the secrets gate rejected. Its release is already built and the
+  // gate's only complaint was a vault value, so once that value is saved the
+  // same promote can simply run — the user asked for it once already.
+  const [blockedPromoteId, setBlockedPromoteId] = useState<string | null>(null);
   const { loadHistory, loadRecords, loadRequiredSecrets } = detail;
 
   useEffect(() => {
@@ -208,17 +212,6 @@ export function DeploymentsTab({
       })),
   );
 
-  const saveRequiredSecrets = async (
-    valuesByApplication: Map<number, Record<string, string>>,
-  ) => {
-    await Promise.all(
-      Array.from(valuesByApplication, ([applicationId, values]) =>
-        detail.setEnvVars?.(applicationId, values),
-      ),
-    );
-    await detail.ensureRequiredSecrets?.(missingRequiredApps);
-  };
-
   if (!source) {
     return detail.loading ? (
       <LoadingPanel label="Loading project…" />
@@ -242,6 +235,7 @@ export function DeploymentsTab({
     });
     try {
       const result = await detail.promote(deploymentId);
+      setBlockedPromoteId(null);
       setOp({
         kind: "promote",
         deploymentId,
@@ -259,13 +253,16 @@ export function DeploymentsTab({
     } catch (err) {
       const missing = (err as { body?: { missing?: Record<string, string[]> } })
         .body?.missing;
-      if (missing) detail.noteMissingRequiredSecrets(missing);
+      if (missing) {
+        detail.noteMissingRequiredSecrets(missing);
+        setBlockedPromoteId(deploymentId);
+      }
       setOp({
         kind: "promote",
         deploymentId,
         status: "error",
         message: missing
-          ? "Required secrets are missing. Set them below before promoting."
+          ? "Required secrets are missing. Set them below and this promotion resumes — the build is reused."
           : err instanceof Error
             ? err.message
             : "Promote failed",
@@ -303,6 +300,35 @@ export function DeploymentsTab({
       toast({ title: "Failed. Retry", tone: "error" });
     }
   };
+
+  const saveRequiredSecrets = async (
+    valuesByApplication: Map<number, Record<string, string>>,
+  ) => {
+    await Promise.all(
+      Array.from(valuesByApplication, ([applicationId, values]) =>
+        detail.setEnvVars?.(applicationId, values),
+      ),
+    );
+    await detail.ensureRequiredSecrets?.(missingRequiredApps);
+    // The gate is clear, so finish what it interrupted. Only a promote the
+    // user already requested resumes on its own: activating is cheap but it
+    // makes an app live, which must never be a side effect of saving a key.
+    if (blockedPromoteId) {
+      const resume = blockedPromoteId;
+      setBlockedPromoteId(null);
+      await runPromote(resume);
+    }
+  };
+
+  const activateBuild = async () => {
+    setOp(null);
+    await detail.activateBuiltRelease();
+  };
+
+  // Offered only when a built release is actually waiting: `builtRelease` is
+  // derived from the project's own latest deployment, so it survives the
+  // reload that a gate rejection used to strand.
+  const canActivateBuild = Boolean(detail.builtRelease) && !status?.isLive;
 
   const historyCountLabel =
     deployments.length === 1
@@ -374,6 +400,18 @@ export function DeploymentsTab({
             >
               <PowerOff className="size-3.5" aria-hidden />
               Deactivate
+            </button>
+          )}
+          {canActivateBuild && (
+            <button
+              type="button"
+              disabled={deploying || secretsGateBlocked}
+              onClick={() => void activateBuild()}
+              className="border-border bg-surface-1 text-foreground hover:bg-accent-hover inline-flex h-9 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border px-2.5 text-xs font-medium disabled:cursor-not-allowed disabled:opacity-50"
+              title="Activate the release CI already built — no second build"
+            >
+              <Rocket className="size-3.5" aria-hidden />
+              {deploying ? "Activating…" : "Activate build"}
             </button>
           )}
           <div className="flex flex-col items-end gap-0.5">

--- a/apps/build/src/features/launch/components/deployments/tabs/home-tab.test.tsx
+++ b/apps/build/src/features/launch/components/deployments/tabs/home-tab.test.tsx
@@ -7,16 +7,19 @@ const loadSecrets = vi.fn();
 const loadRequiredSecrets = vi.fn();
 const operateFetch = vi.fn();
 
+const emptyLifecycle = {
+  kind: "empty",
+  repo: "a/b",
+  statusLabel: "No deployment",
+  statusTone: "muted",
+  message: "No deployment recorded yet.",
+  appNames: [],
+  releaseTags: [],
+};
+let lifecycle: Record<string, unknown> = { ...emptyLifecycle };
+
 vi.mock("@aomi-labs/deploy/lifecycle", () => ({
-  deploymentLifecycleFromProject: () => ({
-    kind: "empty",
-    repo: "a/b",
-    statusLabel: "No deployment",
-    statusTone: "muted",
-    message: "No deployment recorded yet.",
-    appNames: [],
-    releaseTags: [],
-  }),
+  deploymentLifecycleFromProject: () => lifecycle,
 }));
 
 vi.mock("@build/features/operate/client", () => ({
@@ -67,6 +70,7 @@ describe("HomeTab", () => {
     operateFetch.mockResolvedValue({ daily: [] });
     (detail.source as { apps: unknown[] }).apps = [];
     (detail as { requiredSecrets: unknown }).requiredSecrets = null;
+    lifecycle = { ...emptyLifecycle };
   });
 
   it("shows status cards and a deploy next action when not live", async () => {
@@ -94,6 +98,67 @@ describe("HomeTab", () => {
       "/operate/usage?project=1",
     );
     expect(screen.queryByText("Monetization")).not.toBeInTheDocument();
+  });
+
+  it("offers to activate a built release rather than build it again", async () => {
+    lifecycle = {
+      ...emptyLifecycle,
+      kind: "build_ready",
+      statusLabel: "Build ready",
+      appNames: ["somm-agent"],
+      releaseTags: ["somm-agent-r1"],
+    };
+
+    renderTab(
+      <HomeTab detail={detail} tabHref={(tab) => `/projects/1?tab=${tab}`} />,
+    );
+
+    expect(
+      await screen.findByRole("link", { name: /activate build/i }),
+    ).toHaveAttribute("href", "/projects/1?tab=deployments");
+    expect(screen.getByText(/no rebuild needed/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /redeploy from linked repository/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("sends a blocked built release to Environment, not to another build", async () => {
+    lifecycle = {
+      ...emptyLifecycle,
+      kind: "build_ready",
+      statusLabel: "Build ready",
+      appNames: ["somm-agent"],
+      releaseTags: ["somm-agent-r1"],
+    };
+    (detail.source as { apps: unknown[] }).apps = [
+      { id: 17, name: "somm-agent" },
+    ];
+    (detail as { requiredSecrets: unknown }).requiredSecrets = {
+      "somm-agent": {
+        applicationId: 17,
+        slots: [{ name: "OPENAI_API_KEY" }],
+        missing: ["OPENAI_API_KEY"],
+      },
+    };
+
+    renderTab(
+      <HomeTab detail={detail} tabHref={(tab) => `/projects/1?tab=${tab}`} />,
+    );
+
+    // The next action and the environment status card both read "Open
+    // Environment" here; the copy is what identifies the next action.
+    const next = await screen.findByText(
+      /The build is ready and will be reused/,
+    );
+    expect(next).toBeInTheDocument();
+    for (const link of screen.getAllByRole("link", {
+      name: /open environment/i,
+    })) {
+      expect(link).toHaveAttribute("href", "/projects/1?tab=environment");
+    }
+    expect(
+      screen.queryByRole("link", { name: /redeploy from linked repository/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("warns with the app and key names when a required key is unset", async () => {

--- a/apps/build/src/features/launch/components/deployments/tabs/home-tab.tsx
+++ b/apps/build/src/features/launch/components/deployments/tabs/home-tab.tsx
@@ -297,30 +297,46 @@ export function HomeTab({
           label: `Upgrade to ${requiredSdk}`,
           copy: "Update the linked repository before opening chat.",
         }
-      : !isLive
-        ? {
-            href: hrefForTab("deployments"),
-            label: "Redeploy from Linked Repository",
-            copy: "Publish a deployment, then set keys and open chat.",
-          }
-        : environment.blocked
+      : // A built release is waiting. Activating it takes seconds and reuses
+        // the artifact CI already published; secret values live in the vault,
+        // never in the build, so a missing key cannot invalidate it. Ask for
+        // the keys first, then activate — never send this state to a rebuild.
+        lifecycle.kind === "build_ready"
+        ? environment.blocked
           ? {
               href: hrefForTab("environment"),
               label: "Open Environment",
-              copy: environment.hint,
+              copy: `${environment.hint} The build is ready and will be reused.`,
             }
-          : chatUrl
+          : {
+              href: hrefForTab("deployments"),
+              label: "Activate build",
+              copy: "This build is ready. Activate it to go live — no rebuild needed.",
+            }
+        : !isLive
+          ? {
+              href: hrefForTab("deployments"),
+              label: "Redeploy from Linked Repository",
+              copy: "Publish a deployment, then set keys and open chat.",
+            }
+          : environment.blocked
             ? {
-                href: chatUrl,
-                label: "Open Chat",
-                copy: "App is live and keys look set. Try it in chat.",
-                external: true,
+                href: hrefForTab("environment"),
+                label: "Open Environment",
+                copy: environment.hint,
               }
-            : {
-                href: hrefForTab("chat"),
-                label: "Open Chat tab",
-                copy: "Continue in the Chat tab.",
-              };
+            : chatUrl
+              ? {
+                  href: chatUrl,
+                  label: "Open Chat",
+                  copy: "App is live and keys look set. Try it in chat.",
+                  external: true,
+                }
+              : {
+                  href: hrefForTab("chat"),
+                  label: "Open Chat tab",
+                  copy: "Continue in the Chat tab.",
+                };
 
   return (
     <div className="divide-border divide-y">
@@ -416,7 +432,8 @@ export function HomeTab({
             >
               {nextAction.label.startsWith("Upgrade to ") ? (
                 <CircleArrowUp className="size-3.5" aria-hidden />
-              ) : nextAction.label === "Redeploy from Linked Repository" ? (
+              ) : nextAction.label === "Redeploy from Linked Repository" ||
+                nextAction.label === "Activate build" ? (
                 <Rocket className="size-3.5" aria-hidden />
               ) : nextAction.label === "Open Environment" ? (
                 <KeyRound className="size-3.5" aria-hidden />

--- a/apps/build/src/features/launch/hooks/use-project-detail.test.ts
+++ b/apps/build/src/features/launch/hooks/use-project-detail.test.ts
@@ -367,6 +367,13 @@ describe("useProjectDetail", () => {
         message: expect.stringContaining("Set them in Environment"),
       }),
     );
+    // CI already published this release, and the secret the gate wants lives
+    // in the vault rather than in the artifact — so the build stays correct.
+    // Asking for another deploy would rebuild it for nothing.
+    expect(result.current.deployFlow.message).toContain(
+      "activate — the build is already done",
+    );
+    expect(result.current.deployFlow.message).not.toContain("deploy again");
     expect(result.current.requiredSecrets?.["my-bot"]).toMatchObject({
       applicationId: 17,
       missing: ["PROVIDER_API_KEY"],
@@ -397,5 +404,114 @@ describe("useProjectDetail", () => {
         "aomi-build:project:7:candidate-required-secrets",
       ),
     ).toBeNull();
+  });
+
+  it("activates a release CI already built instead of deploying again", async () => {
+    // A project whose latest deployment built and never went live — the state
+    // a required-secrets 409 leaves behind. It is read from the project itself,
+    // so it outlives the tab that hit the gate.
+    vi.mocked(deploymentProjects).mockResolvedValue({
+      projects: [
+        {
+          id: 7,
+          installationId: 5,
+          repositoryLink: "a/b",
+          platformName: "community",
+          apps: [{ id: 17, name: "my-bot", isActive: false }],
+          latestDeployment: {
+            deploymentId: "dep_1",
+            state: "ready",
+            ciStatus: "passed",
+            releaseTags: ["my-bot-r1"],
+            apps: [{ name: "my-bot", applicationId: 17, isActive: false }],
+            createdAt: 1,
+          },
+        },
+      ],
+    } as never);
+    vi.mocked(deploymentRequiredSecrets).mockResolvedValue({ byApp: {} });
+    vi.mocked(launchActivate).mockResolvedValue({
+      ok: true,
+      activation: {
+        apps: [{ name: "my-bot", applicationId: 17, loaded: true }],
+      },
+    } as never);
+
+    const { result } = renderHook(() => useProjectDetail(7), {
+      wrapper: wrapper(),
+    });
+    await waitFor(() =>
+      expect(result.current.builtRelease).toEqual({
+        releaseTags: ["my-bot-r1"],
+        apps: ["my-bot"],
+      }),
+    );
+
+    await act(async () => {
+      await result.current.activateBuiltRelease();
+    });
+
+    expect(launchActivate).toHaveBeenCalledWith({
+      projectId: 7,
+      releaseTags: ["my-bot-r1"],
+      apps: ["my-bot"],
+    });
+    // The whole point: the existing artifact goes live with no second build.
+    expect(launchDeploy).not.toHaveBeenCalled();
+    expect(launchPreflight).not.toHaveBeenCalled();
+    expect(launchStatus).not.toHaveBeenCalled();
+    expect(result.current.deployFlow).toMatchObject({
+      phase: "done",
+      message: "New version is live.",
+    });
+  });
+
+  it("re-gates an activation of a built release and keeps its key names", async () => {
+    vi.mocked(deploymentProjects).mockResolvedValue({
+      projects: [
+        {
+          id: 7,
+          installationId: 5,
+          repositoryLink: "a/b",
+          platformName: "community",
+          apps: [{ id: 17, name: "my-bot", isActive: false }],
+          latestDeployment: {
+            deploymentId: "dep_1",
+            state: "ready",
+            ciStatus: "passed",
+            releaseTags: ["my-bot-r1"],
+            apps: [{ name: "my-bot", applicationId: 17, isActive: false }],
+            createdAt: 1,
+          },
+        },
+      ],
+    } as never);
+    vi.mocked(deploymentRequiredSecrets).mockResolvedValue({ byApp: {} });
+    vi.mocked(launchActivate).mockRejectedValue(
+      Object.assign(new Error("missing required secrets"), {
+        status: 409,
+        body: { missing: { "my-bot": ["PROVIDER_API_KEY"] } },
+      }),
+    );
+
+    const { result } = renderHook(() => useProjectDetail(7), {
+      wrapper: wrapper(),
+    });
+    await waitFor(() => expect(result.current.builtRelease).not.toBeNull());
+
+    await act(async () => {
+      await result.current.activateBuiltRelease();
+    });
+
+    // Still a gate, and still no rebuild in the instruction.
+    expect(result.current.deployFlow).toMatchObject({
+      phase: "error",
+      message: expect.stringContaining("then activate"),
+    });
+    expect(result.current.requiredSecrets?.["my-bot"]).toMatchObject({
+      applicationId: 17,
+      missing: ["PROVIDER_API_KEY"],
+    });
+    expect(launchDeploy).not.toHaveBeenCalled();
   });
 });

--- a/apps/build/src/features/launch/hooks/use-project-detail.ts
+++ b/apps/build/src/features/launch/hooks/use-project-detail.ts
@@ -30,6 +30,7 @@ import {
   waitForAppsToLoad,
   waitForDeploymentReady,
 } from "@aomi-labs/deploy/launch";
+import { deploymentLifecycleFromProject } from "@aomi-labs/deploy/lifecycle";
 import {
   MissingRequiredSecretsError,
   missingRequiredSecrets,
@@ -598,6 +599,165 @@ export function useProjectDetail(projectId: number) {
     [projectId],
   );
 
+  /**
+   * Activate a release CI has already published — the last leg of a deploy,
+   * and the whole of a resume.
+   *
+   * Secret values live in the Manager's vault and are read per turn; a release
+   * only declares the slot *names* it needs. So a release the gate rejected for
+   * a missing secret becomes activatable the moment that value is saved, with
+   * the same artifact and no second build. Resolves `true` once the release is
+   * live, `false` when it set an error state the caller should stop on.
+   */
+  const runActivation = useCallback(
+    async (input: {
+      targetProjectId: number;
+      releaseTags: string[];
+      apps: string[];
+      controller: AbortController;
+      isCurrent: () => boolean;
+    }): Promise<boolean> => {
+      const { targetProjectId, releaseTags, apps, controller, isCurrent } =
+        input;
+      setDeployFlow({ phase: "activating", message: "Activating release…" });
+      const activated = await launchActivate({
+        projectId: targetProjectId,
+        releaseTags,
+        apps,
+      });
+      if (!isCurrent()) return false;
+      // A rejected/partial activation still returns apps (with `error` set), and
+      // a malformed response may omit `activation` entirely — surface the real
+      // reason instead of throwing into the generic "Deploy failed" catch.
+      const activatedApps = activated.activation?.apps ?? [];
+      const failed = activatedApps.find((app) => app.error);
+      if (!activated.ok || failed) {
+        setDeployFlow({
+          phase: "error",
+          message: failed?.error ?? "Activation was not accepted.",
+        });
+        return false;
+      }
+      if (apps.length > 0 && activatedApps.length === 0) {
+        setDeployFlow({
+          phase: "error",
+          message: "Activation returned no application statuses.",
+        });
+        return false;
+      }
+      const unloaded = activatedApps.filter((app) => !app.loaded);
+      if (unloaded.length > 0) {
+        setDeployFlow({
+          phase: "activating",
+          message: "Loading app runtime…",
+        });
+        try {
+          await waitForAppsToLoad(
+            () => launchAppsStatus({ projectId: targetProjectId }),
+            unloaded.map((app) => ({
+              name: app.name,
+              releaseTag: app.releaseTag ?? undefined,
+            })),
+            {
+              signal: controller.signal,
+              intervalMs: DEPLOY_POLL_MS,
+              timeoutMs: RUNTIME_READY_TIMEOUT_MS,
+              isFatal: isFatalLaunchRequestError,
+              onProgress: ({ ready, total }) => {
+                if (isCurrent()) {
+                  setDeployFlow({
+                    phase: "activating",
+                    message: `Loading app runtime… (${ready}/${total})`,
+                  });
+                }
+              },
+            },
+          );
+        } catch (err) {
+          if (controller.signal.aborted) return false;
+          throw err;
+        }
+        if (!isCurrent()) return false;
+      }
+      return true;
+    },
+    [],
+  );
+
+  /**
+   * The candidate release the last deploy published, when it is built and not
+   * yet live. Server-derived, so it survives the reload that a 409 gate used to
+   * strand: the tags come from the project's own latest deployment, not from
+   * whatever this tab happened to hold in memory.
+   */
+  const builtRelease = useMemo(() => {
+    if (!source) return null;
+    const lifecycle = deploymentLifecycleFromProject(source);
+    if (lifecycle.kind !== "build_ready") return null;
+    if (lifecycle.releaseTags.length === 0 || lifecycle.appNames.length === 0) {
+      return null;
+    }
+    return { releaseTags: lifecycle.releaseTags, apps: lifecycle.appNames };
+  }, [source]);
+
+  /**
+   * Make the already-built release live. This is the correct recovery from a
+   * required-secrets 409 — the build is finished and unaffected by the secret
+   * that was missing, so re-running CI would produce the same artifact.
+   */
+  const activateBuiltRelease = useCallback(async () => {
+    const requestEpoch = projectEpochRef.current;
+    const isCurrent = () => projectEpochRef.current === requestEpoch;
+    if (!builtRelease) {
+      setDeployFlow({
+        phase: "error",
+        message: "No built release is waiting to be activated.",
+      });
+      return;
+    }
+    deployAbortRef.current?.abort();
+    const controller = new AbortController();
+    deployAbortRef.current = controller;
+    try {
+      await ensureRequiredSecrets(builtRelease.apps);
+      if (!isCurrent()) return;
+      const live = await runActivation({
+        targetProjectId: projectId,
+        releaseTags: builtRelease.releaseTags,
+        apps: builtRelease.apps,
+        controller,
+        isCurrent,
+      });
+      if (!live || !isCurrent()) return;
+      setDeployFlow({ phase: "done", message: "New version is live." });
+      await reload();
+      if (!isCurrent()) return;
+      refreshRecords();
+    } catch (err) {
+      if (controller.signal.aborted || !isCurrent()) return;
+      const missing = missingSecretsFromLaunchError(err);
+      if (missing) noteMissingRequiredSecrets(missing);
+      setDeployFlow({
+        phase: "error",
+        message: missing
+          ? `Missing required secrets — ${missingSecretsMessage(missing)}. Set them in Environment, then activate.`
+          : err instanceof Error
+            ? err.message
+            : "Activation failed",
+      });
+    } finally {
+      if (deployAbortRef.current === controller) deployAbortRef.current = null;
+    }
+  }, [
+    builtRelease,
+    ensureRequiredSecrets,
+    noteMissingRequiredSecrets,
+    projectId,
+    refreshRecords,
+    reload,
+    runActivation,
+  ]);
+
   // Deploy the source repo's current HEAD and activate the resulting release
   // once CI publishes it. GitHub is read only here (status polling) — the
   // "update deployment" operation — never on the passive tab render.
@@ -608,6 +768,10 @@ export function useProjectDetail(projectId: number) {
     deployAbortRef.current?.abort();
     const controller = new AbortController();
     deployAbortRef.current = controller;
+    // Whether CI got far enough to publish a release. It decides what to tell
+    // a user the gate stopped: before the build there is nothing to reuse, but
+    // after it another deploy would rebuild an artifact that is already correct.
+    let built = false;
     if (!repo) {
       setDeployFlow({ phase: "error", message: "Source repo is unknown." });
       deployAbortRef.current = null;
@@ -671,68 +835,19 @@ export function useProjectDetail(projectId: number) {
       releaseTags = ready.releaseTags?.length ? ready.releaseTags : releaseTags;
       if (!isCurrent()) return;
 
-      setDeployFlow({ phase: "activating", message: "Activating release…" });
+      // CI has published the release: from here on the artifact exists, and a
+      // gate failure must not send the user back through another build.
+      built = true;
       // Activate the SAME project the deploy targeted — `targetProjectId`
       // is preflight-resolved and can differ from the page's `projectId`.
-      const activated = await launchActivate({
-        projectId: targetProjectId,
+      const live = await runActivation({
+        targetProjectId,
         releaseTags,
         apps,
+        controller,
+        isCurrent,
       });
-      if (!isCurrent()) return;
-      // A rejected/partial activation still returns apps (with `error` set), and
-      // a malformed response may omit `activation` entirely — surface the real
-      // reason instead of throwing into the generic "Deploy failed" catch.
-      const activatedApps = activated.activation?.apps ?? [];
-      const failed = activatedApps.find((app) => app.error);
-      if (!activated.ok || failed) {
-        setDeployFlow({
-          phase: "error",
-          message: failed?.error ?? "Activation was not accepted.",
-        });
-        return;
-      }
-      if (apps.length > 0 && activatedApps.length === 0) {
-        setDeployFlow({
-          phase: "error",
-          message: "Activation returned no application statuses.",
-        });
-        return;
-      }
-      const unloaded = activatedApps.filter((app) => !app.loaded);
-      if (unloaded.length > 0) {
-        setDeployFlow({
-          phase: "activating",
-          message: "Loading app runtime…",
-        });
-        try {
-          await waitForAppsToLoad(
-            () => launchAppsStatus({ projectId: targetProjectId }),
-            unloaded.map((app) => ({
-              name: app.name,
-              releaseTag: app.releaseTag ?? undefined,
-            })),
-            {
-              signal: controller.signal,
-              intervalMs: DEPLOY_POLL_MS,
-              timeoutMs: RUNTIME_READY_TIMEOUT_MS,
-              isFatal: isFatalLaunchRequestError,
-              onProgress: ({ ready, total }) => {
-                if (isCurrent()) {
-                  setDeployFlow({
-                    phase: "activating",
-                    message: `Loading app runtime… (${ready}/${total})`,
-                  });
-                }
-              },
-            },
-          );
-        } catch (err) {
-          if (controller.signal.aborted) return;
-          throw err;
-        }
-        if (!isCurrent()) return;
-      }
+      if (!live || !isCurrent()) return;
       setDeployFlow({ phase: "done", message: "New version is live." });
       await reload();
       if (!isCurrent()) return;
@@ -744,7 +859,7 @@ export function useProjectDetail(projectId: number) {
       setDeployFlow({
         phase: "error",
         message: missing
-          ? `Missing required secrets — ${missingSecretsMessage(missing)}. Set them in Environment, then redeploy.`
+          ? `Missing required secrets — ${missingSecretsMessage(missing)}. Set them in Environment, then ${built ? "activate — the build is already done" : "deploy again"}.`
           : err instanceof Error
             ? err.message
             : "Deploy failed",
@@ -758,6 +873,7 @@ export function useProjectDetail(projectId: number) {
     projectPlatform,
     refreshRecords,
     reload,
+    runActivation,
     source,
     projectId,
   ]);
@@ -804,6 +920,9 @@ export function useProjectDetail(projectId: number) {
     refreshRecords,
     promote,
     deactivate,
+    /** The built-but-not-live release waiting to be activated, if any. */
+    builtRelease,
+    activateBuiltRelease,
     redeploySource,
     upgradeSdk,
     checkSdkUpgradeStatus,


### PR DESCRIPTION
## The bug

When a deployment is blocked by a missing required secret, the project tells its owner to deploy again. Setting the key and re-deploying runs a full CI build that produces a byte-identical artifact.

## Why the build is reusable

Secret values never enter a build. A release declares only the slot **names** it needs, in its `manifest.json`; the values live in the Manager's vault and are read per tool call at runtime — `aomi/crates/core/src/app/dynamic.rs` in product-mono, `SecretVault::get_application_secrets`.

The gate is its own proof. `missingSecretsForActivation` computes `manifest slots − vault keys` (`packages/deploy/src/bff/release-manifest.ts`). Saving the key changes only the vault side of that subtraction, so the same release tag passes the next check. No input to the build changed.

Promotion never builds either: the BFF re-derives the release pairs from the stored deployment and the Manager runs `accept_activation` on those tags, with no CI dispatch in the path.

## What changed

Three places acted as if the build were invalid:

1. **Home's next action** tested `!isLive` before `environment.blocked`, so a secrets-blocked project got "Redeploy from Linked Repository" and could never reach the branch that asks for the keys. It now recognises `build_ready` — keys first when the gate is closed, "Activate build" otherwise.
2. **The deploy flow's 409 copy** said "then redeploy" even when CI had finished and the release tags were in hand. It now distinguishes the two gate positions: before the build there is nothing to reuse, after it the instruction is to activate.
3. **A promote the write-time gate rejected** required the user to notice it could be retried. Saving the keys from that banner now resumes it.

`builtRelease` is derived from the project's own latest deployment rather than from anything the deploy flow held in memory, so the release stays recoverable across the reload — or the session — that a 409 used to strand.

## On auto-triggering

Only a promote the user already requested resumes on its own. Activating is cheap, but it makes an app live, and that must not be a side effect of saving a key — the unrequested case gets an explicit "Activate build" button instead. Nothing auto-*deploys*: that was the expensive action to begin with.

## Verification

- `pnpm --filter aomi-build test` — 480 passed, 1 skipped (6 new)
- `pnpm --filter aomi-build type-check` — clean
- `pnpm --filter aomi-build lint` — 0 errors (3 pre-existing warnings)
- `pnpm --filter aomi-build build` — clean

New coverage: activating a built release calls `launchActivate` with the persisted tags and never `launchDeploy`/`launchPreflight`/`launchStatus`; a re-gated activation keeps its key names and still avoids a rebuild; the deploy 409 says "activate" rather than "deploy again"; Home offers Activate (or Environment) instead of Redeploy for `build_ready`; saving the keys resumes the rejected promotion without touching the source repo.

Not verified in a browser: reaching this state needs a real project whose latest deployment built and was gated, which a local preview cannot produce. The component tests drive those states directly instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789832861&installation_model_id=12362&pr_number=515&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F515&signature=5cacf893efc0697440b55adb02c3fc8a8abeb5039eaa2ad35d3ff0f2b6e0299c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->