### PR TITLE
feat(build): list the platforms you can reach, and name the one you are on

### DIFF
--- a/apps/build/src/app/(control-plane)/settings/settings-general-panel.tsx
+++ b/apps/build/src/app/(control-plane)/settings/settings-general-panel.tsx
@@ -10,8 +10,9 @@ export function SettingsGeneralPanel() {
           Deployment platform
         </h2>
         <p className="text-subtle max-w-2xl text-sm leading-6">
-          Enter the platform name provided by your partner. Build checks for an
-          exact match without exposing a directory of supported platforms.
+          Build deploys to one platform at a time. These are the platforms your
+          projects are on. If a partner gave you a platform you have not
+          connected a project to yet, enter its exact name below.
         </p>
       </div>
       <div className="max-w-2xl">

--- a/apps/build/src/components/control-plane/control-plane-shell.tsx
+++ b/apps/build/src/components/control-plane/control-plane-shell.tsx
@@ -31,6 +31,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { AomiLogo } from "@build/components/brand/aomi-logo";
 import { ColorThemeToggle } from "@build/components/control-plane/color-theme-toggle";
 import { ControlPlaneLink } from "@build/components/control-plane/control-plane-link";
+import { PlatformBadge } from "@build/components/control-plane/platform-badge";
 import { platformHref } from "@build/features/launch/platform";
 import { usePlatform } from "@build/features/launch/use-platform";
 import {
@@ -664,14 +665,19 @@ function ControlPlaneShellContent({ children }: { children: React.ReactNode }) {
 
       <div className="flex min-h-0 min-w-0 flex-col">
         <header className="border-border flex h-11 shrink-0 items-center justify-between border-b px-4">
-          <IconButton
-            label="Open menu"
-            onClick={() => setMobileOpen(true)}
-            className="lg:hidden"
-          >
-            <Menu className="size-4" />
-          </IconButton>
-          <div className="hidden lg:block" />
+          {/* The left slot was an empty spacer on desktop. It now carries the
+              one piece of state every scoped page depends on and none of them
+              displayed: which platform you are pointed at. */}
+          <div className="flex min-w-0 items-center gap-2">
+            <IconButton
+              label="Open menu"
+              onClick={() => setMobileOpen(true)}
+              className="lg:hidden"
+            >
+              <Menu className="size-4" />
+            </IconButton>
+            <PlatformBadge />
+          </div>
           <div className="flex items-center gap-2">
             {/* Desktop-first: full Search · ⌘K on sm+. Phone: icon only (usable, not designed for). */}
             <button

--- a/apps/build/src/components/control-plane/platform-badge.test.tsx
+++ b/apps/build/src/components/control-plane/platform-badge.test.tsx
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/projects",
+}));
+
+import { PlatformBadge } from "./platform-badge";
+
+function visit(search: string) {
+  window.history.replaceState({}, "", `/projects${search}`);
+}
+
+afterEach(() => {
+  window.localStorage.clear();
+  visit("");
+});
+
+describe("PlatformBadge", () => {
+  it("names the platform the current page rendered against", async () => {
+    visit("?platform=somm.finance");
+    render(<PlatformBadge />);
+
+    expect(await screen.findByText("somm.finance")).toBeInTheDocument();
+  });
+
+  it("falls back to Community when nothing scopes the page", async () => {
+    render(<PlatformBadge />);
+
+    expect(await screen.findByText("community")).toBeInTheDocument();
+  });
+
+  it("leads to the platform selector", () => {
+    render(<PlatformBadge />);
+
+    expect(
+      screen.getByRole("link", { name: /Change platform/ }),
+    ).toHaveAttribute("href", "/settings/general");
+  });
+});

--- a/apps/build/src/components/control-plane/platform-badge.tsx
+++ b/apps/build/src/components/control-plane/platform-badge.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import Link from "next/link";
+import { Layers3 } from "lucide-react";
+
+import { usePlatform } from "@build/features/launch/use-platform";
+
+/**
+ * Which platform Build is currently pointed at, in the shell top bar.
+ *
+ * Every scoped page — Projects, Deployments, Overview — renders against one
+ * platform, and until now nothing on screen said which one. The badge is the
+ * standing answer, and the way into the selector: it links to Settings →
+ * General, where {@link PlatformSwitcher} lists the platforms you can reach.
+ */
+export function PlatformBadge() {
+  const platform = usePlatform();
+
+  return (
+    <Link
+      href="/settings/general"
+      aria-label={`Platform: ${platform}. Change platform`}
+      title="Change platform"
+      className="icon-button border-border hover:bg-accent-hover inline-flex h-8 min-w-0 items-center gap-2 rounded-md border px-2 text-xs transition"
+    >
+      <Layers3 className="text-dim size-3.5 shrink-0" aria-hidden />
+      <span className="text-dim hidden sm:inline">Platform</span>
+      <span className="text-foreground max-w-[12rem] truncate font-medium">
+        {platform}
+      </span>
+    </Link>
+  );
+}

--- a/apps/build/src/components/control-plane/platform-switcher.test.tsx
+++ b/apps/build/src/components/control-plane/platform-switcher.test.tsx
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const { push, deploymentProjects } = vi.hoisted(() => ({
@@ -33,6 +39,44 @@ import { LaunchRequestError } from "@build/features/launch/client";
 import { buildQueryKeys } from "@build/features/launch/query-keys";
 import { PlatformSwitcher } from "./platform-switcher";
 
+/** The account-wide read the platform list is derived from. */
+function projectsOn(...platformNames: string[]) {
+  return {
+    projects: platformNames.map((platformName, index) => ({
+      id: index + 1,
+      platformName,
+    })),
+  };
+}
+
+/** `deploymentProjects()` answers the list read; `deploymentProjects(name)` is
+ *  the exact-name verification. Route them separately so a test can fail one
+ *  without disturbing the other. */
+function respond({
+  list,
+  scoped,
+}: {
+  list?: unknown;
+  scoped?: (platform: string) => unknown;
+} = {}) {
+  deploymentProjects.mockImplementation((platform?: string) => {
+    if (platform === undefined) {
+      return list === undefined
+        ? Promise.reject(new Error("list unavailable"))
+        : Promise.resolve(list);
+    }
+    return scoped
+      ? Promise.resolve(scoped(platform))
+      : Promise.reject(new Error("no scoped response configured"));
+  });
+}
+
+/** Calls that verify one platform by name — the list read is not one. */
+function scopedCalls() {
+  return deploymentProjects.mock.calls.filter((call) => call[0] !== undefined)
+    .length;
+}
+
 function renderSwitcher(currentPlatform: string | null = null) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -51,58 +95,130 @@ describe("PlatformSwitcher", () => {
     deploymentProjects.mockReset();
   });
 
-  it("switches only after an exact platform source lookup succeeds", async () => {
-    const result = { projects: [] };
-    deploymentProjects.mockResolvedValue(result);
-    const client = renderSwitcher();
-    const input = screen.getByRole("textbox", { name: "Platform name" });
+  describe("the platforms you can reach", () => {
+    it("lists each distinct platform your projects are on, once", async () => {
+      respond({ list: projectsOn("somm.finance", "somm.finance", "byreal") });
+      renderSwitcher("community");
 
-    fireEvent.change(input, { target: { value: "  somm.finance  " } });
-    fireEvent.click(screen.getByRole("button", { name: "Switch" }));
+      const list = await screen.findByRole("list", { name: "Your platforms" });
+      const rows = within(list).getAllByRole("listitem");
+      expect(rows.map((row) => row.textContent)).toEqual([
+        expect.stringContaining("community"),
+        expect.stringContaining("byreal"),
+        expect.stringContaining("somm.finance"),
+      ]);
+      expect(within(list).getByText("2 projects")).toBeInTheDocument();
+    });
 
-    await waitFor(() =>
-      expect(push).toHaveBeenCalledWith("/projects?platform=somm.finance"),
-    );
-    expect(deploymentProjects).toHaveBeenCalledWith("somm.finance");
-    expect(
-      client.getQueryData(buildQueryKeys.projects("alice", "somm.finance")),
-    ).toEqual(result);
+    it("always offers Community, and marks the platform you are on", async () => {
+      respond({ list: projectsOn("somm.finance") });
+      renderSwitcher("somm.finance");
+
+      const list = await screen.findByRole("list", { name: "Your platforms" });
+      expect(within(list).getByText("community")).toBeInTheDocument();
+      expect(within(list).getByText("No projects yet")).toBeInTheDocument();
+      expect(within(list).getByText("Current")).toBeInTheDocument();
+      expect(
+        within(list).getByRole("button", { current: true }),
+      ).toHaveTextContent("somm.finance");
+    });
+
+    it("shows the platform you are on even before it owns a project", async () => {
+      respond({ list: projectsOn() });
+      renderSwitcher("new.partner");
+
+      const list = await screen.findByRole("list", { name: "Your platforms" });
+      expect(within(list).getByText("new.partner")).toBeInTheDocument();
+    });
+
+    it("switches on click without re-verifying a name it just read", async () => {
+      respond({ list: projectsOn("somm.finance") });
+      renderSwitcher("community");
+
+      const list = await screen.findByRole("list", { name: "Your platforms" });
+      fireEvent.click(
+        within(list).getByRole("button", { name: /somm\.finance/ }),
+      );
+
+      expect(push).toHaveBeenCalledWith("/projects?platform=somm.finance");
+      expect(scopedCalls()).toBe(0);
+    });
+
+    it("falls back to the typed name when the list cannot be read", async () => {
+      respond({ scoped: () => ({ projects: [] }) });
+      renderSwitcher("community");
+
+      await waitFor(() =>
+        expect(
+          screen.queryByRole("list", { name: "Your platforms" }),
+        ).not.toBeInTheDocument(),
+      );
+      const input = screen.getByRole("textbox", { name: "Platform name" });
+      fireEvent.change(input, { target: { value: "somm.finance" } });
+      fireEvent.click(screen.getByRole("button", { name: "Switch" }));
+
+      await waitFor(() =>
+        expect(push).toHaveBeenCalledWith("/projects?platform=somm.finance"),
+      );
+    });
   });
 
-  it("keeps the current platform when the exact name is not found", async () => {
-    deploymentProjects.mockRejectedValue(
-      new LaunchRequestError("deployment projects failed", 404, {}),
-    );
-    renderSwitcher("community");
-    const input = screen.getByRole("textbox", { name: "Platform name" });
+  describe("the exact-name fallback", () => {
+    it("switches only after an exact platform source lookup succeeds", async () => {
+      const result = { projects: [] };
+      respond({ list: projectsOn(), scoped: () => result });
+      const client = renderSwitcher();
+      const input = screen.getByRole("textbox", { name: "Platform name" });
 
-    fireEvent.change(input, { target: { value: "missing.partner" } });
-    fireEvent.click(screen.getByRole("button", { name: "Switch" }));
+      fireEvent.change(input, { target: { value: "  somm.finance  " } });
+      fireEvent.click(screen.getByRole("button", { name: "Switch" }));
 
-    expect(await screen.findByRole("alert")).toHaveTextContent(
-      "Platform not found. Nothing changed",
-    );
-    expect(push).not.toHaveBeenCalled();
+      await waitFor(() =>
+        expect(push).toHaveBeenCalledWith("/projects?platform=somm.finance"),
+      );
+      expect(deploymentProjects).toHaveBeenCalledWith("somm.finance");
+      expect(
+        client.getQueryData(buildQueryKeys.projects("alice", "somm.finance")),
+      ).toEqual(result);
+    });
+
+    it("keeps the current platform when the exact name is not found", async () => {
+      respond({
+        list: projectsOn(),
+        scoped: () => {
+          throw new LaunchRequestError("deployment projects failed", 404, {});
+        },
+      });
+      renderSwitcher("community");
+      const input = screen.getByRole("textbox", { name: "Platform name" });
+
+      fireEvent.change(input, { target: { value: "missing.partner" } });
+      fireEvent.click(screen.getByRole("button", { name: "Switch" }));
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        "Platform not found. Nothing changed",
+      );
+      expect(push).not.toHaveBeenCalled();
+    });
+
+    it("disables Switch until a platform name is entered", () => {
+      respond({ list: projectsOn() });
+      renderSwitcher();
+
+      expect(screen.getByRole("button", { name: "Switch" })).toBeDisabled();
+    });
   });
 
-  it("returns to explicitly scoped Community projects without a lookup", () => {
+  it("explains Community where it is offered", async () => {
+    respond({ list: projectsOn("somm.finance") });
     renderSwitcher("somm.finance");
 
+    await screen.findByRole("list", { name: "Your platforms" });
     expect(
       screen.getByRole("button", { name: "What is Community?" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("tooltip")).toHaveTextContent(
       "Aomi's default platform",
     );
-    fireEvent.click(screen.getByRole("button", { name: "Use Community" }));
-
-    expect(push).toHaveBeenCalledWith("/projects?platform=community");
-    expect(deploymentProjects).not.toHaveBeenCalled();
-  });
-
-  it("disables Switch until a platform name is entered", () => {
-    renderSwitcher();
-
-    expect(screen.getByRole("button", { name: "Switch" })).toBeDisabled();
   });
 });

--- a/apps/build/src/components/control-plane/platform-switcher.tsx
+++ b/apps/build/src/components/control-plane/platform-switcher.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, type FormEvent } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
-import { Layers3, LoaderCircle } from "lucide-react";
+import { Check, Layers3, LoaderCircle } from "lucide-react";
 
 import { useGitHubSession } from "@build/components/control-plane/github-session-context";
 import { HelpBadge } from "@build/components/help-badge";
@@ -17,7 +17,17 @@ import {
 } from "@build/features/launch/query-keys";
 import { writePlatform } from "@build/features/launch/platform";
 import { usePlatform } from "@build/features/launch/use-platform";
+import {
+  useAccessiblePlatforms,
+  type AccessiblePlatform,
+} from "@build/features/launch/use-accessible-platforms";
 import { DEFAULT_DEPLOY_PLATFORM } from "@build/lib/deploy-platform";
+import { cn } from "@build/lib/utils";
+
+function projectCountLabel(count: number) {
+  if (count === 0) return "No projects yet";
+  return count === 1 ? "1 project" : `${count} projects`;
+}
 
 export function PlatformSwitcher({
   currentPlatform,
@@ -35,6 +45,7 @@ export function PlatformSwitcher({
       : currentPlatform;
   const queryClient = useQueryClient();
   const { account } = useGitHubSession();
+  const accessible = useAccessiblePlatforms(activePlatform);
   const [value, setValue] = useState(activePlatform ?? "");
   const [checking, setChecking] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -43,6 +54,21 @@ export function PlatformSwitcher({
     setValue(activePlatform ?? "");
     setError(null);
   }, [activePlatform]);
+
+  function goToPlatform(platform: string) {
+    writePlatform(platform);
+    router.push(`/projects?platform=${encodeURIComponent(platform)}`);
+  }
+
+  /** A name that came out of an authorized read of the user's own projects is
+   *  already known-good; re-verifying it would only add latency and a second
+   *  way to fail. */
+  function select(platform: string) {
+    if (checking || platform === activePlatform) return;
+    setValue(platform);
+    setError(null);
+    goToPlatform(platform);
+  }
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -75,8 +101,7 @@ export function PlatformSwitcher({
           });
         }
       }
-      writePlatform(platform);
-      router.push(`/projects?platform=${encodeURIComponent(platform)}`);
+      goToPlatform(platform);
     } catch (cause) {
       setError(
         cause instanceof LaunchRequestError &&
@@ -89,18 +114,36 @@ export function PlatformSwitcher({
     }
   }
 
-  function useCommunity() {
-    if (checking) return;
-    setValue(DEFAULT_DEPLOY_PLATFORM);
-    setError(null);
-    writePlatform(DEFAULT_DEPLOY_PLATFORM);
-    router.push(
-      `/projects?platform=${encodeURIComponent(DEFAULT_DEPLOY_PLATFORM)}`,
-    );
-  }
-
   return (
     <div className="w-full">
+      {accessible.status === "loading" ? (
+        <ul aria-hidden className="mb-8 space-y-2">
+          {[0, 1].map((row) => (
+            <li
+              key={row}
+              className="border-border h-[62px] w-full rounded-xl border"
+            />
+          ))}
+        </ul>
+      ) : null}
+
+      {accessible.status === "ready" ? (
+        <ul aria-label="Your platforms" className="mb-8 space-y-2">
+          {accessible.platforms.map((platform) => (
+            <PlatformRow
+              key={platform.name}
+              platform={platform}
+              current={platform.name === activePlatform}
+              disabled={checking}
+              onSelect={() => select(platform.name)}
+            />
+          ))}
+        </ul>
+      ) : null}
+
+      <p className="text-subtle mb-3 text-[13px]">
+        On a platform that is not listed? Enter its exact name.
+      </p>
       <form onSubmit={submit} className="flex items-center gap-3">
         <div className="border-border bg-background focus-within:ring-ring flex h-10 min-w-0 flex-1 items-center gap-2.5 rounded-full border px-4 focus-within:ring-1">
           {checking ? (
@@ -147,23 +190,60 @@ export function PlatformSwitcher({
           {error}
         </p>
       ) : null}
-      <div className="border-border mt-8 flex items-center justify-between gap-4 border-t pt-6">
-        <div className="flex min-w-0 items-center gap-1">
-          <p className="text-foreground text-[13px] font-medium">Community</p>
+    </div>
+  );
+}
+
+function PlatformRow({
+  platform,
+  current,
+  disabled,
+  onSelect,
+}: {
+  platform: AccessiblePlatform;
+  current: boolean;
+  disabled: boolean;
+  onSelect: () => void;
+}) {
+  const isCommunity = platform.name === DEFAULT_DEPLOY_PLATFORM;
+  return (
+    <li>
+      <div
+        className={cn(
+          "border-border flex items-center gap-3 rounded-xl border px-4 py-3 transition",
+          current && "border-foreground/30 bg-accent",
+        )}
+      >
+        <button
+          type="button"
+          onClick={onSelect}
+          disabled={disabled || current}
+          aria-current={current ? "true" : undefined}
+          className="flex min-w-0 flex-1 items-center gap-3 text-left disabled:cursor-default"
+        >
+          <Layers3 className="text-dim size-4 shrink-0" aria-hidden />
+          <span className="min-w-0">
+            <span className="text-foreground block truncate text-[13px] font-medium">
+              {platform.name}
+            </span>
+            <span className="text-dim block text-xs">
+              {projectCountLabel(platform.projectCount)}
+            </span>
+          </span>
+        </button>
+        {isCommunity ? (
           <HelpBadge label="What is Community?">
             Community is Aomi&apos;s default platform for projects that are not
             scoped to a partner deployment.
           </HelpBadge>
-        </div>
-        <button
-          type="button"
-          onClick={useCommunity}
-          disabled={checking}
-          className="border-border hover:bg-accent-hover text-foreground inline-flex h-9 shrink-0 items-center rounded-full border px-4 text-[13px] transition disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          Use Community
-        </button>
+        ) : null}
+        {current ? (
+          <span className="text-foreground inline-flex shrink-0 items-center gap-1 text-xs">
+            <Check className="size-3.5" aria-hidden />
+            Current
+          </span>
+        ) : null}
       </div>
-    </div>
+    </li>
   );
 }

--- a/apps/build/src/features/launch/use-accessible-platforms.test.ts
+++ b/apps/build/src/features/launch/use-accessible-platforms.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+const { deploymentProjects } = vi.hoisted(() => ({
+  deploymentProjects: vi.fn(),
+}));
+
+vi.mock("@build/features/launch/client", () => ({ deploymentProjects }));
+vi.mock("@build/components/control-plane/github-session-context", () => ({
+  useGitHubSession: () => ({
+    account: { loading: false, signedIn: true, githubLogin: "alice" },
+  }),
+}));
+
+import { useAccessiblePlatforms } from "./use-accessible-platforms";
+
+function wrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children);
+  };
+}
+
+function on(...platformNames: string[]) {
+  return {
+    projects: platformNames.map((platformName, index) => ({
+      id: index + 1,
+      platformName,
+    })),
+  };
+}
+
+async function platforms(list: unknown, active?: string) {
+  deploymentProjects.mockResolvedValue(list);
+  const { result } = renderHook(() => useAccessiblePlatforms(active), {
+    wrapper: wrapper(),
+  });
+  await waitFor(() => expect(result.current.status).toBe("ready"));
+  return result.current.status === "ready" ? result.current.platforms : [];
+}
+
+describe("useAccessiblePlatforms", () => {
+  beforeEach(() => deploymentProjects.mockReset());
+
+  it("reads the account-wide project list, unscoped by platform", async () => {
+    await platforms(on("somm.finance"));
+
+    expect(deploymentProjects).toHaveBeenCalledWith();
+  });
+
+  it("counts projects per distinct platform, Community first", async () => {
+    expect(
+      await platforms(on("somm.finance", "byreal", "somm.finance")),
+    ).toEqual([
+      { name: "community", projectCount: 0 },
+      { name: "byreal", projectCount: 1 },
+      { name: "somm.finance", projectCount: 2 },
+    ]);
+  });
+
+  it("trims names and ignores projects with no platform", async () => {
+    expect(
+      await platforms({
+        projects: [
+          { id: 1, platformName: "  somm.finance  " },
+          { id: 2, platformName: "" },
+          { id: 3, platformName: null },
+        ],
+      }),
+    ).toEqual([
+      { name: "community", projectCount: 0 },
+      { name: "somm.finance", projectCount: 1 },
+    ]);
+  });
+
+  it("includes the active platform even with no projects on it", async () => {
+    expect(await platforms(on(), "new.partner")).toEqual([
+      { name: "community", projectCount: 0 },
+      { name: "new.partner", projectCount: 0 },
+    ]);
+  });
+
+  it("counts the active platform's own projects rather than resetting it", async () => {
+    expect(await platforms(on("somm.finance"), "somm.finance")).toEqual([
+      { name: "community", projectCount: 0 },
+      { name: "somm.finance", projectCount: 1 },
+    ]);
+  });
+
+  it("reports unavailable when the read fails, never an empty list", async () => {
+    deploymentProjects.mockImplementation(() =>
+      Promise.reject(new Error("nope")),
+    );
+    const { result, unmount } = renderHook(() => useAccessiblePlatforms(), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("unavailable"));
+    // Teardown calls the mock once more. A rejecting implementation left in
+    // place surfaces that call as an unhandled rejection rather than a query
+    // error, so hand back a resolving one before the test ends.
+    unmount();
+    deploymentProjects.mockResolvedValue({ projects: [] });
+  });
+});

--- a/apps/build/src/features/launch/use-accessible-platforms.ts
+++ b/apps/build/src/features/launch/use-accessible-platforms.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { useGitHubSession } from "@build/components/control-plane/github-session-context";
+import { deploymentProjects } from "@build/features/launch/client";
+import { DEFAULT_DEPLOY_PLATFORM } from "@build/lib/deploy-platform";
+import {
+  buildQueryKeys,
+  buildQueryStaleTime,
+  githubAccountKey,
+} from "./query-keys";
+
+export type AccessiblePlatform = {
+  name: string;
+  projectCount: number;
+};
+
+export type AccessiblePlatformsState =
+  | { status: "loading" }
+  /** Signed out, or the account-wide read failed. Callers fall back to the
+   *  typed platform name — a list we could not load must never take away the
+   *  entry path that does not depend on it. */
+  | { status: "unavailable" }
+  | { status: "ready"; platforms: AccessiblePlatform[] };
+
+/**
+ * The platforms the signed-in user can reach, derived from the platforms their
+ * own projects are bound to.
+ *
+ * Deliberately not the Manager's `GET /api/platforms`: that one is unauthorized
+ * and returns every platform Aomi hosts, which would publish a partner
+ * directory. This read is session-scoped, so a user only ever learns the names
+ * of platforms whose projects they can already list.
+ *
+ * It cannot see a platform a partner has named but where the user has no
+ * project yet; that case stays on the exact-name entry in
+ * {@link PlatformSwitcher}.
+ */
+export function useAccessiblePlatforms(
+  activePlatform?: string | null,
+): AccessiblePlatformsState {
+  const { account } = useGitHubSession();
+  const accountKey = githubAccountKey(account.githubLogin);
+  // No platform argument: the unfiltered account-wide list. Same query key the
+  // Projects page uses for its unscoped view, so the two share one cache entry
+  // instead of racing two identical reads.
+  const projects = useQuery({
+    queryKey: buildQueryKeys.projects(accountKey ?? "unavailable", undefined),
+    queryFn: () => deploymentProjects(),
+    enabled: account.signedIn && accountKey !== null,
+    staleTime: buildQueryStaleTime.projects,
+  });
+
+  const active = activePlatform?.trim() || null;
+
+  return useMemo<AccessiblePlatformsState>(() => {
+    if (account.loading) return { status: "loading" };
+    if (!account.signedIn || !accountKey) return { status: "unavailable" };
+    if (projects.isPending) return { status: "loading" };
+    if (projects.error) return { status: "unavailable" };
+
+    const counts = new Map<string, number>();
+    // Community is always reachable, and the platform you are on has to appear
+    // in the list that claims to show where you are — both before either owns
+    // a single project.
+    counts.set(DEFAULT_DEPLOY_PLATFORM, 0);
+    if (active) counts.set(active, counts.get(active) ?? 0);
+    for (const project of projects.data?.projects ?? []) {
+      const name = project.platformName?.trim();
+      if (!name) continue;
+      counts.set(name, (counts.get(name) ?? 0) + 1);
+    }
+
+    const platforms = [...counts.entries()]
+      .map(([name, projectCount]) => ({ name, projectCount }))
+      // Community first, then alphabetical: a stable order, so the list does
+      // not reshuffle under the cursor as project counts change.
+      .sort((left, right) => {
+        if (left.name === DEFAULT_DEPLOY_PLATFORM) return -1;
+        if (right.name === DEFAULT_DEPLOY_PLATFORM) return 1;
+        return left.name.localeCompare(right.name);
+      });
+
+    return { status: "ready", platforms };
+  }, [
+    account.loading,
+    account.signedIn,
+    accountKey,
+    active,
+    projects.data,
+    projects.error,
+    projects.isPending,
+  ]);
+}

--- a/docs/superpowers/specs/2026-08-20-build-accessible-platform-list-design.md
+++ b/docs/superpowers/specs/2026-08-20-build-accessible-platform-list-design.md
@@ -30,6 +30,11 @@ already list.
 The typed entry stays as a fallback, because the derivation cannot see a
 platform a partner has named but where the user has not connected a project yet.
 
+The shell also gains a standing answer to "which platform am I on". Every scoped
+page — Projects, Deployments, Overview — renders against one platform and
+nothing on screen said which; the top bar now names it, and clicking it opens
+the selector.
+
 ## Data flow
 
 Unchanged upstream, all of it already in place:
@@ -112,6 +117,16 @@ platform)`, same invalidation of the platform being left, same
 again." It gets a quieter heading marking it as the path for a platform not in
 the list.
 
+### `apps/build/src/components/control-plane/platform-badge.tsx` (new)
+
+A top-bar link reading `Platform <name>`, from `usePlatform()` — the same
+URL-then-storage-then-Community resolution the sidebar's platform-scoped links
+already use, so the badge cannot disagree with where those links point. It links
+to `/settings/general`, the selector.
+
+It takes the left slot of the shell header (`control-plane-shell.tsx`), which
+was an empty spacer on desktop, and sits next to the menu button on mobile.
+
 ### `apps/build/src/app/(control-plane)/settings/settings-general-panel.tsx` (changed)
 
 Copy replaced. It currently promises the opposite of what the screen will do:
@@ -139,7 +154,11 @@ name.
   the old platform; 404 shows "Platform not found".
 
 `features/launch/use-accessible-platforms.test.ts` (new): the derivation —
-dedupe, trim, counts, Community injection, active-platform injection, ordering.
+dedupe, trim, counts, Community injection, active-platform injection, ordering,
+and `unavailable` (never an empty list) when the read fails.
+
+`components/control-plane/platform-badge.test.tsx` (new): names the platform the
+page is scoped to, falls back to Community, and links to `/settings/general`.
 
 ## Out of scope
 
@@ -147,5 +166,5 @@ dedupe, trim, counts, Community injection, active-platform injection, ordering.
   real grant model in product-mono (activation tokens or an explicit
   membership table) and a new service-auth endpoint; the typed fallback covers
   the case until then.
-- The shell sidebar and command palette platform affordances.
+- The command palette's platform affordances.
 - Any change to `GET /api/platforms`, which stays unused by Build.

--- a/docs/superpowers/specs/2026-08-20-build-accessible-platform-list-design.md
+++ b/docs/superpowers/specs/2026-08-20-build-accessible-platform-list-design.md
@@ -1,0 +1,151 @@
+# Build settings: list the platforms a user can deploy to
+
+Date: 2026-08-20
+Status: approved, not implemented
+Scope: `apps/build` only. No `aomi-labs/product-mono` change.
+
+## Problem
+
+Settings → General → Deployment platform is a blind text box. It asks for an
+exact platform name "provided by your partner" and verifies it by attempting a
+scoped project read. A developer who belongs to a partner platform has no way to
+see which platform they are on, or which others they can reach, without already
+knowing the string.
+
+The blindness was deliberate: the only listing endpoint in the manager,
+`GET /api/platforms`, is unauthenticated and returns every platform in the
+database. Rendering that would publish a directory of Aomi's partners.
+
+## Decision
+
+Derive the list from the projects the signed-in user can already see, rather
+than from the global platform directory. "A platform I have access to" means "a
+platform I have at least one project on", plus Community, which is always
+reachable.
+
+This exposes nothing new. The read is session-scoped and already powers the
+projects page; a user learns only the names of platforms whose projects they can
+already list.
+
+The typed entry stays as a fallback, because the derivation cannot see a
+platform a partner has named but where the user has not connected a project yet.
+
+## Data flow
+
+Unchanged upstream, all of it already in place:
+
+```
+PlatformSwitcher
+  → deploymentProjects()                       features/launch/client.ts
+    → GET /api/bff/launch/projects             (no `platform` param)
+      → userProjectsRoute                      server/bff/launch/routes.ts:1058
+        → client.listUserProjects({ githubUserId, platform: undefined })
+          → GET /api/integrations/github-app/user/projects?github_user_id=…
+            → list_builder_projects            manager project/endpoints.rs:224
+```
+
+`list_builder_projects` returns the unfiltered visible-project list when
+`platform` is absent, and every project row carries `platform_name`
+(`Project::list_json`, manager `project/mod.rs:206`), surfaced to the client as
+`UserProject.platformName`.
+
+The BFF passes `platform: undefined` through when the query param is absent
+(`routes.ts:1066`), and the browser client omits the param when no platform is
+bound (`packages/deploy/src/launch/browser-client.ts:185`). Build's client binds
+no platform. So `deploymentProjects()` with no argument is already an
+account-wide read.
+
+## Components
+
+### `apps/build/src/features/launch/use-accessible-platforms.ts` (new)
+
+```ts
+export type AccessiblePlatform = { name: string; projectCount: number };
+
+export type AccessiblePlatformsState =
+  | { status: "loading" }
+  | { status: "unavailable" }                       // signed out, or read failed
+  | { status: "ready"; platforms: AccessiblePlatform[] };
+
+export function useAccessiblePlatforms(
+  activePlatform?: string | null,
+): AccessiblePlatformsState;
+```
+
+- `useQuery` on `buildQueryKeys.projects(accountKey, undefined)` — the same key
+  the projects page uses for its unfiltered list, so the two share one cache
+  entry — with `queryFn: () => deploymentProjects()` and
+  `staleTime: buildQueryStaleTime.projects`. Enabled only when signed in with a
+  resolved account key, matching `useProjects`.
+- Derivation: trim each `platformName`, drop empties, count projects per
+  distinct name.
+- `DEFAULT_DEPLOY_PLATFORM` ("community") is always in the result, at zero
+  projects if it has none.
+- `activePlatform`, when given, is always in the result, so the panel can never
+  mark a platform "Current" that is missing from its own list.
+- Order: Community first, then the rest alphabetically. Stable, so the list does
+  not reshuffle as counts change.
+
+### `apps/build/src/components/control-plane/platform-switcher.tsx` (changed)
+
+Above the existing form, a list of platform rows: name, project count
+("3 projects" / "No projects yet"), and a "Current" marker on the active one.
+
+- Selecting a row switches immediately — `writePlatform(name)` then
+  `router.push('/projects?platform=…')` — with **no** verification fetch. The
+  name came from an authorized read of the user's own projects; re-verifying it
+  would only add latency and a new failure mode. Selecting the current platform
+  is a no-op.
+- Community is a row in this list and keeps its `HelpBadge` explanation. The
+  separate bottom "Community / Use Community" section is removed; it was a
+  hardcoded stand-in for the list this spec adds.
+- `status: "loading"` renders skeleton rows and leaves the form enabled.
+- `status: "unavailable"` renders no list at all, leaving today's exact screen —
+  input, Switch button, and the existing "Sign in with GitHub before switching
+  platforms." submit guard. A failed list read must never block the fallback
+  that does not depend on it.
+
+The form below it is unchanged: same `deploymentProjects(platform)`
+verification, same cache priming of `buildQueryKeys.projects(accountKey,
+platform)`, same invalidation of the platform being left, same
+400/404 → "Platform not found. Nothing changed—check the exact name and try
+again." It gets a quieter heading marking it as the path for a platform not in
+the list.
+
+### `apps/build/src/app/(control-plane)/settings/settings-general-panel.tsx` (changed)
+
+Copy replaced. It currently promises the opposite of what the screen will do:
+
+> Enter the platform name provided by your partner. Build checks for an exact
+> match without exposing a directory of supported platforms.
+
+New copy states that Build lists the platforms your projects are on, and that a
+partner platform you have not connected a project to yet can be entered by exact
+name.
+
+## Tests
+
+`components/control-plane/platform-switcher.test.tsx` already mocks
+`deploymentProjects`, `next/navigation`, and the GitHub session, and wraps in a
+`QueryClientProvider`. Extend it:
+
+- Distinct platforms render from a project list containing duplicates.
+- Community renders even when no project is on it.
+- The active platform is marked "Current" and is present even with no projects.
+- Clicking a row calls `push('/projects?platform=…')` and persists the choice,
+  with no additional `deploymentProjects` call beyond the list read.
+- A rejected list read leaves the input and Switch button working.
+- Existing cases still pass: exact-match switch primes the cache and invalidates
+  the old platform; 404 shows "Platform not found".
+
+`features/launch/use-accessible-platforms.test.ts` (new): the derivation —
+dedupe, trim, counts, Community injection, active-platform injection, ordering.
+
+## Out of scope
+
+- Access to a platform where the user has zero projects. Covering that needs a
+  real grant model in product-mono (activation tokens or an explicit
+  membership table) and a new service-auth endpoint; the typed fallback covers
+  the case until then.
+- The shell sidebar and command palette platform affordances.
+- Any change to `GET /api/platforms`, which stays unused by Build.


### PR DESCRIPTION
## Why

Settings → General was a blind text box: enter the exact platform name your partner gave you. Nothing on the screen — or anywhere in Build — said which platform you were currently on, or which others you could reach.

The blindness was deliberate. The only listing endpoint in the Manager, `GET /api/platforms`, is unauthorized and returns every platform in the database; rendering it would publish a directory of Aomi's partners.

## What

**The platforms you can reach are derived from your own projects.** Distinct `platformName` over the account-wide `deploymentProjects()` read (no `platform` param), plus Community, which is always reachable, plus the platform you are on so the list can never omit the one it marks "Current".

That read is session-scoped and already backs the Projects page, so:

- nothing new is exposed — you only learn the names of platforms whose projects you can already list;
- it reuses the same query key (`buildQueryKeys.projects(account, undefined)`), so the two views share one cache entry instead of racing two identical reads;
- **no `aomi-labs/product-mono` change is needed.** `list_builder_projects` already returns the unfiltered visible-project list when `platform` is absent, and `Project::list_json` already carries `platform_name`.

**Selecting a listed platform switches without a verification round trip.** The name came out of an authorized read of your own projects; re-verifying it would only add latency and a second way to fail.

**The typed entry stays**, below the list, unchanged — same exact-match lookup, same cache priming, same "Platform not found. Nothing changed" — because the derivation cannot see a platform a partner has named but where you have no project yet. If the list read fails, the screen degrades to exactly what it is today rather than taking that path away.

**The shell top bar now names the active platform** and links to the selector. Every scoped page — Projects, Deployments, Overview — renders against one platform, and none of them said which. The badge uses `usePlatform()`, the same URL → storage → Community resolution the sidebar's platform-scoped links already use, so it cannot disagree with where those links point.

Design doc: `docs/superpowers/specs/2026-08-20-build-accessible-platform-list-design.md`.

## Verification

- `vitest run` on the three touched/added suites: **18 tests, all green** (`platform-switcher`, `platform-badge`, `use-accessible-platforms`).
- Full `apps/build/src` suite: **444 passed**, 5 suites fail to resolve `@aomi-labs/widget-lib`. Those 5 reproduce on a clean `origin/main` tree (`git stash` + re-run) — pre-existing, unrelated.
- `tsc --noEmit --incremental false`: clean. `eslint`: clean (one pre-existing `<img>` warning in `control-plane-shell.tsx:216`, untouched).
- Not verified in a running browser: the list needs a live Manager session, which I do not have here. The visual states are covered by the component tests only.

## Out of scope

- Access to a platform where you have **zero** projects. That needs a real grant model in product-mono (activation tokens, or an explicit membership table) and a new service-auth endpoint. The typed fallback covers it until then.
- The command palette's platform affordances.
- Any change to `GET /api/platforms`, which stays unused by Build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789840123&installation_model_id=12362&pr_number=516&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F516&signature=459d07e77fad3bd67b2b576f82c4ddd298fe27316d754174cba5aedbfb7a83bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->